### PR TITLE
feat(highlight): add Vimscript grammar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,6 +1450,7 @@ dependencies = [
  "tree-sitter-swift",
  "tree-sitter-toml-ng",
  "tree-sitter-typescript",
+ "tree-sitter-vim",
  "tree-sitter-wgsl-bevy",
  "tree-sitter-xml",
  "tree-sitter-yaml",
@@ -3302,6 +3303,16 @@ checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
 dependencies = [
  "cc",
  "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-vim"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45b6a26a808d8209e0b9514f5ffe0ea01d9fc8dcb33c01ff71f5979164811d6e"
+dependencies = [
+ "cc",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/crates/ox_content_highlight/Cargo.toml
+++ b/crates/ox_content_highlight/Cargo.toml
@@ -43,6 +43,7 @@ tree-sitter-php = "0.24"
 tree-sitter-nix = "0.3"
 tree-sitter-nu = { git = "https://github.com/nushell/tree-sitter-nu", rev = "64613ef22f4116862d7997939c8d1794ceb1f856" }
 tree-sitter-cmake = "0.7"
+tree-sitter-vim = "0.4"
 tree-sitter-c-sharp = "0.23"
 tree-sitter-swift = "0.7"
 tree-sitter-kotlin-ng = "1.1"

--- a/crates/ox_content_highlight/queries/vim-highlights.scm
+++ b/crates/ox_content_highlight/queries/vim-highlights.scm
@@ -1,0 +1,243 @@
+(identifier) @variable
+
+((identifier) @constant
+  (#match? @constant "^[A-Z][A-Z_0-9]*$"))
+
+[
+  "if"
+  "else"
+  "elseif"
+  "endif"
+  "try"
+  "catch"
+  "finally"
+  "endtry"
+  "throw"
+  "for"
+  "endfor"
+  "in"
+  "while"
+  "endwhile"
+  "break"
+  "continue"
+  "function"
+  "endfunction"
+] @keyword
+
+(function_declaration
+  name: (_) @function)
+
+(function_declaration
+  name:
+    (scoped_identifier
+      (identifier) @function))
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function:
+    (scoped_identifier
+      (identifier) @function))
+
+(parameters
+  (identifier) @variable.parameter)
+
+(default_parameter
+  (identifier) @variable.parameter)
+
+[
+  (bang)
+  (spread)
+] @punctuation.special
+
+[
+  (no_option)
+  (inv_option)
+  (default_option)
+  (option_name)
+] @constant.builtin
+
+[
+  (scope)
+  "a:"
+  "$"
+] @module
+
+[
+  "let"
+  "unlet"
+  "const"
+  "call"
+  "execute"
+  "normal"
+  "set"
+  "setfiletype"
+  "setlocal"
+  "silent"
+  "echo"
+  "echon"
+  "echohl"
+  "echomsg"
+  "echoerr"
+  "autocmd"
+  "augroup"
+  "return"
+  "syntax"
+  "filetype"
+  "source"
+  "lua"
+  "ruby"
+  "perl"
+  "python"
+  "highlight"
+  "command"
+  "delcommand"
+  "comclear"
+  "colorscheme"
+  "scriptencoding"
+  "startinsert"
+  "stopinsert"
+  "global"
+  "runtime"
+  "wincmd"
+  "cnext"
+  "cprevious"
+  "cNext"
+  "vertical"
+  "leftabove"
+  "aboveleft"
+  "rightbelow"
+  "belowright"
+  "topleft"
+  "botright"
+  (unknown_command_name)
+  "edit"
+  "enew"
+  "find"
+  "ex"
+  "visual"
+  "view"
+  "eval"
+  "sign"
+] @keyword
+
+(map_statement
+  cmd: _ @keyword)
+
+(keycode) @constant.builtin
+
+(command_name) @function.builtin
+
+(filetype_statement
+  [
+    "detect"
+    "plugin"
+    "indent"
+    "on"
+    "off"
+  ] @keyword)
+
+(syntax_statement
+  (keyword) @string)
+
+(syntax_statement
+  [
+    "enable"
+    "on"
+    "off"
+    "reset"
+    "case"
+    "spell"
+    "foldlevel"
+    "iskeyword"
+    "keyword"
+    "match"
+    "cluster"
+    "region"
+    "clear"
+    "include"
+  ] @keyword)
+
+(syntax_argument
+  name: _ @keyword)
+
+[
+  "<buffer>"
+  "<nowait>"
+  "<silent>"
+  "<script>"
+  "<expr>"
+  "<unique>"
+] @constant.builtin
+
+(augroup_name) @module
+
+(au_event) @constant
+
+(normal_statement
+  (commands) @constant)
+
+(hl_attribute
+  key: _ @property
+  val: _ @constant)
+
+(hl_group) @type
+
+(highlight_statement
+  [
+    "default"
+    "link"
+    "clear"
+  ] @keyword)
+
+(command) @string
+
+(command_attribute
+  name: _ @property)
+
+(command_attribute
+  val: (behavior
+         _ @constant))
+
+(plus_plus_opt
+  val: _? @constant) @property
+
+(plus_cmd
+  "+" @property) @property
+
+(runtime_statement
+  (where) @operator)
+
+(colorscheme_statement
+  (name) @string)
+
+(scriptencoding_statement
+  (encoding) @string.special)
+
+(string_literal) @string
+
+(integer_literal) @number
+
+(float_literal) @number
+
+(comment) @comment
+
+(line_continuation_comment) @comment
+
+(pattern) @string.special
+
+(pattern_multi) @string.special
+
+(filename) @string.special
+
+(heredoc
+  (body) @string)
+
+(heredoc
+  (parameter) @keyword)
+
+[
+  (marker_definition)
+  (endmarker)
+] @label

--- a/crates/ox_content_highlight/src/language_tests.rs
+++ b/crates/ox_content_highlight/src/language_tests.rs
@@ -54,3 +54,33 @@ endif()
     assert!(html.contains("&lt;"), "{html}");
     assert!(html.contains("&amp;"), "{html}");
 }
+
+#[test]
+fn vimscript_highlights_functions_commands_ranges_strings_and_comments() {
+    let code = r#"function! s:Run(cmd) abort
+  let l:output = execute(a:cmd)
+  1,3s/foo/bar/g
+  lua print("hi")
+  echo "done < &"
+  " production corpus shape
+endfunction
+"#;
+
+    let html = highlight_to_html(code, "vimscript").expect("vimscript is supported");
+    assert_eq!(visible_text(&html), code);
+    assert_text_has_capture_token(&html, "function", "keyword");
+    assert_text_has_capture_token(&html, "Run", "function");
+    assert_text_has_capture_token(&html, "cmd", "variable.parameter");
+    assert_text_has_capture_token(&html, "let", "keyword");
+    assert_text_has_capture_token(&html, "l:", "module");
+    assert_text_has_capture_token(&html, "execute", "function");
+    assert_text_has_capture_token(&html, "1", "number");
+    assert_text_has_capture_token(&html, "foo/bar/g", "keyword");
+    assert_text_has_capture_token(&html, "lua", "keyword");
+    assert_text_has_capture_token(&html, "echo", "keyword");
+    assert_text_has_capture_token(&html, "\"done < &\"", "string");
+    assert_text_has_capture_token(&html, "\" production corpus shape", "comment");
+    assert_text_has_capture_token(&html, "endfunction", "keyword");
+    assert!(html.contains("&lt;"), "{html}");
+    assert!(html.contains("&amp;"), "{html}");
+}

--- a/crates/ox_content_highlight/src/languages/markup.rs
+++ b/crates/ox_content_highlight/src/languages/markup.rs
@@ -120,5 +120,13 @@ pub(super) fn grammars() -> &'static [Grammar] {
             tree_sitter_cmake::INJECTIONS_QUERY,
             "",
         ),
+        grammar!(
+            "vimscript",
+            ["vimscript", "vim"],
+            tree_sitter_vim::language(),
+            include_str!("../../queries/vim-highlights.scm"),
+            tree_sitter_vim::INJECTIONS_QUERY,
+            "",
+        ),
     ]
 }

