### PR TITLE
fix(ssg): stop the page flashing during cross-document navigation

### DIFF
--- a/crates/ox_content_ssg/src/html/mpa_navigation.css
+++ b/crates/ox_content_ssg/src/html/mpa_navigation.css
@@ -2,4 +2,52 @@
   @view-transition {
     navigation: auto;
   }
+
+  /* The header, sidebar and mobile footer are identical on both sides of a docs
+     navigation, so leaving them inside the `root` snapshot animates them for no
+     reason. Naming them lifts each into its own group, which the UA leaves
+     alone when the old and new snapshots match. The names are the ones the
+     theme skins already use, so a skin that animates them still wins. Selectors
+     stay anchored to the layout: a duplicate name anywhere in the document
+     aborts the whole transition, and `.header` is a plausible class for page
+     content to carry. */
+  body > .header {
+    view-transition-name: octc-header;
+  }
+  #ox-sidebar {
+    view-transition-name: octc-sidebar;
+  }
+  body > .mobile-footer {
+    view-transition-name: octc-mobile-footer;
+  }
+
+  /* The UA cross-fade composites the two root snapshots with `plus-lighter`.
+     That only stays neutral while both snapshots are fully opaque: any region
+     the root paints as transparent — the page background included, when it is
+     propagated to the canvas from `body` instead of being owned by `html` — is
+     added to itself and the page visibly brightens partway through. Holding the
+     outgoing snapshot opaque and fading the incoming one in over it keeps the
+     stack at full coverage for the whole animation, so neither the blend nor
+     the browser's own base color can show through. */
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    mix-blend-mode: normal;
+  }
+
+  ::view-transition-old(root) {
+    animation: none;
+    opacity: 1;
+  }
+
+  ::view-transition-new(root) {
+    animation-name: octc-view-transition-in;
+    animation-duration: var(--octc-motion-base, 150ms);
+    animation-timing-function: var(--octc-motion-ease, ease);
+  }
+}
+
+@keyframes octc-view-transition-in {
+  from {
+    opacity: 0;
+  }
 }

--- a/crates/ox_content_ssg/src/html/mpa_navigation.rs
+++ b/crates/ox_content_ssg/src/html/mpa_navigation.rs
@@ -31,6 +31,30 @@ mod tests {
     }
 
     #[test]
+    fn root_cross_fade_is_overridden_to_stay_opaque() {
+        // The UA cross-fade adds the two root snapshots together with
+        // `plus-lighter`; anything the root leaves transparent is then counted
+        // twice and the page brightens partway through the navigation.
+        assert!(MPA_NAVIGATION_CSS.contains("::view-transition-old(root)"));
+        assert!(MPA_NAVIGATION_CSS.contains("::view-transition-new(root)"));
+        assert!(MPA_NAVIGATION_CSS.contains("mix-blend-mode: normal"));
+    }
+
+    #[test]
+    fn persistent_chrome_is_named_out_of_the_root_snapshot() {
+        for name in ["octc-header", "octc-sidebar", "octc-mobile-footer"] {
+            assert!(MPA_NAVIGATION_CSS.contains(name), "missing {name}");
+        }
+    }
+
+    #[test]
+    fn root_element_owns_the_canvas_background() {
+        // A `body`-only background is propagated to the canvas, which leaves the
+        // repaint behind a cross-document transition to the UA default color.
+        assert!(super::super::SSG_CSS.contains("background-color: var(--octc-color-bg);"));
+    }
+
+    #[test]
     fn bootstrap_accepts_only_supported_stored_preferences() {
         assert!(THEME_BOOTSTRAP_JS.contains("stored === \"light\" || stored === \"dark\""));
         assert!(THEME_BOOTSTRAP_JS.contains("removeAttribute(\"data-theme\")"));

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
@@ -181,6 +181,11 @@ expression: "super::snapshot_text(&html)"
 }
 
 html {
+  /* The canvas background has to be owned by the root element, not inherited
+     from `body`: it is what the browser paints behind a cross-document view
+     transition and in the gap between two documents, and a `body`-only
+     background leaves that repaint to the UA default. */
+  background-color: var(--octc-color-bg);
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
   scroll-padding-top: calc(var(--octc-header-height) + 1rem);
@@ -2283,6 +2288,54 @@ a:hover {
   @view-transition {
     navigation: auto;
   }
+
+  /* The header, sidebar and mobile footer are identical on both sides of a docs
+     navigation, so leaving them inside the `root` snapshot animates them for no
+     reason. Naming them lifts each into its own group, which the UA leaves
+     alone when the old and new snapshots match. The names are the ones the
+     theme skins already use, so a skin that animates them still wins. Selectors
+     stay anchored to the layout: a duplicate name anywhere in the document
+     aborts the whole transition, and `.header` is a plausible class for page
+     content to carry. */
+  body > .header {
+    view-transition-name: octc-header;
+  }
+  #ox-sidebar {
+    view-transition-name: octc-sidebar;
+  }
+  body > .mobile-footer {
+    view-transition-name: octc-mobile-footer;
+  }
+
+  /* The UA cross-fade composites the two root snapshots with `plus-lighter`.
+     That only stays neutral while both snapshots are fully opaque: any region
+     the root paints as transparent — the page background included, when it is
+     propagated to the canvas from `body` instead of being owned by `html` — is
+     added to itself and the page visibly brightens partway through. Holding the
+     outgoing snapshot opaque and fading the incoming one in over it keeps the
+     stack at full coverage for the whole animation, so neither the blend nor
+     the browser's own base color can show through. */
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    mix-blend-mode: normal;
+  }
+
+  ::view-transition-old(root) {
+    animation: none;
+    opacity: 1;
+  }
+
+  ::view-transition-new(root) {
+    animation-name: octc-view-transition-in;
+    animation-duration: var(--octc-motion-base, 150ms);
+    animation-timing-function: var(--octc-motion-ease, ease);
+  }
+}
+
+@keyframes octc-view-transition-in {
+  from {
+    opacity: 0;
+  }
 }
 
 /* ox-content:css:mpa-navigation:end */
