### PR TITLE
fix(twitter): align replies placement with sveltweet

### DIFF
--- a/crates/ox_content_ssg/src/plugins/social-tweet-full-media.css
+++ b/crates/ox_content_ssg/src/plugins/social-tweet-full-media.css
@@ -203,7 +203,7 @@
 
 .ox-tweet--full .ox-tweet__replies {
   padding: 0.25rem 0;
-  margin: 0.5rem 0 0;
+  margin: 0;
 }
 
 .ox-tweet--full .ox-tweet__replies-link {

--- a/docs/content/credits.md
+++ b/docs/content/credits.md
@@ -54,8 +54,8 @@ Contribution summary:
 - Reported the custom-host Markdown table migration that led to the
   browser-only table helper entrypoint and isolated table stylesheet.
 - Requested class-based dark-mode support for Twitter/X full-card styles.
-- Reported Twitter/X full-card action control geometry mismatches against
-  sveltweet production cards.
+- Reported Twitter/X full-card action control and replies-placement geometry
+  mismatches against sveltweet production cards.
 
 ## Third-party attribution
 

--- a/docs/content/ja/credits.md
+++ b/docs/content/ja/credits.md
@@ -51,6 +51,8 @@ Markdown 属性とリッチなソーシャル埋め込みの見た目の同等�
 - ブラウザ専用の table helper entrypoint と独立した table stylesheet につながった、
   独自ホストでの Markdown table 移行課題を報告しました。
 - Twitter / X full card style の class ベース dark mode 対応を要望しました。
+- Twitter / X full card の action control と replies 配置の geometry が sveltweet の
+  本番 card と合っていないことを報告しました。
 
 ## 第三者の帰属
 

--- a/npm/vite-plugin-ox-content/test/vrt/twitter-full-actions.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/twitter-full-actions.spec.ts
@@ -49,10 +49,17 @@ test.describe("Twitter full-card actions", () => {
         const geometry = await actionGeometry(page);
         expect(geometry.rowHeight).toBeGreaterThanOrEqual(37);
         expect(geometry.rowHeight).toBeLessThan(45);
+        expect(
+          Math.abs(geometry.repliesOffsetTop - geometry.actionsOffsetBottom),
+        ).toBeLessThanOrEqual(1);
         expect(geometry.repliesHeight).toBeGreaterThanOrEqual(32);
         expect(Math.abs(geometry.repliesWidth - geometry.repliesParentWidth)).toBeLessThanOrEqual(
           1,
         );
+        const bottomInset = width === 550 ? 13 : 11;
+        expect(
+          Math.abs(geometry.cardHeight - geometry.repliesOffsetBottom - bottomInset),
+        ).toBeLessThanOrEqual(1);
         expect(geometry.copyHref).toBe(FIXTURE_PERMALINK);
         expect(geometry.copyUrl).toBe(FIXTURE_PERMALINK);
 
@@ -137,8 +144,12 @@ async function concatStyles(): Promise<string> {
 }
 
 async function actionGeometry(page: Page): Promise<{
+  actionsOffsetBottom: number;
+  cardHeight: number;
   rowHeight: number;
   repliesHeight: number;
+  repliesOffsetBottom: number;
+  repliesOffsetTop: number;
   repliesParentWidth: number;
   repliesWidth: number;
   copyHref: string | null;
@@ -162,11 +173,18 @@ async function actionGeometry(page: Page): Promise<{
     const repliesParent = card.querySelector(".ox-tweet__replies") as HTMLElement;
     const copy = card.querySelector("[data-ox-tweet-copy]") as HTMLAnchorElement;
     const rect = (node: Element) => node.getBoundingClientRect();
+    const cardRect = rect(card);
+    const rowRect = rect(row);
+    const repliesParentRect = rect(repliesParent);
 
     return {
-      rowHeight: rect(row).height,
+      actionsOffsetBottom: rowRect.bottom - cardRect.top,
+      cardHeight: cardRect.height,
+      rowHeight: rowRect.height,
       repliesHeight: rect(replies).height,
-      repliesParentWidth: rect(repliesParent).width,
+      repliesOffsetBottom: repliesParentRect.bottom - cardRect.top,
+      repliesOffsetTop: repliesParentRect.top - cardRect.top,
+      repliesParentWidth: repliesParentRect.width,
       repliesWidth: rect(replies).width,
       copyHref: copy.getAttribute("href"),
       copyUrl: copy.getAttribute("data-ox-tweet-copy-url"),


### PR DESCRIPTION
## Summary
- remove the remaining 8px gap before full-card replies so the replies region starts immediately after the actions row
- extend the full-card actions VRT to assert actions-to-replies adjacency and bottom spacing in light/dark desktop/narrow layouts
- credit ryoppippi for the action/replies geometry measurements in both docs locales

Fixes #1167.

## Validation
- vp exec --filter @ox-content/vite-plugin -- playwright test test/vrt/twitter-full-actions.spec.ts
- vp exec --filter @ox-content/vite-plugin -- playwright test test/vrt/twitter-full-actions.spec.ts test/vrt/twitter-full-prose.spec.ts test/vrt/twitter-full-theme.spec.ts
- vp exec --filter @ox-content/vite-plugin -- vp test src/plugins/twitter-full.test.ts src/plugins/twitter/parity.test.ts
- vp fmt crates/ox_content_ssg/src/plugins/social-tweet-full-media.css npm/vite-plugin-ox-content/test/vrt/twitter-full-actions.spec.ts docs/content/credits.md docs/content/ja/credits.md --check
- node scripts/check-file-lines.ts --base origin/main
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790531036&installation_model_id=422833&pr_number=1173&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1173&signature=b2cafc5ef60909a10855c9f29d6d044e28912666c68e9871b17dff185402e94b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->