--- a/crates/ox_content_highlight/src/tests.rs
+++ b/crates/ox_content_highlight/src/tests.rs
@@ -63,6 +63,9 @@ fn aliases_resolve_to_the_same_grammar() {
         assert!(supports(alias), "{alias} should be supported");
     }
     assert!(supports("cmake"));
+    for alias in ["vimscript", "vim"] {
+        assert!(supports(alias), "{alias} should be supported");
+    }
     for alias in ["powershell", "pwsh", "ps1"] {
         assert!(supports(alias), "{alias} should be supported");
     }
@@ -90,6 +93,10 @@ fn aliases_resolve_to_the_same_grammar() {
     assert_eq!(
         highlight_to_html("let x = true\n", "nu"),
         highlight_to_html("let x = true\n", "nushell")
+    );
+    assert_eq!(
+        highlight_to_html("echo \"hi\"\n", "vim"),
+        highlight_to_html("echo \"hi\"\n", "vimscript")
     );
 }
 
@@ -203,6 +210,7 @@ fn added_grammars_tokenize_and_escape() {
         ("variable \"x\" {\n  default = \"a < b & c\"\n}\n", "terraform"),
         ("# a < b & c\nall:\n\techo hi\n", "makefile"),
         ("set(NAME \"a < b & c\")\n", "cmake"),
+        ("echo \"a < b & c\"\n", "vimscript"),
         ("Write-Host \"a < b & c\"\n", "powershell"),
         ("-- a < b & c\nmain = putStrLn \"hi\"\n", "haskell"),
         ("# a < b & c\ndefmodule M do\nend\n", "elixir"),

--- a/docs/content/built-in/code-blocks.md
+++ b/docs/content/built-in/code-blocks.md
@@ -77,6 +77,7 @@ this tree-sitter line.
 | HCL        | `hcl`, `terraform`, `tf`, `tfvars`                                 |
 | Make       | `make`, `makefile`, `mk`                                           |
 | CMake      | `cmake`                                                            |
+| Vimscript  | `vimscript`, `vim`                                                 |
 | Diff       | `diff`, `patch`, `udiff`                                           |
 | PowerShell | `powershell`, `pwsh`, `ps1`, `psm1`                                |
 | Zig        | `zig`, `zon`                                                       |
@@ -112,6 +113,13 @@ end
 cmake_minimum_required(VERSION 3.28)
 project(App)
 add_executable(app main.cpp)
+```
+
+```vimscript
+function! s:Run(cmd) abort
+  let l:output = execute(a:cmd)
+  echo "done"
+endfunction
 ```
 
 Unknown tags stay ordinary `<pre><code>` — for example `perl`, `elm`,

--- a/docs/content/ja/built-in/code-blocks.md
+++ b/docs/content/ja/built-in/code-blocks.md
@@ -76,6 +76,7 @@ tree-sitter 系列と合うメンテされた専用文法がまだありませ�
 | HCL        | `hcl`, `terraform`, `tf`, `tfvars`                                 |
 | Make       | `make`, `makefile`, `mk`                                           |
 | CMake      | `cmake`                                                            |
+| Vimscript  | `vimscript`, `vim`                                                 |
 | Diff       | `diff`, `patch`, `udiff`                                           |
 | PowerShell | `powershell`, `pwsh`, `ps1`, `psm1`                                |
 | Zig        | `zig`, `zon`                                                       |
@@ -102,6 +103,13 @@ end
 cmake_minimum_required(VERSION 3.28)
 project(App)
 add_executable(app main.cpp)
+```
+
+```vimscript
+function! s:Run(cmd) abort
+  let l:output = execute(a:cmd)
+  echo "done"
+endfunction
 ```
 
 未知のタグは普通の `<pre><code>` のままです。例: `perl`、`elm`、


### PR DESCRIPTION
## Summary
- add the Vimscript tree-sitter grammar with `vimscript` and `vim` aliases
- normalize the upstream Vim query captures onto the renderer's supported semantic tokens
- cover function declarations, command calls, ranges, strings, embedded Lua snippets, and comments
- document the supported aliases in English and Japanese docs

## Dependency Record
- crate: `tree-sitter-vim` 0.4.0
- repository: https://github.com/tree-sitter-grammars/tree-sitter-vim
- license: MIT
- ABI: `tree_sitter::Language` via `language()`, matching the existing Fish grammar integration style
- query: normalized from the published Vim query to avoid unsupported capture suffixes such as `function.call` and `keyword.conditional`
- size: adds one parser crate; generated parser sources remain in the crates.io package

## Verification
- `cargo test -p ox_content_highlight vimscript_highlights_functions_commands_ranges_strings_and_comments -- --nocapture`
- `cargo test -p ox_content_highlight -- --nocapture`
- `cargo deny check licenses`
- `cargo audit --deny warnings`
- `cargo fmt --all -- --check`
- `vp fmt docs/content/built-in/code-blocks.md docs/content/ja/built-in/code-blocks.md --check`
- `node scripts/check-file-lines.ts --base origin/feat/highlight-nushell`
- `git diff --cached --check`

Fixes #1184

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790561848&installation_model_id=422833&pr_number=1189&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1189&signature=6693869de06e93fd0204e12029e445df48baefdb62355eab37bc770b80ea3605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->