@@ -2491,12 +2544,25 @@ const themeToggle = document.querySelector(".theme-toggle"),
       return "system";
     }
   },
+  // `theme-color` tracks the system scheme through its media query, so a forced
+  // theme leaves the browser painting its own window — and the gap it shows
+  // between two documents mid-navigation — in the opposite color. Pinning the
+  // matching meta and muting the other keeps the two in step.
+  syncThemeColor = (theme) => {
+    for (const meta of document.querySelectorAll('meta[name="theme-color"][media]')) {
+      const base = (meta.dataset.octcMedia ??= meta.media),
+        scheme = base.includes("dark") ? "dark" : "light";
+      meta.media =
+        theme === "light" || theme === "dark" ? (theme === scheme ? "all" : "not all") : base;
+    }
+  },
   applyThemePreference = (theme) => {
     if (theme === "light" || theme === "dark") {
       document.documentElement.setAttribute("data-theme", theme);
     } else {
       document.documentElement.removeAttribute("data-theme");
     }
+    syncThemeColor(theme);
   },
   setTheme = (theme) => {
     if (theme !== "light" && theme !== "dark") return;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
@@ -178,6 +178,11 @@ expression: "super::snapshot_text(&html)"
 }
 
 html {
+  /* The canvas background has to be owned by the root element, not inherited
+     from `body`: it is what the browser paints behind a cross-document view
+     transition and in the gap between two documents, and a `body`-only
+     background leaves that repaint to the UA default. */
+  background-color: var(--octc-color-bg);
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
   scroll-padding-top: calc(var(--octc-header-height) + 1rem);
@@ -2280,6 +2285,54 @@ a:hover {
   @view-transition {
     navigation: auto;
   }
+
+  /* The header, sidebar and mobile footer are identical on both sides of a docs
+     navigation, so leaving them inside the `root` snapshot animates them for no
+     reason. Naming them lifts each into its own group, which the UA leaves
+     alone when the old and new snapshots match. The names are the ones the
+     theme skins already use, so a skin that animates them still wins. Selectors
+     stay anchored to the layout: a duplicate name anywhere in the document
+     aborts the whole transition, and `.header` is a plausible class for page
+     content to carry. */
+  body > .header {
+    view-transition-name: octc-header;
+  }
+  #ox-sidebar {
+    view-transition-name: octc-sidebar;
+  }
+  body > .mobile-footer {
+    view-transition-name: octc-mobile-footer;
+  }
+
+  /* The UA cross-fade composites the two root snapshots with `plus-lighter`.
+     That only stays neutral while both snapshots are fully opaque: any region
+     the root paints as transparent — the page background included, when it is
+     propagated to the canvas from `body` instead of being owned by `html` — is
+     added to itself and the page visibly brightens partway through. Holding the
+     outgoing snapshot opaque and fading the incoming one in over it keeps the
+     stack at full coverage for the whole animation, so neither the blend nor
+     the browser's own base color can show through. */
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    mix-blend-mode: normal;
+  }
+
+  ::view-transition-old(root) {
+    animation: none;
+    opacity: 1;
+  }
+
+  ::view-transition-new(root) {
+    animation-name: octc-view-transition-in;
+    animation-duration: var(--octc-motion-base, 150ms);
+    animation-timing-function: var(--octc-motion-ease, ease);
+  }
+}
+
+@keyframes octc-view-transition-in {
+  from {
+    opacity: 0;
+  }
 }
 
 /* ox-content:css:mpa-navigation:end */
