### PR TITLE
fix(twitter): match full-card action geometry

### DIFF
--- a/crates/ox_content_ssg/src/plugins/social-tweet-full-isolation.css
+++ b/crates/ox_content_ssg/src/plugins/social-tweet-full-isolation.css
@@ -25,6 +25,10 @@
   margin: var(--ox-tweet-container-margin);
 }
 
+.ox-tweet.ox-tweet--full * {
+  box-sizing: border-box;
+}
+
 .ox-tweet.ox-tweet--full :where(img, video, figure, picture, svg) {
   margin: 0;
 }
@@ -39,8 +43,13 @@
 }
 
 .ox-tweet.ox-tweet--full :where(a) {
+  padding: 0;
+  font-size: inherit;
   font-weight: inherit;
+  line-height: inherit;
   text-decoration: none;
+  background: transparent;
+  border: 0;
 }
 
 .ox-tweet.ox-tweet--full :where(code, pre, kbd, samp) {

--- a/crates/ox_content_ssg/src/plugins/social-tweet-full-media.css
+++ b/crates/ox_content_ssg/src/plugins/social-tweet-full-media.css
@@ -127,27 +127,66 @@
 .ox-tweet--full .ox-tweet__action {
   display: flex;
   align-items: center;
-  margin-right: 1.25rem;
+  min-width: var(--ox-tweet-actions-icon-wrapper-size);
+  min-height: var(--ox-tweet-actions-icon-wrapper-size);
+  padding: 0;
+  margin: 0 1.25rem 0 0;
   font-size: var(--ox-tweet-actions-font-size);
-  font-weight: 700;
-  line-height: 1rem;
+  font-weight: var(--ox-tweet-actions-font-weight);
+  line-height: var(--ox-tweet-actions-line-height);
+  background: transparent;
+  border: 0;
+}
+
+.ox-tweet--full .ox-tweet__action-icon {
+  box-sizing: border-box;
+  display: flex;
+  flex: 0 0 var(--ox-tweet-actions-icon-wrapper-size);
+  align-items: center;
+  justify-content: center;
+  width: var(--ox-tweet-actions-icon-wrapper-size);
+  height: var(--ox-tweet-actions-icon-wrapper-size);
+  margin: 0 0.25rem 0 -0.25rem;
+  border-radius: 9999px;
 }
 
 .ox-tweet--full .ox-tweet__action .ox-tweet__icon {
-  margin-right: 0.25rem;
+  width: var(--ox-tweet-actions-icon-size);
+  height: var(--ox-tweet-actions-icon-size);
 }
 
-.ox-tweet--full .ox-tweet__action--like:hover {
+.ox-tweet--full .ox-tweet__action--like:hover .ox-tweet__action-text {
   color: var(--ox-tweet-color-red);
+  text-decoration-line: underline;
 }
 
-.ox-tweet--full .ox-tweet__action--reply:hover {
+.ox-tweet--full .ox-tweet__action--like:hover .ox-tweet__action-icon {
+  background-color: var(--ox-tweet-color-red-hover);
+}
+
+.ox-tweet--full .ox-tweet__action--reply:hover .ox-tweet__action-text {
   color: var(--ox-tweet-color-blue-text);
+  text-decoration-line: underline;
+}
+
+.ox-tweet--full .ox-tweet__action--reply:hover .ox-tweet__action-icon {
+  background-color: var(--ox-tweet-color-blue-hover);
 }
 
 .ox-tweet--full .ox-tweet__action--copy:hover,
 .ox-tweet--full .ox-tweet__action--copy[data-ox-tweet-copied] {
   color: var(--ox-tweet-color-green);
+}
+
+.ox-tweet--full .ox-tweet__action--copy:hover .ox-tweet__action-icon,
+.ox-tweet--full .ox-tweet__action--copy[data-ox-tweet-copied] .ox-tweet__action-icon {
+  background-color: var(--ox-tweet-color-green-hover);
+}
+
+.ox-tweet--full .ox-tweet__action--copy:hover .ox-tweet__action-text,
+.ox-tweet--full .ox-tweet__action--copy[data-ox-tweet-copied] .ox-tweet__action-text {
+  color: var(--ox-tweet-color-green);
+  text-decoration-line: underline;
 }
 
 .ox-tweet--full .ox-tweet__copied-text {
@@ -175,8 +214,9 @@
   width: 100%;
   min-height: 32px;
   padding: 0 1rem;
-  font-size: 0.875rem;
-  font-weight: 700;
+  font-size: var(--ox-tweet-replies-font-size);
+  font-weight: var(--ox-tweet-replies-font-weight);
+  line-height: var(--ox-tweet-replies-line-height);
   color: var(--ox-tweet-color-blue-text);
   border: var(--ox-tweet-border);
   border-radius: 9999px;

--- a/crates/ox_content_ssg/src/plugins/social-tweet-full.css
+++ b/crates/ox_content_ssg/src/plugins/social-tweet-full.css
@@ -43,7 +43,14 @@
   --ox-tweet-body-line-height: 1.5rem;
   --ox-tweet-quoted-body-font-size: 0.938rem;
   --ox-tweet-info-font-size: 0.9375rem;
-  --ox-tweet-actions-font-size: 0.875rem;
+  --ox-tweet-actions-font-size: 1rem;
+  --ox-tweet-actions-line-height: 1.25rem;
+  --ox-tweet-actions-font-weight: 700;
+  --ox-tweet-actions-icon-size: 1.25em;
+  --ox-tweet-actions-icon-wrapper-size: 2rem;
+  --ox-tweet-replies-font-size: 0.875rem;
+  --ox-tweet-replies-line-height: 1rem;
+  --ox-tweet-replies-font-weight: 700;
   --ox-tweet-icon-size: 1.25em;
   --ox-tweet-border: 1px solid rgb(207, 217, 222);
   --ox-tweet-font-color: rgb(15, 20, 25);

--- a/docs/content/credits.md
+++ b/docs/content/credits.md
@@ -54,6 +54,8 @@ Contribution summary:
 - Reported the custom-host Markdown table migration that led to the
   browser-only table helper entrypoint and isolated table stylesheet.
 - Requested class-based dark-mode support for Twitter/X full-card styles.
+- Reported Twitter/X full-card action control geometry mismatches against
+  sveltweet production cards.
 
 ## Third-party attribution
 

--- a/npm/vite-plugin-ox-content/src/plugins/twitter-full.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter-full.test.ts
@@ -169,7 +169,10 @@ describe("full-fidelity Tweet cards", () => {
     expect(blue).toContain('href="https://x.com/intent/like?tweet_id=555"');
     expect(blue).toContain('href="https://x.com/intent/tweet?in_reply_to=555"');
     expect(blue).toContain("ox-tweet__action--copy");
+    expect(blue.match(/ox-tweet__action-icon/g)).toHaveLength(3);
+    expect(blue.match(/ox-tweet__action-text/g)).toHaveLength(4);
     expect(blue).toContain("data-ox-tweet-copy");
+    expect(blue).toContain('href="https://x.com/i/web/status/555"');
     expect(blue).toContain('data-ox-tweet-copy-url="https://x.com/i/web/status/555"');
     expect(blue).toContain('aria-label="Copy link to post"');
     expect(blue).toContain("ox-tweet__copy-text");

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/full.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/full.ts
@@ -106,9 +106,9 @@ function renderActions(permalink: string, data: TweetData): string {
   const likes = formatCount(data.favorite_count) ?? "0";
   return [
     '<div class="ox-tweet__actions">',
-    `<a class="ox-tweet__action ox-tweet__action--like" href="https://x.com/intent/like?tweet_id=${id}" target="_blank" rel="noopener noreferrer"><span class="ox-tweet__icon ox-tweet__icon--like"></span><span>${likes}</span></a>`,
-    `<a class="ox-tweet__action ox-tweet__action--reply" href="https://x.com/intent/tweet?in_reply_to=${id}" target="_blank" rel="noopener noreferrer"><span class="ox-tweet__icon ox-tweet__icon--reply"></span>Reply</a>`,
-    `<a class="ox-tweet__action ox-tweet__action--copy" href="${escapeAttribute(permalink)}" target="_blank" rel="noopener noreferrer" data-ox-tweet-copy data-ox-tweet-copy-url="${escapeAttribute(permalink)}" aria-label="Copy link to post"><span class="ox-tweet__icon ox-tweet__icon--copy"></span><span class="ox-tweet__copy-text">Copy link</span><span class="ox-tweet__copied-text">Copied!</span></a>`,
+    `<a class="ox-tweet__action ox-tweet__action--like" href="https://x.com/intent/like?tweet_id=${id}" target="_blank" rel="noopener noreferrer"><span class="ox-tweet__action-icon"><span class="ox-tweet__icon ox-tweet__icon--like"></span></span><span class="ox-tweet__action-text">${likes}</span></a>`,
+    `<a class="ox-tweet__action ox-tweet__action--reply" href="https://x.com/intent/tweet?in_reply_to=${id}" target="_blank" rel="noopener noreferrer"><span class="ox-tweet__action-icon"><span class="ox-tweet__icon ox-tweet__icon--reply"></span></span><span class="ox-tweet__action-text">Reply</span></a>`,
+    `<a class="ox-tweet__action ox-tweet__action--copy" href="${escapeAttribute(permalink)}" target="_blank" rel="noopener noreferrer" data-ox-tweet-copy data-ox-tweet-copy-url="${escapeAttribute(permalink)}" aria-label="Copy link to post"><span class="ox-tweet__action-icon"><span class="ox-tweet__icon ox-tweet__icon--copy"></span></span><span class="ox-tweet__action-text ox-tweet__copy-text">Copy link</span><span class="ox-tweet__action-text ox-tweet__copied-text">Copied!</span></a>`,
     "</div>",
   ].join("");
 }

--- a/npm/vite-plugin-ox-content/test/vrt/twitter-full-actions.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/twitter-full-actions.spec.ts
@@ -1,0 +1,193 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { clearTweetCache } from "../../src/plugins/twitter/fetch";
+import { transformFetchedTweets } from "../../src/plugins/twitter/transform";
+
+const SSG_PLUGINS = path.join(import.meta.dirname, "../../../../crates/ox_content_ssg/src/plugins");
+const FIXTURE_ID = "1543404742411698176";
+const FIXTURE_PERMALINK = `https://x.com/i/web/status/${FIXTURE_ID}`;
+const originalFetch = globalThis.fetch;
+
+const STYLE_SOURCES = [
+  "social.css",
+  "social-tweet-full-isolation.css",
+  "social-tweet-full.css",
+  "social-tweet-full-media.css",
+];
+
+const PROSE_CSS = `
+.prose {
+  color: #374151;
+  max-width: 65ch;
+}
+
+.prose a {
+  color: #111827;
+  padding: 0.75rem 1.25rem;
+  font-size: 1.25em;
+  font-weight: 500;
+  line-height: 2;
+  text-decoration: underline;
+}
+`;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+  clearTweetCache();
+});
+
+test.describe("Twitter full-card actions", () => {
+  for (const scheme of ["light", "dark"] as const) {
+    for (const width of [550, 380]) {
+      test(`matches sveltweet action geometry (${scheme}, ${width}px)`, async ({ page }) => {
+        await page.setViewportSize({ width: width === 550 ? 680 : width, height: 900 });
+        await page.emulateMedia({ colorScheme: scheme });
+        await renderFixture(page, { width: width === 550 ? 550 : undefined });
+
+        const geometry = await actionGeometry(page);
+        expect(geometry.rowHeight).toBeGreaterThanOrEqual(37);
+        expect(geometry.rowHeight).toBeLessThan(45);
+        expect(geometry.repliesHeight).toBeGreaterThanOrEqual(32);
+        expect(Math.abs(geometry.repliesWidth - geometry.repliesParentWidth)).toBeLessThanOrEqual(
+          1,
+        );
+        expect(geometry.copyHref).toBe(FIXTURE_PERMALINK);
+        expect(geometry.copyUrl).toBe(FIXTURE_PERMALINK);
+
+        for (const action of geometry.actions) {
+          expect(action.height).toBeGreaterThanOrEqual(32);
+          expect(action.width).toBeGreaterThanOrEqual(32);
+          expect(action.fontSize).toBe("16px");
+          expect(action.lineHeight).toBe("20px");
+          expect(action.paddingLeft).toBe("0px");
+          expect(action.paddingRight).toBe("0px");
+          expect(action.wrapperHeight).toBe(32);
+          expect(action.wrapperWidth).toBe(32);
+          expect(action.iconHeight).toBeGreaterThanOrEqual(20);
+          expect(action.iconWidth).toBeGreaterThanOrEqual(20);
+        }
+      });
+    }
+  }
+});
+
+async function renderFixture(page: Page, options: { width?: number } = {}): Promise<void> {
+  const [css, card] = await Promise.all([concatStyles(), renderFullFixture()]);
+  const width = options.width
+    ? ` style="width: ${options.width}px; max-width: ${options.width}px"`
+    : "";
+  await page.setContent(
+    `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <style>${css}</style>
+    <style>${PROSE_CSS}</style>
+    <style>body { margin: 0; padding: 16px; }</style>
+  </head>
+  <body>
+    <article class="prose"${width}>
+      ${card}
+    </article>
+  </body>
+</html>`,
+    { waitUntil: "load" },
+  );
+}
+
+async function renderFullFixture(): Promise<string> {
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url.startsWith("https://cdn.syndication.twimg.com/")) {
+      return {
+        ok: true,
+        json: async () => ({
+          id_str: FIXTURE_ID,
+          text: "Thank you JavaScript.",
+          created_at: "2022-07-02T23:10:00.000Z",
+          favorite_count: 12_345,
+          conversation_count: 134,
+          retweet_count: 678,
+          quote_count: 9,
+          user: {
+            name: "Action Geometry",
+            screen_name: "action_geometry",
+            is_blue_verified: true,
+          },
+        }),
+      } as Response;
+    }
+    return { ok: true, arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer } as Response;
+  };
+
+  return transformFetchedTweets(`<XPost id="${FIXTURE_ID}" />`, {
+    fetch: true,
+    cache: false,
+    appearance: "full",
+  });
+}
+
+async function concatStyles(): Promise<string> {
+  const parts = await Promise.all(
+    STYLE_SOURCES.map((file) => readFile(path.join(SSG_PLUGINS, file), "utf8")),
+  );
+  return parts.join("\n");
+}
+
+async function actionGeometry(page: Page): Promise<{
+  rowHeight: number;
+  repliesHeight: number;
+  repliesParentWidth: number;
+  repliesWidth: number;
+  copyHref: string | null;
+  copyUrl: string | null;
+  actions: Array<{
+    height: number;
+    width: number;
+    fontSize: string;
+    lineHeight: string;
+    paddingLeft: string;
+    paddingRight: string;
+    wrapperHeight: number;
+    wrapperWidth: number;
+    iconHeight: number;
+    iconWidth: number;
+  }>;
+}> {
+  return page.locator(".ox-tweet--full").evaluate((card) => {
+    const row = card.querySelector(".ox-tweet__actions") as HTMLElement;
+    const replies = card.querySelector(".ox-tweet__replies-link") as HTMLElement;
+    const repliesParent = card.querySelector(".ox-tweet__replies") as HTMLElement;
+    const copy = card.querySelector("[data-ox-tweet-copy]") as HTMLAnchorElement;
+    const rect = (node: Element) => node.getBoundingClientRect();
+
+    return {
+      rowHeight: rect(row).height,
+      repliesHeight: rect(replies).height,
+      repliesParentWidth: rect(repliesParent).width,
+      repliesWidth: rect(replies).width,
+      copyHref: copy.getAttribute("href"),
+      copyUrl: copy.getAttribute("data-ox-tweet-copy-url"),
+      actions: Array.from(row.querySelectorAll(".ox-tweet__action")).map((action) => {
+        const target = action as HTMLElement;
+        const wrapper = target.querySelector(".ox-tweet__action-icon") as HTMLElement;
+        const icon = target.querySelector(".ox-tweet__icon") as HTMLElement;
+        const style = getComputedStyle(target);
+        return {
+          height: rect(target).height,
+          width: rect(target).width,
+          fontSize: style.fontSize,
+          lineHeight: style.lineHeight,
+          paddingLeft: style.paddingLeft,
+          paddingRight: style.paddingRight,
+          wrapperHeight: rect(wrapper).height,
+          wrapperWidth: rect(wrapper).width,
+          iconHeight: rect(icon).height,
+          iconWidth: rect(icon).width,
+        };
+      }),
+    };
+  });
+}

--- a/npm/vite-plugin-ox-content/test/vrt/twitter-full-prose.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/twitter-full-prose.spec.ts
@@ -23,7 +23,14 @@ const SOCIAL_SOURCES = ["social.css"];
  */
 const PROSE_CSS = `
 .prose { color: #374151; max-width: 65ch; }
-.prose a { color: #111827; text-decoration: underline; font-weight: 500; }
+.prose a {
+  color: #111827;
+  padding: 0.75rem 1.25rem;
+  font-size: 1.25em;
+  font-weight: 500;
+  line-height: 2;
+  text-decoration: underline;
+}
 .prose strong { font-weight: 600; }
 .prose ol, .prose ul { margin-top: 1.25em; margin-bottom: 1.25em; padding-inline-start: 1.625em; }
 .prose ol { list-style-type: decimal; }


### PR DESCRIPTION
## Summary
- Align full-card Twitter/X action controls with the sveltweet/react-tweet geometry by adding explicit action icon wrappers and 16px action text.
- Harden full-card link isolation against host prose anchor padding, font-size, and line-height rules.
- Add Playwright geometry coverage for fixture 1543404742411698176 across light/dark and desktop/narrow widths, including full-width replies and Copy link fallback hrefs.

## Validation
- vp exec --filter @ox-content/vite-plugin -- vp test src/published-styles.test.ts src/plugins/twitter-full.test.ts src/plugins/twitter/parity.test.ts
- vp exec --filter @ox-content/vite-plugin -- playwright test test/vrt/twitter-full-actions.spec.ts test/vrt/twitter-full-prose.spec.ts test/vrt/twitter-full-theme.spec.ts
- vp run workspace:fmt:check
- node scripts/check-file-lines.ts --base origin/main
- git diff --cached --check
- vp run check:ts
- vp run build:npm
- vp run --ignore-depends-on build:docs
- node scripts/package-dry-run.mjs
- cargo test --workspace
- vp exec --filter @ox-content/vite-plugin -- vp test src

Closes #1167

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790527797&installation_model_id=422833&pr_number=1169&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1169&signature=4b5a289ed866d9cfe966e12f3bf91820eb790a9574054ff7cf73acc486920b1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved full-size Twitter/X card styling and isolation from surrounding page styles.
  * Corrected action button sizing, spacing, typography, icons, hover states, and reply link presentation.
  * Standardized copy-link and other action labels for more consistent rendering.

* **Tests**
  * Added visual regression coverage across light and dark themes and multiple card widths.
  * Expanded rendering checks for action icons, labels, status links, and card dimensions.

* **Documentation**
  * Updated community credits to recognize reported card layout issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->