### PR TITLE
ci(benchmark): skip runtime for highlight-only lockfile changes

### DIFF
--- a/.github/scripts/detect-pr-benchmark-scope.mjs
+++ b/.github/scripts/detect-pr-benchmark-scope.mjs
@@ -60,16 +60,7 @@ const files = readFileSync(inputPath, "utf8")
   .map((file) => file.trim())
   .filter(Boolean);
 
-const scope = files.reduce(
-  (current, file) => {
-    const fileScope = classifyFile(file);
-    return {
-      runtime: current.runtime || fileScope.runtime,
-      bundle: current.bundle || fileScope.bundle,
-    };
-  },
-  { runtime: false, bundle: false },
-);
+const scope = classifyFiles(files);
 
 console.error(
   `Benchmark scope: runtime=${formatBoolean(scope.runtime)} bundle=${formatBoolean(
@@ -103,6 +94,58 @@ function classifyFile(file) {
   // Unknown paths stay conservative. This keeps new source trees protected
   // until they are deliberately classified.
   return { runtime: true, bundle: true };
+}
+
+/**
+ * @param {string[]} files
+ * @returns {{ runtime: boolean; bundle: boolean }}
+ */
+function classifyFiles(files) {
+  const scope = files.reduce(
+    (current, file) => {
+      const fileScope = classifyFile(file);
+      return {
+        runtime: current.runtime || fileScope.runtime,
+        bundle: current.bundle || fileScope.bundle,
+      };
+    },
+    { runtime: false, bundle: false },
+  );
+
+  if (scope.runtime && isHighlightOnlyCargoLockChange(files)) {
+    return { runtime: false, bundle: scope.bundle };
+  }
+
+  return scope;
+}
+
+/**
+ * Highlight-only changes still need bundle/artifact measurement, but the
+ * Markdown parser runtime benchmark does not become more informative just
+ * because their dependency additions touch Cargo.lock.
+ *
+ * @param {string[]} files
+ * @returns {boolean}
+ */
+function isHighlightOnlyCargoLockChange(files) {
+  return (
+    files.includes("Cargo.lock") &&
+    files.some((file) => file.startsWith("crates/ox_content_highlight/")) &&
+    files.every(isHighlightOnlyBenchmarkFile)
+  );
+}
+
+/**
+ * @param {string} file
+ * @returns {boolean}
+ */
+function isHighlightOnlyBenchmarkFile(file) {
+  return (
+    file === "Cargo.lock" ||
+    file.startsWith("crates/ox_content_highlight/") ||
+    matchesAny(file, TEST_ONLY_PATTERNS) ||
+    matchesAny(file, BENCHMARK_NEUTRAL_PATTERNS)
+  );
 }
 
 /**

--- a/benchmarks/bundle-size/pr-benchmark-scope.test.ts
+++ b/benchmarks/bundle-size/pr-benchmark-scope.test.ts
@@ -21,6 +21,19 @@ describe("detect-pr-benchmark-scope", () => {
     expect(parseOutputs(result.stdout)).toEqual({ runtime: "true", bundle: "true" });
   });
 
+  it("skips runtime benchmark for highlight-only lockfile updates", () => {
+    const result = runScope([
+      "Cargo.lock",
+      "crates/ox_content_highlight/Cargo.toml",
+      "crates/ox_content_highlight/queries/vim-highlights.scm",
+      "crates/ox_content_highlight/src/languages/markup.rs",
+      "docs/content/built-in/code-blocks.md",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ runtime: "false", bundle: "true" });
+  });
+
   it("runs only the bundle gate for theme and UI package edits", () => {
     const result = runScope(["npm/theme/swiss/src/style.css"]);
 


### PR DESCRIPTION
## Summary
- classify highlight-only Cargo.lock changes as bundle-only benchmark work
- keep bundle/artifact checks active for highlight crate changes
- add detector coverage for the grammar-addition shape from the current highlight stack

## Why
Adding highlight grammars touches `Cargo.lock`, which currently forces the Markdown parse/runtime benchmark even when parser and renderer runtime code are unchanged. This keeps the artifact-size guard while avoiding a long base/head runtime benchmark for highlight-only dependency updates.

## Verification
- `vp test benchmarks/bundle-size/pr-benchmark-scope.test.ts`
- `vp fmt .github/scripts/detect-pr-benchmark-scope.mjs benchmarks/bundle-size/pr-benchmark-scope.test.ts --check`
- `node scripts/check-file-lines.ts --base origin/main`
- `git diff --cached --check`

Refs #699

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790563279&installation_model_id=422833&pr_number=1190&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1190&signature=5cdd6348949e84005778983c90823f0509a45a3337db4987ffdda77d94517ad2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->