@@ -2472,12 +2525,25 @@ const themeToggle = document.querySelector(".theme-toggle"),
       return "system";
     }
   },
+  // `theme-color` tracks the system scheme through its media query, so a forced
+  // theme leaves the browser painting its own window — and the gap it shows
+  // between two documents mid-navigation — in the opposite color. Pinning the
+  // matching meta and muting the other keeps the two in step.
+  syncThemeColor = (theme) => {
+    for (const meta of document.querySelectorAll('meta[name="theme-color"][media]')) {
+      const base = (meta.dataset.octcMedia ??= meta.media),
+        scheme = base.includes("dark") ? "dark" : "light";
+      meta.media =
+        theme === "light" || theme === "dark" ? (theme === scheme ? "all" : "not all") : base;
+    }
+  },
   applyThemePreference = (theme) => {
     if (theme === "light" || theme === "dark") {
       document.documentElement.setAttribute("data-theme", theme);
     } else {
       document.documentElement.removeAttribute("data-theme");
     }
+    syncThemeColor(theme);
   },
   setTheme = (theme) => {
     if (theme !== "light" && theme !== "dark") return;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
@@ -178,6 +178,11 @@ expression: "super::snapshot_text(&html)"
 }
 
 html {
+  /* The canvas background has to be owned by the root element, not inherited
+     from `body`: it is what the browser paints behind a cross-document view
+     transition and in the gap between two documents, and a `body`-only
+     background leaves that repaint to the UA default. */
+  background-color: var(--octc-color-bg);
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
   scroll-padding-top: calc(var(--octc-header-height) + 1rem);
@@ -2280,6 +2285,54 @@ a:hover {
   @view-transition {
     navigation: auto;
   }
+
+  /* The header, sidebar and mobile footer are identical on both sides of a docs
+     navigation, so leaving them inside the `root` snapshot animates them for no
+     reason. Naming them lifts each into its own group, which the UA leaves
+     alone when the old and new snapshots match. The names are the ones the
+     theme skins already use, so a skin that animates them still wins. Selectors
+     stay anchored to the layout: a duplicate name anywhere in the document
+     aborts the whole transition, and `.header` is a plausible class for page
+     content to carry. */
+  body > .header {
+    view-transition-name: octc-header;
+  }
+  #ox-sidebar {
+    view-transition-name: octc-sidebar;
+  }
+  body > .mobile-footer {
+    view-transition-name: octc-mobile-footer;
+  }
+
+  /* The UA cross-fade composites the two root snapshots with `plus-lighter`.
+     That only stays neutral while both snapshots are fully opaque: any region
+     the root paints as transparent — the page background included, when it is
+     propagated to the canvas from `body` instead of being owned by `html` — is
+     added to itself and the page visibly brightens partway through. Holding the
+     outgoing snapshot opaque and fading the incoming one in over it keeps the
+     stack at full coverage for the whole animation, so neither the blend nor
+     the browser's own base color can show through. */
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    mix-blend-mode: normal;
+  }
+
+  ::view-transition-old(root) {
+    animation: none;
+    opacity: 1;
+  }
+
+  ::view-transition-new(root) {
+    animation-name: octc-view-transition-in;
+    animation-duration: var(--octc-motion-base, 150ms);
+    animation-timing-function: var(--octc-motion-ease, ease);
+  }
+}
+
+@keyframes octc-view-transition-in {
+  from {
+    opacity: 0;
+  }
 }
 
 /* ox-content:css:mpa-navigation:end */
