### PR TITLE
fix(highlight): preserve Nix-specific captures

### DIFF
--- a/crates/ox_content_highlight/queries/nix-highlights.scm
+++ b/crates/ox_content_highlight/queries/nix-highlights.scm
@@ -1,0 +1,102 @@
+; Source: tree-sitter-nix 0.3.0 queries/highlights.scm, adjusted so
+; specific captures remain after generic identifiers for this renderer.
+
+(comment) @comment
+
+[
+  "if"
+  "then"
+  "else"
+  "let"
+  "inherit"
+  "in"
+  "rec"
+  "with"
+  "assert"
+  "or"
+] @keyword
+
+(variable_expression (identifier) @variable)
+
+((identifier) @constant.builtin
+ (#match? @constant.builtin "^(false|null|true)$")
+ (#is-not? local))
+
+((identifier) @constant.builtin
+ (#match? @constant.builtin "^(__currentSystem|__currentTime|__langVersion|__nixPath|__nixVersion|__storeDir|builtins)$")
+ (#is-not? local))
+
+((identifier) @function.builtin
+ (#match? @function.builtin "^(__add|__addErrorContext|__all|__any|__appendContext|__attrNames|__attrValues|__bitAnd|__bitOr|__bitXor|__catAttrs|__ceil|__compareVersions|__concatLists|__concatMap|__concatStringsSep|__deepSeq|__div|__elem|__elemAt|__fetchurl|__filter|__filterSource|__findFile|__flakeRefToString|__floor|__foldl'|__fromJSON|__functionArgs|__genList|__genericClosure|__getAttr|__getContext|__getEnv|__getFlake|__groupBy|__hasAttr|__hasContext|__hashFile|__hashString|__head|__intersectAttrs|__isAttrs|__isBool|__isFloat|__isFunction|__isInt|__isList|__isPath|__isString|__length|__lessThan|__listToAttrs|__mapAttrs|__match|__mul|__parseDrvName|__parseFlakeRef|__partition|__path|__pathExists|__readDir|__readFile|__readFileType|__replaceStrings|__seq|__sort|__split|__splitVersion|__storePath|__stringLength|__sub|__substring|__tail|__toFile|__toJSON|__toPath|__toXML|__trace|__traceVerbose|__tryEval|__typeOf|__unsafeDiscardOutputDependency|__unsafeDiscardStringContext|__unsafeGetAttrPos|__zipAttrsWith|abort|baseNameOf|break|derivation|derivationStrict|dirOf|fetchGit|fetchMercurial|fetchTarball|fetchTree|fromTOML|import|isNull|map|placeholder|removeAttrs|scopedImport|throw|toString)$")
+ (#is-not? local))
+
+[
+  (integer_expression)
+  (float_expression)
+] @number
+
+(escape_sequence) @string.escape
+(dollar_escape) @string.escape
+
+(function_expression
+  universal: (identifier) @variable.parameter)
+
+(formal
+  name: (identifier) @variable.parameter
+  "?"? @punctuation.delimiter)
+
+(apply_expression
+  function: [
+    (variable_expression (identifier)) @function
+    (select_expression
+      attrpath: (attrpath
+        attr: (identifier) @function .))])
+
+(unary_expression
+  operator: _ @operator)
+
+(binary_expression
+  operator: _ @operator)
+
+(select_expression
+  attrpath: (attrpath (identifier)) @property)
+
+(binding
+  attrpath: (attrpath (identifier)) @property)
+
+(inherit_from
+  attrs: (inherited_attrs attr: (identifier) @property))
+
+[
+  ";"
+  "."
+  ","
+  "="
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  (string_expression)
+  (indented_string_expression)
+] @string
+
+[
+  (path_expression)
+  (hpath_expression)
+  (spath_expression)
+] @string.special
+
+(uri_expression) @text.uri
+
+(interpolation
+  "${" @punctuation.special
+  (_) @embedded
+  "}" @punctuation.special)

--- a/crates/ox_content_highlight/src/languages/extra.rs
+++ b/crates/ox_content_highlight/src/languages/extra.rs
@@ -56,7 +56,7 @@ pub(super) fn grammars() -> &'static [Grammar] {
             "nix",
             ["nix"],
             tree_sitter_nix::LANGUAGE,
-            tree_sitter_nix::HIGHLIGHTS_QUERY,
+            include_str!("../../queries/nix-highlights.scm"),
             tree_sitter_nix::INJECTIONS_QUERY,
             "",
         ),

--- a/crates/ox_content_highlight/src/tests.rs
+++ b/crates/ox_content_highlight/src/tests.rs
@@ -1,6 +1,20 @@
 use super::*;
 use crate::test_support::visible_text;
 
+fn assert_text_has_capture_token(html: &str, text: &str, capture: &str) {
+    let token = crate::theme::token_for(capture).expect(capture);
+    let mut style = String::new();
+    crate::theme::push_color(&mut style, token);
+    let escaped = text
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;");
+    let needle = format!("<span style=\"{style}\">{escaped}</span>");
+    assert!(html.contains(&needle), "missing {capture} token for {text:?}\n{html}");
+}
+
 #[test]
 fn unknown_language_is_left_to_the_caller() {
     assert!(highlight_to_html("hello", "brainfuck").is_none());
@@ -208,6 +222,58 @@ fn added_grammars_tokenize_and_escape() {
         }
         assert!(!html.contains("a < b"), "lang={lang} html={html}");
     }
+}
+
+#[test]
+fn nix_keeps_specific_captures_over_generic_identifiers() {
+    let code = r#"{
+  programs.nix-secure-enclave-key = {
+    enable = true;
+    identities.git-signing = {
+      keyFile = "~/.ssh/id_enclave_key";
+      source = import ./module.nix;
+    };
+  };
+}
+"#;
+
+    let html = highlight_to_html(code, "nix").expect("nix is supported");
+    assert_eq!(visible_text(&html), code);
+    assert_text_has_capture_token(&html, "programs", "property");
+    assert_text_has_capture_token(&html, "nix-secure-enclave-key", "property");
+    assert_text_has_capture_token(&html, "enable", "property");
+    assert_text_has_capture_token(&html, "identities", "property");
+    assert_text_has_capture_token(&html, "git-signing", "property");
+    assert_text_has_capture_token(&html, "keyFile", "property");
+    assert_text_has_capture_token(&html, "true", "constant.builtin");
+    assert_text_has_capture_token(&html, "import", "function.builtin");
+    assert_text_has_capture_token(&html, "./module.nix", "string.special");
+    assert_text_has_capture_token(&html, "\"~/.ssh/id_enclave_key\"", "string");
+}
+
+#[test]
+fn nix_covers_comments_keywords_parameters_calls_paths_and_interpolation() {
+    let code = r#"let
+  makePath = name: ./packages/${name};
+in with builtins; {
+  url = https://example.com/pkg;
+  names = map (name: makePath name) [ "core" ];
+  # production corpus shape
+}
+"#;
+
+    let html = highlight_to_html(code, "nix").expect("nix is supported");
+    assert_eq!(visible_text(&html), code);
+    assert_text_has_capture_token(&html, "let", "keyword");
+    assert_text_has_capture_token(&html, "in", "keyword");
+    assert_text_has_capture_token(&html, "with", "keyword");
+    assert_text_has_capture_token(&html, "makePath", "property");
+    assert_text_has_capture_token(&html, "name", "variable.parameter");
+    assert_text_has_capture_token(&html, "builtins", "constant.builtin");
+    assert_text_has_capture_token(&html, "map", "function.builtin");
+    assert_text_has_capture_token(&html, "https://example.com/pkg", "text.uri");
+    assert_text_has_capture_token(&html, "# production corpus shape", "comment");
+    assert_text_has_capture_token(&html, "${", "punctuation.special");
 }
 
 #[test]

--- a/docs/content/built-in/code-blocks.md
+++ b/docs/content/built-in/code-blocks.md
@@ -82,6 +82,15 @@ this tree-sitter line.
 | Scala      | `scala`, `sc`, `sbt`                                               |
 | R          | `r`, `rscript`                                                     |
 
+```nix
+{
+  programs.nix-secure-enclave-key = {
+    enable = true;
+    identities.git-signing.keyFile = "~/.ssh/id_enclave_key";
+  };
+}
+```
+
 Unknown tags stay ordinary `<pre><code>` — for example `perl`, `elm`,
 `assembly`, `asm`, `llvm`, `clojure`, and `brainfuck`. Do not alias those onto
 an unrelated grammar. Plain tags such as


### PR DESCRIPTION
## Summary
- vendor the Nix highlight query so specific captures are not overwritten by generic identifiers
- keep Nix attributes, built-in constants, function calls, paths, strings, keywords, comments, and interpolation delimiters covered by regression tests
- add a representative Nix sample to the supported-language docs

Fixes #1182

## Verification
- cargo test -p ox_content_highlight -- --nocapture
- cargo fmt --all -- --check
- vp fmt docs/content/built-in/code-blocks.md --check
- node scripts/check-file-lines.ts --base origin/main
- git diff --cached --check

## Notes
- `vp run build:docs` was attempted locally after `vp install --frozen-lockfile --prefer-offline`, but the local macOS linker stopped with `errno=28` because the volume had about 198MiB free. GitHub Actions should be the docs/build authority for this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790560110&installation_model_id=422833&pr_number=1185&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1185&signature=995763557bbf912930cadc3e16d50b5b0a462b6eee00123a33f4c1789059b87e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added syntax highlighting support for Nix code blocks, including keywords, functions, strings, comments, operators, paths, and interpolations.
  * Improved recognition of Nix properties and built-in values.

* **Documentation**
  * Added a Nix example to the supported code block languages documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->