### PR TITLE
feat(highlight): add CMake grammar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,6 +1415,7 @@ dependencies = [
  "tree-sitter-bash",
  "tree-sitter-c",
  "tree-sitter-c-sharp",
+ "tree-sitter-cmake",
  "tree-sitter-containerfile",
  "tree-sitter-cpp",
  "tree-sitter-css",
@@ -2941,6 +2942,16 @@ name = "tree-sitter-c-sharp"
 version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-cmake"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164e0c4f4236ec5ceff14824a5528615cf462e100467e49826442ff57d327061"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/ox_content_highlight/Cargo.toml
+++ b/crates/ox_content_highlight/Cargo.toml
@@ -42,6 +42,7 @@ tree-sitter-ruby = "0.23"
 tree-sitter-php = "0.24"
 tree-sitter-nix = "0.3"
 tree-sitter-nu = { git = "https://github.com/nushell/tree-sitter-nu", rev = "64613ef22f4116862d7997939c8d1794ceb1f856" }
+tree-sitter-cmake = "0.7"
 tree-sitter-c-sharp = "0.23"
 tree-sitter-swift = "0.7"
 tree-sitter-kotlin-ng = "1.1"

--- a/crates/ox_content_highlight/queries/cmake-highlights.scm
+++ b/crates/ox_content_highlight/queries/cmake-highlights.scm
@@ -1,0 +1,86 @@
+; Source: tree-sitter-cmake 0.7.4 queries/highlights.scm, reduced and
+; normalized to Ox Content's supported capture names.
+
+[
+  (quoted_argument)
+  (bracket_argument)
+] @string
+
+(escape_sequence) @string.escape
+
+[
+  (bracket_comment)
+  (line_comment)
+] @comment
+
+(variable_ref) @variable.parameter
+(variable) @variable.parameter
+
+(normal_command
+  (identifier) @function)
+
+(normal_command
+  (identifier) @function.builtin
+  (#match? @function.builtin "^(cmake_minimum_required|project|add_executable|add_library|target_compile_definitions|target_include_directories|target_link_libraries|set|unset|list|message|find_package|include)$"))
+
+[
+  "ENV"
+  "CACHE"
+] @module
+
+[
+  "$"
+  "{"
+  "}"
+] @punctuation.special
+
+[
+  "("
+  ")"
+] @punctuation.bracket
+
+[
+  (function)
+  (endfunction)
+  (macro)
+  (endmacro)
+  (if)
+  (elseif)
+  (else)
+  (endif)
+  (foreach)
+  (endforeach)
+  (while)
+  (endwhile)
+] @keyword
+
+(normal_command
+  (identifier) @keyword
+  (#match? @keyword "^(continue|break|return)$"))
+
+((argument) @constant.builtin
+  (#match? @constant.builtin "^(1|ON|YES|TRUE|Y|0|OFF|NO|FALSE|N|IGNORE|NOTFOUND|.*-NOTFOUND)$"))
+
+(if_command
+  (if)
+  (argument_list
+    (argument) @operator)
+  (#any-of? @operator
+    "NOT" "AND" "OR" "COMMAND" "POLICY" "TARGET" "TEST" "DEFINED" "IN_LIST" "EXISTS" "IS_NEWER_THAN"
+    "IS_DIRECTORY" "IS_SYMLINK" "IS_ABSOLUTE" "MATCHES" "LESS" "GREATER" "EQUAL" "LESS_EQUAL"
+    "GREATER_EQUAL" "STRLESS" "STRGREATER" "STREQUAL" "STRLESS_EQUAL" "STRGREATER_EQUAL"
+    "VERSION_LESS" "VERSION_GREATER" "VERSION_EQUAL" "VERSION_LESS_EQUAL" "VERSION_GREATER_EQUAL"))
+
+(function_command
+  (function)
+  (argument_list
+    .
+    (argument) @function
+    (argument)* @variable.parameter))
+
+(macro_command
+  (macro)
+  (argument_list
+    .
+    (argument) @function
+    (argument)* @variable.parameter))

--- a/crates/ox_content_highlight/src/language_tests.rs
+++ b/crates/ox_content_highlight/src/language_tests.rs
@@ -23,3 +23,34 @@ end
     assert!(html.contains("&lt;"), "{html}");
     assert!(html.contains("&amp;"), "{html}");
 }
+
+#[test]
+fn cmake_highlights_commands_variables_generator_expressions_and_comments() {
+    let code = r#"cmake_minimum_required(VERSION 3.28)
+project(App)
+set(SOURCES "main < &.cpp")
+add_executable(app ${SOURCES})
+target_compile_definitions(app PRIVATE "$<$<CONFIG:Debug>:DEBUG_BUILD>")
+if(DEFINED SOURCES)
+  message(STATUS "configured")
+endif()
+# production corpus shape
+"#;
+
+    let html = highlight_to_html(code, "cmake").expect("cmake is supported");
+    assert_eq!(visible_text(&html), code);
+    assert_text_has_capture_token(&html, "cmake_minimum_required", "function.builtin");
+    assert_text_has_capture_token(&html, "project", "function.builtin");
+    assert_text_has_capture_token(&html, "set", "function.builtin");
+    assert_text_has_capture_token(&html, "add_executable", "function.builtin");
+    assert_text_has_capture_token(&html, "SOURCES", "variable.parameter");
+    assert_text_has_capture_token(&html, "\"main < &.cpp\"", "string");
+    assert_text_has_capture_token(&html, "$", "punctuation.special");
+    assert_text_has_capture_token(&html, "<CONFIG:Debug>:DEBUG_BUILD>\"", "string");
+    assert_text_has_capture_token(&html, "if", "keyword");
+    assert_text_has_capture_token(&html, "DEFINED", "operator");
+    assert_text_has_capture_token(&html, "endif", "keyword");
+    assert_text_has_capture_token(&html, "# production corpus shape", "comment");
+    assert!(html.contains("&lt;"), "{html}");
+    assert!(html.contains("&amp;"), "{html}");
+}

--- a/crates/ox_content_highlight/src/languages/markup.rs
+++ b/crates/ox_content_highlight/src/languages/markup.rs
@@ -112,5 +112,13 @@ pub(super) fn grammars() -> &'static [Grammar] {
             "",
             "",
         ),
+        grammar!(
+            "cmake",
+            ["cmake"],
+            tree_sitter_cmake::LANGUAGE,
+            include_str!("../../queries/cmake-highlights.scm"),
+            tree_sitter_cmake::INJECTIONS_QUERY,
+            "",
+        ),
     ]
 }

--- a/crates/ox_content_highlight/src/tests.rs
+++ b/crates/ox_content_highlight/src/tests.rs
@@ -62,6 +62,7 @@ fn aliases_resolve_to_the_same_grammar() {
     for alias in ["makefile", "make", "mk"] {
         assert!(supports(alias), "{alias} should be supported");
     }
+    assert!(supports("cmake"));
     for alias in ["powershell", "pwsh", "ps1"] {
         assert!(supports(alias), "{alias} should be supported");
     }
@@ -201,6 +202,7 @@ fn added_grammars_tokenize_and_escape() {
         ("local s = \"a < b & c\"\n", "lua"),
         ("variable \"x\" {\n  default = \"a < b & c\"\n}\n", "terraform"),
         ("# a < b & c\nall:\n\techo hi\n", "makefile"),
+        ("set(NAME \"a < b & c\")\n", "cmake"),
         ("Write-Host \"a < b & c\"\n", "powershell"),
         ("-- a < b & c\nmain = putStrLn \"hi\"\n", "haskell"),
         ("# a < b & c\ndefmodule M do\nend\n", "elixir"),

--- a/docs/content/built-in/code-blocks.md
+++ b/docs/content/built-in/code-blocks.md
@@ -76,6 +76,7 @@ this tree-sitter line.
 | Lua        | `lua`                                                              |
 | HCL        | `hcl`, `terraform`, `tf`, `tfvars`                                 |
 | Make       | `make`, `makefile`, `mk`                                           |
+| CMake      | `cmake`                                                            |
 | Diff       | `diff`, `patch`, `udiff`                                           |
 | PowerShell | `powershell`, `pwsh`, `ps1`, `psm1`                                |
 | Zig        | `zig`, `zon`                                                       |
@@ -105,6 +106,12 @@ function fish_prompt
   set -l branch (git branch --show-current)
   echo "$branch" | string upper
 end
+```
+
+```cmake
+cmake_minimum_required(VERSION 3.28)
+project(App)
+add_executable(app main.cpp)
 ```
 
 Unknown tags stay ordinary `<pre><code>` — for example `perl`, `elm`,

--- a/docs/content/ja/built-in/code-blocks.md
+++ b/docs/content/ja/built-in/code-blocks.md
@@ -75,6 +75,7 @@ tree-sitter 系列と合うメンテされた専用文法がまだありませ�
 | Lua        | `lua`                                                              |
 | HCL        | `hcl`, `terraform`, `tf`, `tfvars`                                 |
 | Make       | `make`, `makefile`, `mk`                                           |
+| CMake      | `cmake`                                                            |
 | Diff       | `diff`, `patch`, `udiff`                                           |
 | PowerShell | `powershell`, `pwsh`, `ps1`, `psm1`                                |
 | Zig        | `zig`, `zon`                                                       |
@@ -95,6 +96,12 @@ function fish_prompt
   set -l branch (git branch --show-current)
   echo "$branch" | string upper
 end
+```
+
+```cmake
+cmake_minimum_required(VERSION 3.28)
+project(App)
+add_executable(app main.cpp)
 ```
 
 未知のタグは普通の `<pre><code>` のままです。例: `perl`、`elm`、


### PR DESCRIPTION
## Summary
- add the CMake tree-sitter grammar and normalized highlight query
- cover built-in commands, variables, generator-expression punctuation, operators, strings, and comments
- document the `cmake` language alias in English and Japanese docs

## Dependency Record
- crate: `tree-sitter-cmake` 0.7.4
- repository: https://github.com/uyha/tree-sitter-cmake
- license: MIT
- ABI: `tree_sitter_language::LanguageFn`
- query: normalized from the published grammar query because the upstream query uses unsupported predicates/capture suffixes for this renderer
- size: adds one parser crate; generated parser sources remain in the crates.io package

## Verification
- `cargo test -p ox_content_highlight -- --nocapture`
- `cargo deny check licenses`
- `cargo audit --deny warnings`
- `cargo fmt --all -- --check`
- `vp fmt docs/content/built-in/code-blocks.md docs/content/ja/built-in/code-blocks.md --check`
- `node scripts/check-file-lines.ts --base feat/highlight-fish`
- `git diff --cached --check`

Refs #1184

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790561532&installation_model_id=422833&pr_number=1188&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1188&signature=2e7a0176dae4dd9b005aceec58efbacdff9802f78716a5f32bb41a8f4167e9bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->