@@ -2472,12 +2525,25 @@ const themeToggle = document.querySelector(".theme-toggle"),
       return "system";
     }
   },
+  // `theme-color` tracks the system scheme through its media query, so a forced
+  // theme leaves the browser painting its own window — and the gap it shows
+  // between two documents mid-navigation — in the opposite color. Pinning the
+  // matching meta and muting the other keeps the two in step.
+  syncThemeColor = (theme) => {
+    for (const meta of document.querySelectorAll('meta[name="theme-color"][media]')) {
+      const base = (meta.dataset.octcMedia ??= meta.media),
+        scheme = base.includes("dark") ? "dark" : "light";
+      meta.media =
+        theme === "light" || theme === "dark" ? (theme === scheme ? "all" : "not all") : base;
+    }
+  },
   applyThemePreference = (theme) => {
     if (theme === "light" || theme === "dark") {
       document.documentElement.setAttribute("data-theme", theme);
     } else {
       document.documentElement.removeAttribute("data-theme");
     }
+    syncThemeColor(theme);
   },
   setTheme = (theme) => {
     if (theme !== "light" && theme !== "dark") return;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
@@ -178,6 +178,11 @@ expression: "super::snapshot_text(&html)"
 }
 
 html {
+  /* The canvas background has to be owned by the root element, not inherited
+     from `body`: it is what the browser paints behind a cross-document view
+     transition and in the gap between two documents, and a `body`-only
+     background leaves that repaint to the UA default. */
+  background-color: var(--octc-color-bg);
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
   scroll-padding-top: calc(var(--octc-header-height) + 1rem);
@@ -2280,6 +2285,54 @@ a:hover {
   @view-transition {
     navigation: auto;
   }
+
+  /* The header, sidebar and mobile footer are identical on both sides of a docs
+     navigation, so leaving them inside the `root` snapshot animates them for no
+     reason. Naming them lifts each into its own group, which the UA leaves
+     alone when the old and new snapshots match. The names are the ones the
+     theme skins already use, so a skin that animates them still wins. Selectors
+     stay anchored to the layout: a duplicate name anywhere in the document
+     aborts the whole transition, and `.header` is a plausible class for page
+     content to carry. */
+  body > .header {
+    view-transition-name: octc-header;
+  }
+  #ox-sidebar {
+    view-transition-name: octc-sidebar;
+  }
+  body > .mobile-footer {
+    view-transition-name: octc-mobile-footer;
+  }
+
+  /* The UA cross-fade composites the two root snapshots with `plus-lighter`.
+     That only stays neutral while both snapshots are fully opaque: any region
+     the root paints as transparent — the page background included, when it is
+     propagated to the canvas from `body` instead of being owned by `html` — is
+     added to itself and the page visibly brightens partway through. Holding the
+     outgoing snapshot opaque and fading the incoming one in over it keeps the
+     stack at full coverage for the whole animation, so neither the blend nor
+     the browser's own base color can show through. */
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    mix-blend-mode: normal;
+  }
+
+  ::view-transition-old(root) {
+    animation: none;
+    opacity: 1;
+  }
+
+  ::view-transition-new(root) {
+    animation-name: octc-view-transition-in;
+    animation-duration: var(--octc-motion-base, 150ms);
+    animation-timing-function: var(--octc-motion-ease, ease);
+  }
+}
+
+@keyframes octc-view-transition-in {
+  from {
+    opacity: 0;
+  }
 }
 
 /* ox-content:css:mpa-navigation:end */
@@ -2474,12 +2527,25 @@ const themeToggle = document.querySelector(".theme-toggle"),
       return "system";
     }
   },
