### PR TITLE
feat(reader-chrome): expose copy sizing tokens

### DIFF
--- a/crates/ox_content_ssg/src/html/reader_chrome.css
+++ b/crates/ox_content_ssg/src/html/reader_chrome.css
@@ -1,5 +1,8 @@
 .ox-code {
-  --ox-copy-reserved-inline-size: 2rem;
+  --ox-copy-reserved-inline-size: max(
+    2rem,
+    calc(var(--ox-copy-control-size, 1.75rem) + var(--ox-copy-inset, 0.5rem) - 0.25rem)
+  );
   position: relative;
   margin: 1.25rem 0;
 }
@@ -17,12 +20,12 @@
 }
 .ox-copy {
   position: absolute;
-  inset-block-start: 0.5rem;
-  inset-inline-end: 0.5rem;
+  inset-block-start: var(--ox-copy-inset, 0.5rem);
+  inset-inline-end: var(--ox-copy-inset, 0.5rem);
   z-index: 1;
   display: grid;
-  width: 1.75rem;
-  height: 1.75rem;
+  width: var(--ox-copy-control-size, 1.75rem);
+  height: var(--ox-copy-control-size, 1.75rem);
   padding: 0;
   place-items: center;
   border: 1px solid transparent;
@@ -41,16 +44,16 @@
   z-index: 2;
   min-width: 0;
   min-height: 0;
-  width: 1.75rem;
-  height: 1.75rem;
+  width: var(--ox-copy-control-size, 1.75rem);
+  height: var(--ox-copy-control-size, 1.75rem);
   padding: 0;
   font: inherit;
   line-height: 1;
 }
 .ox-copy::before {
   content: "";
-  width: 0.8125rem;
-  height: 0.8125rem;
+  width: var(--ox-copy-icon-size, 0.8125rem);
+  height: var(--ox-copy-icon-size, 0.8125rem);
   background-color: currentColor;
   -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><rect x='9' y='9' width='11' height='11' rx='2'/><path d='M15 9V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h3'/></svg>")
     center / contain no-repeat;

--- a/crates/ox_content_ssg/src/html/reader_chrome/style_tests.rs
+++ b/crates/ox_content_ssg/src/html/reader_chrome/style_tests.rs
@@ -3,8 +3,8 @@ use super::{READER_CHROME_CSS, READER_CHROME_JS};
 #[test]
 fn copy_control_uses_inline_clearance_without_wasting_vertical_space() {
     assert!(
-        READER_CHROME_CSS.contains("inset-block-start: 0.5rem;")
-            && READER_CHROME_CSS.contains("inset-inline-end: 0.5rem;"),
+        READER_CHROME_CSS.contains("inset-block-start: var(--ox-copy-inset, 0.5rem);")
+            && READER_CHROME_CSS.contains("inset-inline-end: var(--ox-copy-inset, 0.5rem);"),
         "copy positioning must follow the document writing direction: {READER_CHROME_CSS}"
     );
     assert!(
@@ -48,9 +48,9 @@ fn copy_control_uses_capability_media_queries_and_stable_status_ui() {
     );
     assert!(
         READER_CHROME_CSS.contains(
-            ".ox-code > .ox-copy {\n  z-index: 2;\n  min-width: 0;\n  min-height: 0;\n  width: 1.75rem;\n  height: 1.75rem;\n  padding: 0;"
+            ".ox-code > .ox-copy {\n  z-index: 2;\n  min-width: 0;\n  min-height: 0;\n  width: var(--ox-copy-control-size, 1.75rem);\n  height: var(--ox-copy-control-size, 1.75rem);\n  padding: 0;"
         ),
-        "custom prose button styles must not resize the fixed copy control: {READER_CHROME_CSS}"
+        "custom prose button styles must not resize the token-controlled copy control: {READER_CHROME_CSS}"
     );
     assert!(
         READER_CHROME_CSS.contains("border: 1px solid transparent;")

--- a/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
+++ b/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
@@ -230,6 +230,25 @@ fn reduced_motion_class_and_css_are_present() {
 }
 
 #[test]
+fn code_copy_sizing_tokens_drive_the_control_and_gutter() {
+    assert!(READER_CHROME_CSS.contains("--ox-copy-control-size, 1.75rem"), "{READER_CHROME_CSS}");
+    assert!(READER_CHROME_CSS.contains("--ox-copy-icon-size, 0.8125rem"), "{READER_CHROME_CSS}");
+    assert!(READER_CHROME_CSS.contains("--ox-copy-inset, 0.5rem"), "{READER_CHROME_CSS}");
+    assert!(
+        READER_CHROME_CSS.contains("var(--ox-copy-control-size, 1.75rem)")
+            && READER_CHROME_CSS.contains("var(--ox-copy-icon-size, 0.8125rem)")
+            && READER_CHROME_CSS.contains("var(--ox-copy-inset, 0.5rem)"),
+        "{READER_CHROME_CSS}"
+    );
+    assert!(
+        READER_CHROME_CSS.contains(
+            "calc(var(--ox-copy-control-size, 1.75rem) + var(--ox-copy-inset, 0.5rem) - 0.25rem)"
+        ),
+        "{READER_CHROME_CSS}"
+    );
+}
+
+#[test]
 fn unclosed_or_hostile_input_is_left_intact() {
     let unclosed_pre = "<pre><code>no end";
     let unclosed_link = r#"<a href="https://example.com/docs">no end"#;

--- a/docs/content/built-in/reader-chrome.md
+++ b/docs/content/built-in/reader-chrome.md
@@ -51,6 +51,28 @@ is not copied at build time, and annotated fences prefer `data-ox-code-source`
 so the copied value matches the authored block. Page-level Copy as Markdown is
 a separate opt-in on [`ssg.markdownSource.copy`](./markdown-source.md).
 
+The built-in SSG stylesheet and
+`@ox-content/vite-plugin/styles/reader-chrome.css` expose stable copy-control
+sizing tokens:
+
+| Token                    | Default     | Effect                                   |
+| ------------------------ | ----------- | ---------------------------------------- |
+| `--ox-copy-control-size` | `1.75rem`   | Square button size                       |
+| `--ox-copy-icon-size`    | `0.8125rem` | Copy and copied-state glyph size         |
+| `--ox-copy-inset`        | `0.5rem`    | Block-start and inline-end button offset |
+
+Set them on `.content` or another reader root instead of overriding internal
+`.ox-copy` selectors:
+
+```css
+.content {
+  --ox-copy-icon-size: 1rem;
+}
+```
+
+The code title and inline-end gutter reservation follow customized control and
+inset sizes.
+
 Outbound icons skip relative, hash, `mailto:`, and `tel:` links. Links inside
 fenced blocks or inline code spans are left alone. `javascript:`, `data:`, and
 `vbscript:` hrefs are not given a live action.

--- a/docs/content/credits.md
+++ b/docs/content/credits.md
@@ -60,6 +60,8 @@ Contribution summary:
   downstream migration without a site-specific listener.
 - Matched the Twitter/X full-card action icons and accessible names to the
   sveltweet reference contract.
+- Reported the custom-host reader-chrome copy sizing requirement from the
+  ryoppippi.com integration.
 
 ## Third-party attribution
 

--- a/docs/content/ja/built-in/reader-chrome.md
+++ b/docs/content/ja/built-in/reader-chrome.md
@@ -45,6 +45,27 @@ oxContent({
 
 コピーは読者がボタンを押したときにブラウザのクリップボードを使います。フェンス本文はビルド時にはコピーしません。注釈付きフェンスでは `data-ox-code-source` を優先するので、コピーされる値は書いたコードに一致します。ページ全体の Copy as Markdown は別のオプトイン [`ssg.markdownSource.copy`](./markdown-source.md) です。
 
+組み込み SSG の stylesheet と
+`@ox-content/vite-plugin/styles/reader-chrome.css` は、コピー操作のサイズを
+調整できる安定 token を公開しています。
+
+| Token                    | 既定値      | 効果                                        |
+| ------------------------ | ----------- | ------------------------------------------- |
+| `--ox-copy-control-size` | `1.75rem`   | 正方形のボタンサイズ                        |
+| `--ox-copy-icon-size`    | `0.8125rem` | copy と copied 状態の glyph サイズ          |
+| `--ox-copy-inset`        | `0.5rem`    | block-start / inline-end のボタンオフセット |
+
+内部の `.ox-copy` selector を上書きせず、`.content` など reader root に token
+を置いて調整します。
+
+```css
+.content {
+  --ox-copy-icon-size: 1rem;
+}
+```
+
+コードタイトルと inline-end の余白予約は、カスタマイズした control / inset サイズに追従します。
+
 外部リンクアイコンは相対、ハッシュ、`mailto:`、`tel:` を飛ばします。フェンス内やインラインコード内のリンクはそのままです。`javascript:`、`data:`、`vbscript:` の href には生きた操作を付けません。
 
 先頭へ戻る操作は `prefers-reduced-motion` を尊重します。エントリページでは出しません。

--- a/docs/content/ja/credits.md
+++ b/docs/content/ja/credits.md
@@ -57,6 +57,8 @@ Markdown 属性とリッチなソーシャル埋め込みの見た目の同等�
   site-specific listener を外せる downstream migration を検証しました。
 - Twitter / X full card action icon と accessible name を sveltweet の
   reference contract に合わせました。
+- ryoppippi.com integration で、独自ホストの reader-chrome copy sizing 要件を
+  報告しました。
 
 ## 第三者の帰属
 

--- a/npm/vite-plugin-ox-content/test/vrt/copy-button-sizing.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/copy-button-sizing.spec.ts
@@ -1,0 +1,285 @@
+import { expect, test, type Page } from "@playwright/test";
+import {
+  applyReaderChromeHtml,
+  renderReaderChromeAttributes,
+  renderReaderChromeStyleTag,
+} from "../../src/reader-chrome";
+import { generateHtmlPage } from "../../src/ssg";
+import { transformMarkdown } from "../../src/transform";
+import { createDocsResolvedOptions } from "../fixtures/docs-fixture";
+
+const COPY_SIZE_MARKDOWN = [
+  "# Copy Sizing",
+  "",
+  "```ts:line-numbers=117 :wrap [src/components/really-long-reader-chrome-copy-button-layout-example.ts]",
+  "export async function loadUserSession(request: Request, cache: Map<string, Promise<UserSession>>) {",
+  '  const authorization = request.headers.get("authorization") ?? request.headers.get("x-legacy-auth-token");',
+  '  const key = authorization?.replace(/^Bearer\\s+/i, "") ?? "anonymous-session-without-token";',
+  "  return cache.get(key) ?? fetchAndStoreUserSession(cache, key, authorization);",
+  "}",
+  "```",
+].join("\n");
+
+const COPY_SIZE_EXPECTATIONS = {
+  default: { control: 28, icon: 13, inset: 8 },
+  custom: { control: 40, icon: 16, inset: 12 },
+} as const;
+
+type CopySizeMode = keyof typeof COPY_SIZE_EXPECTATIONS;
+type CopyColorScheme = "light" | "dark";
+type CopyDirection = "ltr" | "rtl";
+
+test.describe("reader chrome copy sizing tokens", () => {
+  for (const scheme of ["light", "dark"] as const) {
+    for (const mode of ["default", "custom"] as const) {
+      test(`keep code controls clear (${scheme}, desktop, ${mode})`, async ({ page }) => {
+        await page.setViewportSize({ width: 760, height: 720 });
+        await assertCopySizing(page, { scheme, mode, direction: "ltr" });
+      });
+    }
+  }
+});
+
+test.describe("reader chrome copy sizing tokens on touch layouts", () => {
+  test.use({ hasTouch: true, isMobile: true, viewport: { width: 390, height: 844 } });
+
+  for (const scheme of ["light", "dark"] as const) {
+    for (const mode of ["default", "custom"] as const) {
+      test(`keep code controls clear (${scheme}, touch, ${mode})`, async ({ page }) => {
+        await assertCopySizing(page, {
+          scheme,
+          mode,
+          direction: scheme === "dark" && mode === "custom" ? "rtl" : "ltr",
+        });
+      });
+    }
+  }
+});
+
+test("custom host can resize copy controls with public tokens only", async ({ page }) => {
+  const markdown = ["# Copy", "", "```ts", "const value = 1;", "```"].join("\n");
+  const result = await transformMarkdown(
+    markdown,
+    "docs/vrt-custom-copy-size.md",
+    createDocsResolvedOptions({ highlight: true }),
+  );
+  const article = applyReaderChromeHtml(result.html, {
+    copy: true,
+    externalLinks: false,
+    backToTop: false,
+  });
+
+  await page.setContent(
+    `<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    :root {
+      --octc-color-primary: #4f6fae;
+      --octc-color-text: #131a30;
+      --octc-color-bg: #ffffff;
+      --octc-color-bg-alt: #f5f7fb;
+      --octc-color-code-text: #e5e9f0;
+      --octc-color-code-bg: #121a2f;
+      --octc-color-code-frame-border: #44506a;
+    }
+    .content {
+      --ox-copy-control-size: 2.25rem;
+      --ox-copy-icon-size: 1rem;
+      --ox-copy-inset: 0.625rem;
+      max-width: 680px;
+      margin: 0 auto;
+    }
+    .content pre { margin: 2rem 0; padding: 3rem; background: var(--octc-color-code-bg); color: var(--octc-color-code-text); }
+    .content button { width: 14rem; min-height: 5rem; padding: 2rem; font-size: 3rem; }
+  </style>
+  ${renderReaderChromeStyleTag({ copy: true, externalLinks: false, backToTop: false })}
+</head>
+<body>
+  <article class="content"${renderReaderChromeAttributes({ copy: true, externalLinks: false, backToTop: false })}>${article}</article>
+</body>
+</html>`,
+    { waitUntil: "load" },
+  );
+
+  const metrics = await readCopyMetrics(page);
+  expectClose(metrics.controlWidth, 36);
+  expectClose(metrics.controlHeight, 36);
+  expectClose(metrics.iconWidth, 16);
+  expectClose(metrics.iconHeight, 16);
+  expectClose(metrics.insetBlockStart, 10);
+  expectClose(metrics.insetInlineEnd, 10);
+});
+
+async function assertCopySizing(
+  page: Page,
+  options: { direction: CopyDirection; mode: CopySizeMode; scheme: CopyColorScheme },
+) {
+  await page.emulateMedia({ colorScheme: options.scheme });
+  await renderCopySizingFixture(page, options);
+
+  const button = page.locator(".ox-code").first().locator(".ox-copy");
+  const expected = COPY_SIZE_EXPECTATIONS[options.mode];
+  const rest = await readCopyMetrics(page);
+  expectCopyMetrics(rest, expected);
+  expect(rest.lineNumberWidth).toBeGreaterThan(0);
+  expect(rest.preScrollWidth).toBeLessThanOrEqual(rest.preClientWidth + 1);
+  expect(rest.prePaddingInlineEnd).toBeGreaterThanOrEqual(expected.control + expected.inset - 1);
+  expect(rest.titlePaddingInlineEnd).toBeGreaterThanOrEqual(expected.control + expected.inset - 1);
+  expect(Math.abs(rest.titleMarginInlineEnd)).toBeGreaterThanOrEqual(
+    rest.titlePaddingInlineEnd - 1,
+  );
+
+  await page.locator(".ox-code").first().hover();
+  await button.hover({ force: true });
+  expectSameCopyLayout(rest, await readCopyMetrics(page));
+
+  await button.focus();
+  expectSameCopyLayout(rest, await readCopyMetrics(page));
+
+  await button.evaluate((node) => node.setAttribute("data-copy-state", "copied"));
+  expectSameCopyLayout(rest, await readCopyMetrics(page));
+
+  await button.evaluate((node) => node.setAttribute("data-copy-state", "failed"));
+  expectSameCopyLayout(rest, await readCopyMetrics(page));
+}
+
+async function renderCopySizingFixture(
+  page: Page,
+  options: { direction: CopyDirection; mode: CopySizeMode; scheme: CopyColorScheme },
+) {
+  const result = await transformMarkdown(
+    COPY_SIZE_MARKDOWN,
+    "docs/vrt-copy-sizing.md",
+    createDocsResolvedOptions({
+      highlight: true,
+      codeAnnotations: {
+        enabled: true,
+        notation: "vitepress",
+        metaKey: "annotate",
+        defaultLineNumbers: false,
+      },
+    }),
+  );
+  const html = await generateHtmlPage(
+    {
+      title: "Copy Sizing",
+      content: result.html,
+      toc: result.toc,
+      frontmatter: {},
+      path: "/vrt-copy-sizing",
+      href: "/vrt-copy-sizing/index.html",
+    },
+    [],
+    "Ox Content",
+    "/",
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    false,
+    { copy: true, externalLinks: false, backToTop: false },
+  );
+
+  await page.setContent(html, { waitUntil: "load" });
+  await page.evaluate(({ direction, scheme }) => {
+    document.documentElement.setAttribute("dir", direction);
+    document.documentElement.setAttribute("data-theme", scheme);
+    document.querySelector(".content")?.classList.add("copy-sizing-fixture");
+  }, options);
+  await page.addStyleTag({
+    content: `
+      .copy-sizing-fixture {
+        max-width: 420px;
+        margin: 0 auto;
+        font-size: 16px;
+      }
+      .copy-sizing-fixture pre {
+        font-size: 16px;
+      }
+      .copy-sizing-fixture.copy-sizing-fixture--custom {
+        --ox-copy-control-size: 2.5rem;
+        --ox-copy-icon-size: 1rem;
+        --ox-copy-inset: 0.75rem;
+      }
+    `,
+  });
+  if (options.mode === "custom") {
+    await page.locator(".content").evaluate((content) => {
+      content.classList.add("copy-sizing-fixture--custom");
+    });
+  }
+}
+
+async function readCopyMetrics(page: Page) {
+  return page
+    .locator(".ox-code")
+    .first()
+    .evaluate((code) => {
+      if (!(code instanceof HTMLElement)) throw new Error("Missing code wrapper");
+      const button = code.querySelector(".ox-copy");
+      const pre = code.querySelector("pre");
+      const firstLine = code.querySelector(".line");
+      if (!(button instanceof HTMLElement)) throw new Error("Missing copy button");
+      if (!(pre instanceof HTMLElement)) throw new Error("Missing code block");
+      if (!(firstLine instanceof HTMLElement)) throw new Error("Missing code line");
+
+      const px = (style: CSSStyleDeclaration, property: string) =>
+        Number.parseFloat(style.getPropertyValue(property)) || 0;
+      const wrapperRect = code.getBoundingClientRect();
+      const buttonRect = button.getBoundingClientRect();
+      const preStyle = getComputedStyle(pre);
+      const titleStyle = getComputedStyle(pre, "::before");
+      const iconStyle = getComputedStyle(button, "::before");
+      const lineNumberStyle = getComputedStyle(firstLine, "::before");
+      const isRtl = getComputedStyle(code).direction === "rtl";
+
+      return {
+        controlHeight: buttonRect.height,
+        controlWidth: buttonRect.width,
+        iconHeight: px(iconStyle, "height"),
+        iconWidth: px(iconStyle, "width"),
+        insetBlockStart: buttonRect.top - wrapperRect.top,
+        insetInlineEnd: isRtl
+          ? buttonRect.left - wrapperRect.left
+          : wrapperRect.right - buttonRect.right,
+        lineNumberWidth: px(lineNumberStyle, "width"),
+        preClientWidth: pre.clientWidth,
+        prePaddingInlineEnd: px(preStyle, "padding-inline-end"),
+        preScrollWidth: pre.scrollWidth,
+        titleMarginInlineEnd: px(titleStyle, "margin-inline-end"),
+        titlePaddingInlineEnd: px(titleStyle, "padding-inline-end"),
+      };
+    });
+}
+
+function expectCopyMetrics(
+  metrics: Awaited<ReturnType<typeof readCopyMetrics>>,
+  expected: (typeof COPY_SIZE_EXPECTATIONS)[CopySizeMode],
+) {
+  expectClose(metrics.controlWidth, expected.control);
+  expectClose(metrics.controlHeight, expected.control);
+  expectClose(metrics.iconWidth, expected.icon);
+  expectClose(metrics.iconHeight, expected.icon);
+  expectClose(metrics.insetBlockStart, expected.inset);
+  expectClose(metrics.insetInlineEnd, expected.inset);
+}
+
+function expectSameCopyLayout(
+  before: Awaited<ReturnType<typeof readCopyMetrics>>,
+  after: Awaited<ReturnType<typeof readCopyMetrics>>,
+) {
+  expectClose(after.controlWidth, before.controlWidth);
+  expectClose(after.controlHeight, before.controlHeight);
+  expectClose(after.iconWidth, before.iconWidth);
+  expectClose(after.iconHeight, before.iconHeight);
+  expectClose(after.insetBlockStart, before.insetBlockStart);
+  expectClose(after.insetInlineEnd, before.insetInlineEnd);
+  expectClose(after.prePaddingInlineEnd, before.prePaddingInlineEnd);
+  expectClose(after.titlePaddingInlineEnd, before.titlePaddingInlineEnd);
+  expect(after.preScrollWidth).toBeLessThanOrEqual(after.preClientWidth + 1);
+}
+
+function expectClose(value: number, expected: number) {
+  expect(Math.abs(value - expected)).toBeLessThanOrEqual(0.75);
+}


### PR DESCRIPTION
## Summary

- expose stable reader-chrome copy sizing tokens for the control, glyph, and inset while preserving the compact defaults
- make code title/gutter reservation follow the public sizing tokens
- document the built-in SSG/custom-host token contract and credit @ryoppippi
- cover light/dark, desktop/touch, RTL, hover/focus/copied/failed layout stability, and custom-host public-token usage

## Downstream check

- checked ryoppippi/ryoppippi.com#2112: the migration imports @ox-content/vite-plugin/styles/reader-chrome.css, and the relevant CSS/render files do not contain internal .ox-copy overrides

## Validation

- vp exec --filter @ox-content/vite-plugin -- playwright test test/vrt/copy-button.spec.ts test/vrt/copy-button-sizing.spec.ts
- cargo test -p ox_content_ssg code_copy_sizing_tokens_drive_the_control_and_gutter
- vp fmt crates/ox_content_ssg/src/html/reader_chrome.css docs/content/built-in/reader-chrome.md docs/content/ja/built-in/reader-chrome.md docs/content/credits.md docs/content/ja/credits.md npm/vite-plugin-ox-content/test/vrt/copy-button-sizing.spec.ts --check
- node scripts/check-file-lines.ts --base origin/main
- vp run check:ts (0 errors, existing 19 warnings)
- cargo fmt --all -- --check
- git diff --check
- vp run --filter @ox-content/vite-plugin build
- vp run build:npm
- node scripts/package-dry-run.mjs

Fixes #1177

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790535500&installation_model_id=422833&pr_number=1180&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1180&signature=b24b3e5049654ba6525612db6a0efd58e8e81215df40dea3fae72360555766b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable CSS tokens for reader-chrome copy-button size, icon size, and inset.
  * Copy-button spacing, code-title alignment, and gutter reservation now adapt to custom sizing.
* **Documentation**
  * Added English and Japanese guidance for configuring copy-button sizing tokens.
  * Updated community contribution credits.
* **Tests**
  * Added coverage for custom sizing across themes, layouts, directions, and button states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->