### PR TITLE
fix(vite-plugin): preserve reader-chrome subpath declarations

### DIFF
--- a/npm/vite-plugin-ox-content/package.json
+++ b/npm/vite-plugin-ox-content/package.json
@@ -113,7 +113,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "vp pack && node scripts/build-standalone-entries.mjs && node scripts/build-reader-chrome-client.mjs && node scripts/copy-component-styles.mjs",
+    "build": "vp pack && node scripts/build-reader-chrome-types.mjs && node scripts/build-standalone-entries.mjs && node scripts/build-reader-chrome-client.mjs && node scripts/copy-component-styles.mjs",
     "build:styles": "node scripts/copy-component-styles.mjs",
     "dev": "vp pack --watch",
     "typecheck": "tsgo --noEmit",

--- a/npm/vite-plugin-ox-content/scripts/build-reader-chrome-types.mjs
+++ b/npm/vite-plugin-ox-content/scripts/build-reader-chrome-types.mjs
@@ -1,0 +1,122 @@
+import { rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+const distDir = join(packageRoot, "dist");
+
+const declarations = `/**
+ * Per-control flags for \`ssg.readerChrome\`.
+ *
+ * Omitted fields stay on when the feature itself is enabled.
+ */
+export interface ReaderChromeOptions {
+  /**
+   * Copy button on fenced code blocks. The clipboard is read in the browser,
+   * never at build time.
+   *
+   * @default true
+   */
+  copy?: boolean;
+
+  /**
+   * Icon and \`rel="noopener noreferrer"\` on outbound \`http(s)\` links.
+   * Relative, hash, and same-document links are left alone.
+   *
+   * @default true
+   */
+  externalLinks?: boolean;
+
+  /**
+   * Back-to-top control that appears after the page is scrolled.
+   *
+   * @default true
+   */
+  backToTop?: boolean;
+}
+
+/**
+ * Resolved reader chrome. \`false\` means no extra markup or JS.
+ */
+export type ResolvedReaderChrome =
+  | false
+  | {
+      copy: boolean;
+      externalLinks: boolean;
+      backToTop: boolean;
+    };
+
+type EnabledReaderChrome = Exclude<ResolvedReaderChrome, false>;
+
+export type ReaderChromeInput =
+  | boolean
+  | ReaderChromeOptions
+  | EnabledReaderChrome
+  | undefined;
+
+/**
+ * Resolve the public reader-chrome option shape.
+ */
+export declare function resolveReaderChromeInput(
+  input?: ReaderChromeInput,
+): ResolvedReaderChrome;
+
+/**
+ * Apply the same native reader-chrome HTML transform used by the built-in SSG.
+ */
+export declare function applyReaderChromeHtml(
+  html: string,
+  input?: ReaderChromeInput,
+): string;
+
+/**
+ * Root attributes consumed by the browser runtime.
+ */
+export declare function readerChromeAttributes(
+  input?: ReaderChromeInput,
+): Readonly<Record<string, "">>;
+
+/**
+ * Render the root attributes as a leading-space HTML fragment.
+ */
+export declare function renderReaderChromeAttributes(input?: ReaderChromeInput): string;
+
+/**
+ * CSS shared by the built-in SSG and custom hosts.
+ */
+export declare function readerChromeCss(input?: ReaderChromeInput): string;
+
+/**
+ * Auto-initializing script shared by the built-in SSG and custom hosts.
+ */
+export declare function readerChromeScript(input?: ReaderChromeInput): string;
+
+/**
+ * Inline stylesheet tag for hosts that do not import
+ * \`@ox-content/vite-plugin/styles/reader-chrome.css\`.
+ */
+export declare function renderReaderChromeStyleTag(input?: ReaderChromeInput): string;
+
+/**
+ * Inline auto-init script for static hosts that do not bundle
+ * \`@ox-content/vite-plugin/reader-chrome/client\`.
+ */
+export declare function renderReaderChromeScriptTag(input?: ReaderChromeInput): string;
+
+export declare function readerChromeIsEnabled(
+  chrome: ResolvedReaderChrome,
+): chrome is Exclude<ResolvedReaderChrome, false>;
+
+export declare function readerChromeNeedsJs(chrome: ResolvedReaderChrome): boolean;
+`;
+
+await Promise.all([
+  writeFile(join(distDir, "reader-chrome.d.mts"), declarations),
+  writeFile(join(distDir, "reader-chrome.d.cts"), declarations),
+  rm(join(distDir, "reader-chrome.d.mts.map"), { force: true }),
+  rm(join(distDir, "reader-chrome.d.cts.map"), { force: true }),
+  rm(join(distDir, "reader-chrome2.d.mts"), { force: true }),
+  rm(join(distDir, "reader-chrome2.d.cts"), { force: true }),
+  rm(join(distDir, "reader-chrome2.d.mts.map"), { force: true }),
+  rm(join(distDir, "reader-chrome2.d.cts.map"), { force: true }),
+]);

--- a/npm/vite-plugin-ox-content/src/reader-chrome-options.ts
+++ b/npm/vite-plugin-ox-content/src/reader-chrome-options.ts
@@ -1,0 +1,40 @@
+/**
+ * Per-control flags for `ssg.readerChrome`.
+ *
+ * Omitted fields stay on when the feature itself is enabled.
+ */
+export interface ReaderChromeOptions {
+  /**
+   * Copy button on fenced code blocks. The clipboard is read in the browser,
+   * never at build time.
+   *
+   * @default true
+   */
+  copy?: boolean;
+
+  /**
+   * Icon and `rel="noopener noreferrer"` on outbound `http(s)` links.
+   * Relative, hash, and same-document links are left alone.
+   *
+   * @default true
+   */
+  externalLinks?: boolean;
+
+  /**
+   * Back-to-top control that appears after the page is scrolled.
+   *
+   * @default true
+   */
+  backToTop?: boolean;
+}
+
+/**
+ * Resolved reader chrome. `false` means no extra markup or JS.
+ */
+export type ResolvedReaderChrome =
+  | false
+  | {
+      copy: boolean;
+      externalLinks: boolean;
+      backToTop: boolean;
+    };

--- a/npm/vite-plugin-ox-content/src/reader-chrome.test.ts
+++ b/npm/vite-plugin-ox-content/src/reader-chrome.test.ts
@@ -55,12 +55,20 @@ describe("reader chrome public API", () => {
     const source = readFileSync(join(packageRoot, "src/reader-chrome.ts"), "utf8");
     expect(source).not.toContain('from "./ssg"');
     expect(source).not.toContain("defaultTheme");
+    expect(source).not.toContain('from "./types"');
 
+    const typesScript = readFileSync(
+      join(packageRoot, "scripts/build-reader-chrome-types.mjs"),
+      "utf8",
+    );
+    expect(typesScript).toContain("reader-chrome.d.mts");
+    expect(typesScript).toContain("reader-chrome.d.cts");
     const buildScript = readFileSync(
       join(packageRoot, "scripts/build-reader-chrome-client.mjs"),
       "utf8",
     );
     expect(buildScript).toContain("reader_chrome_runtime.js");
+    expect(packageJson.scripts.build).toContain("node scripts/build-reader-chrome-types.mjs");
     expect(packageJson.scripts.build).toContain("node scripts/build-reader-chrome-client.mjs");
   });
 

--- a/npm/vite-plugin-ox-content/src/reader-chrome.ts
+++ b/npm/vite-plugin-ox-content/src/reader-chrome.ts
@@ -1,5 +1,5 @@
 import { importNapiModuleSync } from "./napi";
-import type { ReaderChromeOptions, ResolvedReaderChrome } from "./types";
+import type { ReaderChromeOptions, ResolvedReaderChrome } from "./reader-chrome-options";
 
 export type { ReaderChromeOptions, ResolvedReaderChrome };
 

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -27,8 +27,10 @@ import type {
   ResolvedCitationsOptions,
 } from "./citation-types";
 import type { BudouxOptions, ResolvedBudouxOptions } from "./budoux-types";
+import type { ReaderChromeOptions, ResolvedReaderChrome } from "./reader-chrome-options";
 import type { ThemeComponent } from "./theme-renderer";
 
+export type { ReaderChromeOptions, ResolvedReaderChrome } from "./reader-chrome-options";
 export type {
   BibliographyEntry,
   CitationFailureMode,
@@ -551,47 +553,6 @@ export interface SsgOptions {
    */
   navigation?: SsgNavigationGroup[];
 }
-
-/**
- * Per-control flags for `ssg.readerChrome`.
- *
- * Omitted fields stay on when the feature itself is enabled.
- */
-export interface ReaderChromeOptions {
-  /**
-   * Copy button on fenced code blocks. The clipboard is read in the browser,
-   * never at build time.
-   *
-   * @default true
-   */
-  copy?: boolean;
-
-  /**
-   * Icon and `rel="noopener noreferrer"` on outbound `http(s)` links.
-   * Relative, hash, and same-document links are left alone.
-   *
-   * @default true
-   */
-  externalLinks?: boolean;
-
-  /**
-   * Back-to-top control that appears after the page is scrolled.
-   *
-   * @default true
-   */
-  backToTop?: boolean;
-}
-
-/**
- * Resolved reader chrome. `false` means no extra markup or JS.
- */
-export type ResolvedReaderChrome =
-  | false
-  | {
-      copy: boolean;
-      externalLinks: boolean;
-      backToTop: boolean;
-    };
 
 /**
  * Per-control flags for `ssg.a11y`.

--- a/scripts/package-dry-run-reader-chrome.mjs
+++ b/scripts/package-dry-run-reader-chrome.mjs
@@ -1,0 +1,159 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const publicValues = [
+  "applyReaderChromeHtml",
+  "readerChromeAttributes",
+  "readerChromeCss",
+  "readerChromeIsEnabled",
+  "readerChromeNeedsJs",
+  "readerChromeScript",
+  "renderReaderChromeAttributes",
+  "renderReaderChromeScriptTag",
+  "renderReaderChromeStyleTag",
+  "resolveReaderChromeInput",
+];
+const publicTypes = ["ReaderChromeInput", "ReaderChromeOptions", "ResolvedReaderChrome"];
+const tscBin = join("node_modules", ".bin", process.platform === "win32" ? "tsc.cmd" : "tsc");
+
+export function checkReaderChromeDeclarations({ pkg, tarball, packDir, failures, readPackedFile }) {
+  for (const extension of ["mts", "cts"]) {
+    const declaration = readPackedFile(tarball, `dist/reader-chrome.d.${extension}`);
+    for (const name of [...publicValues, ...publicTypes]) {
+      if (!new RegExp(`\\b${name}\\b`).test(declaration)) {
+        failures.push(`${pkg.name} reader-chrome.d.${extension} is missing ${name}`);
+      }
+    }
+    if (/\bapplyReaderChromeHtml\s+as\s+\w+\b/.test(declaration)) {
+      failures.push(`${pkg.name} reader-chrome.d.${extension} aliases applyReaderChromeHtml`);
+    }
+    if (/reader-chrome2/.test(declaration)) {
+      failures.push(`${pkg.name} reader-chrome.d.${extension} references reader-chrome2`);
+    }
+  }
+
+  for (const mode of ["bundler", "nodenext", "node16"]) {
+    checkReaderChromeConsumer({ pkg, tarball, packDir, failures, mode });
+  }
+}
+
+function checkReaderChromeConsumer({ pkg, tarball, packDir, failures, mode }) {
+  const consumerRoot = mkdtempSync(join(packDir, `reader-chrome-${mode}-`));
+  const packageRoot = join(consumerRoot, "node_modules", "@ox-content", "vite-plugin");
+  mkdirSync(packageRoot, { recursive: true });
+
+  const extract = spawnSync("tar", ["-xzf", tarball, "-C", packageRoot, "--strip-components=1"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (extract.error) {
+    throw extract.error;
+  }
+  if (extract.status !== 0) {
+    throw new Error(extract.stderr || `Failed to extract ${pkg.name} into ${consumerRoot}`);
+  }
+
+  writeFileSync(join(consumerRoot, "package.json"), JSON.stringify({ type: "module" }));
+  writeFileSync(join(consumerRoot, "esm-fixture.ts"), esmFixture());
+  writeFileSync(join(consumerRoot, "cjs-fixture.cts"), cjsFixture());
+  writeFileSync(join(consumerRoot, "tsconfig.json"), tsconfig(mode));
+
+  const result = spawnSync(tscBin, ["-p", join(consumerRoot, "tsconfig.json")], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    failures.push(
+      `${pkg.name} reader-chrome ${mode} consumer failed:\n${result.stdout}${result.stderr}`,
+    );
+  }
+}
+
+function esmFixture() {
+  return [
+    `import { ${publicValues.join(", ")} } from "@ox-content/vite-plugin/reader-chrome";`,
+    `import type { ${publicTypes.join(", ")} } from "@ox-content/vite-plugin/reader-chrome";`,
+    "",
+    "const options: ReaderChromeOptions = { copy: true, externalLinks: false };",
+    "const input: ReaderChromeInput = options;",
+    "const resolved: ResolvedReaderChrome = resolveReaderChromeInput(input);",
+    "const html: string = applyReaderChromeHtml('<pre><code>x</code></pre>', resolved);",
+    "const attrs: Readonly<Record<string, ''>> = readerChromeAttributes(input);",
+    "const snippets: string[] = [",
+    "  html,",
+    "  readerChromeCss(input),",
+    "  readerChromeScript(input),",
+    "  renderReaderChromeAttributes(input),",
+    "  renderReaderChromeScriptTag(input),",
+    "  renderReaderChromeStyleTag(input),",
+    "];",
+    "const flags: boolean[] = [readerChromeIsEnabled(resolved), readerChromeNeedsJs(resolved)];",
+    "void attrs;",
+    "void snippets;",
+    "void flags;",
+  ].join("\n");
+}
+
+function cjsFixture() {
+  return [
+    `import readerChrome = require("@ox-content/vite-plugin/reader-chrome");`,
+    `type ReaderChromeInput = import("@ox-content/vite-plugin/reader-chrome").ReaderChromeInput;`,
+    `type ReaderChromeOptions = import("@ox-content/vite-plugin/reader-chrome").ReaderChromeOptions;`,
+    `type ResolvedReaderChrome = import("@ox-content/vite-plugin/reader-chrome").ResolvedReaderChrome;`,
+    "",
+    "const options: ReaderChromeOptions = { copy: true, backToTop: false };",
+    "const input: ReaderChromeInput = options;",
+    "const resolved: ResolvedReaderChrome = readerChrome.resolveReaderChromeInput(input);",
+    "const html: string = readerChrome.applyReaderChromeHtml('<pre><code>x</code></pre>', input);",
+    "const attrs: Readonly<Record<string, ''>> = readerChrome.readerChromeAttributes(resolved);",
+    "const snippets: string[] = [",
+    "  html,",
+    "  readerChrome.readerChromeCss(input),",
+    "  readerChrome.readerChromeScript(input),",
+    "  readerChrome.renderReaderChromeAttributes(input),",
+    "  readerChrome.renderReaderChromeScriptTag(input),",
+    "  readerChrome.renderReaderChromeStyleTag(input),",
+    "];",
+    "const flags: boolean[] = [",
+    "  readerChrome.readerChromeIsEnabled(resolved),",
+    "  readerChrome.readerChromeNeedsJs(resolved),",
+    "];",
+    "void attrs;",
+    "void snippets;",
+    "void flags;",
+  ].join("\n");
+}
+
+function tsconfig(mode) {
+  const compilerOptions =
+    mode === "bundler"
+      ? {
+          target: "ES2022",
+          module: "ESNext",
+          moduleResolution: "Bundler",
+          strict: true,
+          skipLibCheck: true,
+          noEmit: true,
+        }
+      : {
+          target: "ES2022",
+          module: mode === "nodenext" ? "NodeNext" : "Node16",
+          moduleResolution: mode === "nodenext" ? "NodeNext" : "Node16",
+          strict: true,
+          skipLibCheck: true,
+          noEmit: true,
+        };
+
+  return JSON.stringify(
+    {
+      compilerOptions,
+      files: mode === "bundler" ? ["esm-fixture.ts"] : ["esm-fixture.ts", "cjs-fixture.cts"],
+    },
+    null,
+    2,
+  );
+}

--- a/scripts/package-dry-run.mjs
+++ b/scripts/package-dry-run.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
-import { spawnSync } from "node:child_process";
+import { checkReaderChromeDeclarations } from "./package-dry-run-reader-chrome.mjs";
 
 const packages = [
   "crates/ox_content_napi",
@@ -70,10 +71,23 @@ function checkPackage(packageDir) {
   if (pkg.name === "@ox-content/napi") {
     checkNapiPackage(packageDir, pkg, files);
   }
+  if (pkg.name === "@ox-content/vite-plugin") {
+    checkReaderChromeDeclarations({
+      pkg,
+      tarball: packed.filename,
+      packDir,
+      failures,
+      readPackedFile,
+    });
+  }
 }
 
 function readPackedPackageJson(filename) {
-  const result = spawnSync("tar", ["-xOf", filename, "package/package.json"], {
+  return JSON.parse(readPackedFile(filename, "package.json"));
+}
+
+function readPackedFile(filename, path) {
+  const result = spawnSync("tar", ["-xOf", filename, `package/${path}`], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -82,10 +96,10 @@ function readPackedPackageJson(filename) {
     throw result.error;
   }
   if (result.status !== 0) {
-    throw new Error(result.stderr || `Failed to read package.json from ${filename}`);
+    throw new Error(result.stderr || `Failed to read ${path} from ${filename}`);
   }
 
-  return JSON.parse(result.stdout);
+  return result.stdout;
 }
 
 function checkVitePeerDependency(pkg) {


### PR DESCRIPTION
## Summary
- keep reader-chrome public types in a small dedicated module so the subpath entry no longer pulls the full root declaration graph
- replace the generated reader-chrome declaration facade with stable ESM/CJS named declarations during package build
- add packed-package dry-run checks that compile reader-chrome imports under Bundler, NodeNext, and Node16 resolution

Fixes #1172

## Validation
- vp run build:napi
- vp run --filter @ox-content/vite-plugin build
- vp exec --filter @ox-content/vite-plugin -- vp test src/reader-chrome.test.ts src/public-exports.test.ts
- vp run build:npm
- node scripts/package-dry-run.mjs
- vp run check:ts
- vp fmt npm/vite-plugin-ox-content/package.json npm/vite-plugin-ox-content/src/reader-chrome.test.ts npm/vite-plugin-ox-content/src/reader-chrome.ts npm/vite-plugin-ox-content/src/types.ts npm/vite-plugin-ox-content/src/reader-chrome-options.ts npm/vite-plugin-ox-content/scripts/build-reader-chrome-types.mjs scripts/package-dry-run.mjs scripts/package-dry-run-reader-chrome.mjs --check
- node scripts/check-file-lines.ts --base origin/main
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790532098&installation_model_id=422833&pr_number=1176&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1176&signature=7d518a1826f649442e93ece7b0fcdfe4b2abcac21224df21b07b10f222175ec7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer configuration options for reader chrome controls, including copy, external links, and back-to-top functionality.
  * Improved access to reader chrome types and helpers for both ESM and CommonJS integrations.
* **Bug Fixes**
  * Improved package output and compatibility across supported module and TypeScript configurations.
* **Tests**
  * Added validation to ensure packaged reader chrome declarations work correctly in consumer projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->