+  // `theme-color` tracks the system scheme through its media query, so a forced
+  // theme leaves the browser painting its own window — and the gap it shows
+  // between two documents mid-navigation — in the opposite color. Pinning the
+  // matching meta and muting the other keeps the two in step.
+  syncThemeColor = (theme) => {
+    for (const meta of document.querySelectorAll('meta[name="theme-color"][media]')) {
+      const base = (meta.dataset.octcMedia ??= meta.media),
+        scheme = base.includes("dark") ? "dark" : "light";
+      meta.media =
+        theme === "light" || theme === "dark" ? (theme === scheme ? "all" : "not all") : base;
+    }
+  },
   applyThemePreference = (theme) => {
     if (theme === "light" || theme === "dark") {
       document.documentElement.setAttribute("data-theme", theme);
     } else {
       document.documentElement.removeAttribute("data-theme");
     }
+    syncThemeColor(theme);
   },
   setTheme = (theme) => {
     if (theme !== "light" && theme !== "dark") return;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
@@ -178,6 +178,11 @@ expression: "super::snapshot_text(&html)"
 }
 
 html {
+  /* The canvas background has to be owned by the root element, not inherited
+     from `body`: it is what the browser paints behind a cross-document view
+     transition and in the gap between two documents, and a `body`-only
+     background leaves that repaint to the UA default. */
+  background-color: var(--octc-color-bg);
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
   scroll-padding-top: calc(var(--octc-header-height) + 1rem);
@@ -2280,6 +2285,54 @@ a:hover {
   @view-transition {
     navigation: auto;
   }
+
+  /* The header, sidebar and mobile footer are identical on both sides of a docs
+     navigation, so leaving them inside the `root` snapshot animates them for no
+     reason. Naming them lifts each into its own group, which the UA leaves
+     alone when the old and new snapshots match. The names are the ones the
+     theme skins already use, so a skin that animates them still wins. Selectors
+     stay anchored to the layout: a duplicate name anywhere in the document
+     aborts the whole transition, and `.header` is a plausible class for page
+     content to carry. */
+  body > .header {
+    view-transition-name: octc-header;
+  }
+  #ox-sidebar {
+    view-transition-name: octc-sidebar;
+  }
+  body > .mobile-footer {
+    view-transition-name: octc-mobile-footer;
+  }
+
+  /* The UA cross-fade composites the two root snapshots with `plus-lighter`.
+     That only stays neutral while both snapshots are fully opaque: any region
+     the root paints as transparent — the page background included, when it is
+     propagated to the canvas from `body` instead of being owned by `html` — is
+     added to itself and the page visibly brightens partway through. Holding the
+     outgoing snapshot opaque and fading the incoming one in over it keeps the
+     stack at full coverage for the whole animation, so neither the blend nor
+     the browser's own base color can show through. */
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    mix-blend-mode: normal;
+  }
+
+  ::view-transition-old(root) {
+    animation: none;
+    opacity: 1;
+  }
+
+  ::view-transition-new(root) {
+    animation-name: octc-view-transition-in;
+    animation-duration: var(--octc-motion-base, 150ms);
+    animation-timing-function: var(--octc-motion-ease, ease);
+  }
+}
+
+@keyframes octc-view-transition-in {
+  from {
+    opacity: 0;
+  }
 }
 
 /* ox-content:css:mpa-navigation:end */
@@ -2507,12 +2560,25 @@ const themeToggle = document.querySelector(".theme-toggle"),
       return "system";
     }
   },
+  // `theme-color` tracks the system scheme through its media query, so a forced
+  // theme leaves the browser painting its own window — and the gap it shows
+  // between two documents mid-navigation — in the opposite color. Pinning the
+  // matching meta and muting the other keeps the two in step.
+  syncThemeColor = (theme) => {
+    for (const meta of document.querySelectorAll('meta[name="theme-color"][media]')) {
+      const base = (meta.dataset.octcMedia ??= meta.media),
+        scheme = base.includes("dark") ? "dark" : "light";
+      meta.media =
+        theme === "light" || theme === "dark" ? (theme === scheme ? "all" : "not all") : base;
+    }
+  },
   applyThemePreference = (theme) => {
     if (theme === "light" || theme === "dark") {
       document.documentElement.setAttribute("data-theme", theme);
     } else {
       document.documentElement.removeAttribute("data-theme");
     }
+    syncThemeColor(theme);
   },
   setTheme = (theme) => {
     if (theme !== "light" && theme !== "dark") return;

--- a/crates/ox_content_ssg/src/ssg.css
+++ b/crates/ox_content_ssg/src/ssg.css
@@ -144,6 +144,11 @@
 }
 
 html {
+  /* The canvas background has to be owned by the root element, not inherited
+     from `body`: it is what the browser paints behind a cross-document view
+     transition and in the gap between two documents, and a `body`-only
+     background leaves that repaint to the UA default. */
+  background-color: var(--octc-color-bg);
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
   scroll-padding-top: calc(var(--octc-header-height) + 1rem);

--- a/crates/ox_content_ssg/src/ssg.js
+++ b/crates/ox_content_ssg/src/ssg.js
@@ -88,12 +88,25 @@ const themeToggle = document.querySelector(".theme-toggle"),
       return "system";
     }
   },
+  // `theme-color` tracks the system scheme through its media query, so a forced
+  // theme leaves the browser painting its own window — and the gap it shows
+  // between two documents mid-navigation — in the opposite color. Pinning the
+  // matching meta and muting the other keeps the two in step.
+  syncThemeColor = (theme) => {
+    for (const meta of document.querySelectorAll('meta[name="theme-color"][media]')) {
+      const base = (meta.dataset.octcMedia ??= meta.media),
+        scheme = base.includes("dark") ? "dark" : "light";
+      meta.media =
+        theme === "light" || theme === "dark" ? (theme === scheme ? "all" : "not all") : base;
+    }
+  },
   applyThemePreference = (theme) => {
     if (theme === "light" || theme === "dark") {
       document.documentElement.setAttribute("data-theme", theme);
     } else {
       document.documentElement.removeAttribute("data-theme");
     }
+    syncThemeColor(theme);
   },
   setTheme = (theme) => {
     if (theme !== "light" && theme !== "dark") return;


### PR DESCRIPTION
## Summary

- Docs navigation flashes on Arc. The cause is the default cross-document view transition: Chromium composites the two `root` snapshots with `mix-blend-mode: plus-lighter`, which is only neutral while both snapshots are fully opaque. The page background was declared on `body` and propagated to the canvas, so the root snapshot itself carried transparency — the blend added those regions to themselves and the page visibly brightened partway through every navigation.
- Own the canvas background on `html`, so the root snapshot is opaque and the browser has a page color to paint in the gap between two documents instead of falling back to its own base color.
- Replace the symmetric root cross-fade with an opaque outgoing snapshot and an incoming one that fades in over it. Coverage never drops below full, so the blend mode stops mattering at all.
- Name the header, sidebar and mobile footer out of the root snapshot. They are identical on both sides of a docs navigation and were being animated for nothing. The names (`octc-header`, `octc-sidebar`) are the ones the theme skins already use, so a skin that animates them still wins. Selectors are anchored to the layout (`body > .header`, `#ox-sidebar`) because a duplicate `view-transition-name` anywhere in the document aborts the whole transition, and `.header` is a plausible class for page content to carry.
- Keep `theme-color` in step with a forced theme. Left on its media query it tracks the system scheme, so a reader who overrode the theme got the opposite color painted around the document.

Reuses `--octc-motion-base` for the fade rather than adding a token — its documented role already covers "page swap".

## Risk

- Risk level: low
- User or production impact: CSS and progressive-enhancement JS only. Under `prefers-reduced-motion: reduce` nothing changes, because `@view-transition` is still never declared there. Browsers without cross-document view transitions ignore the whole block.
- Rollback plan: revert the commit; the transition falls back to the UA cross-fade.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_ssg` (281 passed), `vp run check:ts` (0 errors). Four new unit tests lock in the root override, the named chrome, and the root-owned background; the five HTML snapshots are regenerated.
- [ ] Manual verification completed: **not done — I do not have Arc here.** The mechanism above is reasoned from the generated CSS, not observed in Arc, so a check on the deployed preview is worth doing before merge.
- [x] Edge cases or failure modes considered: duplicate `view-transition-name` aborting the transition (selectors scoped); pages without a sidebar (entry page) where the named group only has one side, which the UA cross-fades on its own; `body`'s noise overlay, which still paints over the new `html` background inside the body box.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed. Each rule carries the reasoning inline; no new public token to document.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790586992&installation_model_id=422833&pr_number=1191&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1191&signature=b04e29cd81ccb682e9d27583f593ce33737aea3342fd69aed723a2eb7e958e1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smoother view transitions between pages, including persistent headers, sidebars, and mobile footers.
  * Improved transition backgrounds to prevent flashing and unwanted blending.

* **Bug Fixes**
  * Theme-color metadata now updates correctly when light or dark mode is forced and restores system-based behavior when preferences change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->