### PR TITLE
docs(embeds): give every provider card a real preview

### DIFF
--- a/crates/ox_content_transform/src/media_embeds/catalog_tests.rs
+++ b/crates/ox_content_transform/src/media_embeds/catalog_tests.rs
@@ -67,6 +67,7 @@ fn figma_file_design_and_prototype_all_render() {
         "https://www.figma.com/design/AbC123/My-Design",
         "https://www.figma.com/proto/AbC123/My-Design",
         "https://www.figma.com/board/AbC123/My-Board",
+        "https://www.figma.com/community/file/AbC123/Design-Kit",
     ] {
         let out = render_catalog(&format!(r#"<figma url="{url}"></figma>"#));
         assert!(out.contains("ox-provider-card--figma"), "{url}: {out}");

--- a/crates/ox_content_transform/src/media_embeds/document_cards.rs
+++ b/crates/ox_content_transform/src/media_embeds/document_cards.rs
@@ -36,6 +36,9 @@ pub(super) fn render_figma(element: &ComponentElement<'_>) -> Option<String> {
     let segments = path_segments(parsed.path);
     let (kind, key) = match segments.as_slice() {
         [kind @ ("file" | "design" | "board" | "proto" | "slides"), key, ..] => (*kind, *key),
+        // A Community file is the Figma link most likely to be pasted into a
+        // document, and it carries the same key one segment deeper.
+        ["community", kind @ ("file" | "board" | "proto" | "slides"), key, ..] => (*kind, *key),
         _ => return None,
     };
     safe_file_key(key)?;

--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -555,7 +555,12 @@ version and tag URLs where the provider exposes one. `version`, `downloads`,
 `license` and `stars` render as metrics:
 
 ```mdx
-<NpmPackage url="https://www.npmjs.com/package/vite" version="7.1.0" license="MIT" downloads="31M/week" />
+<NpmPackage
+  url="https://www.npmjs.com/package/vite"
+  version="7.1.0"
+  license="MIT"
+  downloads="31M/week"
+/>
 ```
 
 <NpmPackage url="https://www.npmjs.com/package/vite" name="vite" description="Next generation frontend tooling — fast by default" version="7.1.0" license="MIT" downloads="31M/week"></NpmPackage>
@@ -625,7 +630,11 @@ video cards with `duration`, `views` and `status` metrics. Vimeo, Loom and
 asciinema accept a player URL as `embed`:
 
 ```mdx
-<Vimeo url="https://vimeo.com/76979871" title="The New Vimeo Player" embed="https://player.vimeo.com/video/76979871" />
+<Vimeo
+  url="https://vimeo.com/76979871"
+  title="The New Vimeo Player"
+  embed="https://player.vimeo.com/video/76979871"
+/>
 ```
 
 <Vimeo url="https://vimeo.com/76979871" title="The New Vimeo Player (You Know, For Videos)" author="Vimeo Staff" duration="1:03" embed="https://player.vimeo.com/video/76979871"></Vimeo>
@@ -682,7 +691,7 @@ option, and the instance is read off the URL:
 | `iframe`       | `false`                       | Add lazy playground/video iframe URLs.           |
 | `parent`       | `[]`                          | Twitch iframe parent domain or domains.          |
 
-`iframe` is about *derived* embeds: it lets a provider build a player URL from
+`iframe` is about _derived_ embeds: it lets a provider build a player URL from
 the page URL it was given. An explicit `embed` attribute works either way.
 
 `cache` alone lives for one build. `persistCache: true` writes metadata to disk

--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -484,82 +484,192 @@ request is needed at all:
 
 ## Provider Cards
 
-Provider cards render rich static previews for maps, articles, packages,
-playgrounds, videos, design links, slides, communities, and social posts. They
-do not load third-party scripts by default, and authors can pass stable metadata
-directly through attributes.
+Provider cards render static previews for maps, articles, packages,
+playgrounds, videos, design files, slides, and community posts. None of them
+load a third-party widget script: the card is HTML the transform emitted, and
+every value in it was either fetched at build time or passed as an attribute.
 
-The cards below render without a network request at build time:
+Cards whose provider publishes an embed URL take an `embed` attribute as well.
+Pass one and the card grows a lazily loaded iframe below the metadata, so the
+page shows the thing itself instead of a link to it. `embed` is validated per
+provider — only that provider's own embed host and path are accepted, and
+anything else is dropped rather than rendered.
 
-<CratesIo url="https://crates.io/crates/serde" name="serde" description="Serialization framework for Rust" version="1.0.219" downloads="512M"></CratesIo>
+Every card below is live. The tag above each one is what produced it.
 
-<PyPI url="https://pypi.org/project/requests" name="requests" description="HTTP for Humans" version="2.32.3"></PyPI>
+### Maps
 
-<DockerHub url="https://hub.docker.com/_/nginx" name="nginx" description="Official build of Nginx"></DockerHub>
-
-<JSFiddle url="https://jsfiddle.net/ubugeeei/abc123/2/" title="Layout sandbox" author="ubugeeei"></JSFiddle>
-
-<Observable url="https://observablehq.com/@d3/bar-chart" title="Bar chart" author="d3"></Observable>
+`embeds.googleMaps` renders a place card from `place` and `address`. Add
+`embed` with a Google Maps embed URL and the card carries the map itself:
 
 ```mdx
 <GoogleMaps
   url="https://www.google.com/maps/place/Tokyo+Station/"
   place="Tokyo Station"
-  address="1 Chome Marunouchi, Chiyoda City"
+  address="1 Chome-9-1 Marunouchi, Chiyoda City, Tokyo"
+  embed="https://www.google.com/maps/embed?pb=..."
 />
+```
 
+<GoogleMaps url="https://www.google.com/maps/place/Tokyo+Station/" place="Tokyo Station" address="1 Chome-9-1 Marunouchi, Chiyoda City, Tokyo" embed="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3241.2!2d139.7645!3d35.6812!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x60188bfbd89f700b%3A0x277c49ba34ed38!2z5p2x5Lqs6aeF!5e0!3m2!1sen!2sjp!4v1700000000000!5m2!1sen!2sjp"></GoogleMaps>
+
+Drop `embed` and the same tag renders link-only — useful when the page should
+not reach Google at view time:
+
+<GoogleMaps url="https://www.google.com/maps/place/Tokyo+Station/" place="Tokyo Station" address="1 Chome-9-1 Marunouchi, Chiyoda City, Tokyo"></GoogleMaps>
+
+Only `https://www.google.com/maps/embed…` is accepted as `embed`. A place URL,
+a shortened `maps.app.goo.gl` link or any other host is ignored, and the card
+falls back to the link-only form above.
+
+### Articles
+
+`embeds.qiita`, `embeds.zenn` and `embeds.note` fetch title, author and counts
+by default. With `fetch: false` — the setting this site builds with — the card
+is assembled entirely from attributes, so the build stays offline and the
+numbers stay pinned to whatever you wrote:
+
+```mdx
 <Qiita
-  url="https://qiita.com/ubugeeei/items/abcdef123456"
-  title="Rust docs pipeline"
-  author="ubugeeei"
-  tags="Rust, Markdown"
-  likes="42"
+  url="https://qiita.com/ubugeeei/items/73a2416fd46cfe6311a8"
+  title="【日本語版】All we know about Vue 3’s Vapor Mode"
+  author="@ubugeeei"
+  tags="Vue.js, compiler, VaporMode"
+  likes="32"
+  dateTime="2023-12-17"
 >
-  Static cards keep builds predictable.
+  Vapor Mode compiles templates straight to DOM operations.
 </Qiita>
+```
 
-<NpmPackage url="https://www.npmjs.com/package/vite" />
-<CratesIo url="https://crates.io/crates/serde" />
-<PyPI url="https://pypi.org/project/requests" />
-<DockerHub url="https://hub.docker.com/_/nginx" />
+<Qiita url="https://qiita.com/ubugeeei/items/73a2416fd46cfe6311a8" title="【日本語版】All we know about Vue 3’s Vapor Mode" author="@ubugeeei" tags="Vue.js, compiler, VaporMode" likes="32" dateTime="2023-12-17" dateLabel="Dec 17, 2023">Vapor Mode compiles templates straight to DOM operations instead of building a virtual DOM.</Qiita>
 
-<CodePen url="https://codepen.io/ubugeeei/pen/abc123" />
-<CodeSandbox url="https://codesandbox.io/p/sandbox/vite-react-demo" />
+<Zenn url="https://zenn.dev/comm_vue_nuxt/articles/reactive-props-destructure" title="Reactive Props Destructure を支える技術" author="@ubugeeei" tags="Vue.js, reactivity" likes="58" dateTime="2024-09-08" dateLabel="Sep 8, 2024">How the compiler keeps destructured props reactive.</Zenn>
 
-<JSFiddle url="https://jsfiddle.net/ubugeeei/abc123/2/" />
+<Note url="https://note.com/ubugeeei/n/n2ac2b02043da" title="【Vue Fes Japan】ハンズオン企画の裏テーマ！？" author="@ubugeeei" likes="11" dateTime="2024-10-31" dateLabel="Oct 31, 2024">Why the workshop was built on the Nuxt tutorial.</Note>
 
-<Observable url="https://observablehq.com/@d3/bar-chart" />
+### Package registries
 
-<Replit url="https://replit.com/@ubugeeei/markdown-playground" />
+`embeds.packageRegistry` covers npm, crates.io, PyPI and Docker Hub, including
+version and tag URLs where the provider exposes one. `version`, `downloads`,
+`license` and `stars` render as metrics:
 
-<Note url="https://note.com/ubugeeei/n/nabcdef123456" />
+```mdx
+<NpmPackage url="https://www.npmjs.com/package/vite" version="7.1.0" license="MIT" downloads="31M/week" />
+```
 
-<Figma url="https://www.figma.com/design/AbC123xyz/Design-System" />
+<NpmPackage url="https://www.npmjs.com/package/vite" name="vite" description="Next generation frontend tooling — fast by default" version="7.1.0" license="MIT" downloads="31M/week"></NpmPackage>
 
-<GoogleSlides url="https://docs.google.com/presentation/d/1AbC_defGHI/edit" />
+<CratesIo url="https://crates.io/crates/serde" name="serde" description="A generic serialization/deserialization framework" version="1.0.219" license="MIT OR Apache-2.0" downloads="512M"></CratesIo>
 
-<Vimeo url="https://vimeo.com/123456789" />
+<PyPI url="https://pypi.org/project/requests" name="requests" description="Python HTTP for Humans" version="2.32.3" license="Apache-2.0" downloads="1.2B/month"></PyPI>
 
-<Loom url="https://www.loom.com/share/abcdef1234567890" />
+<DockerHub url="https://hub.docker.com/_/nginx" name="nginx" description="Official build of Nginx" version="1.27-alpine" pulls="10B+"></DockerHub>
 
-<Asciinema url="https://asciinema.org/a/569727" />
+### Playgrounds
 
-<Twitch url="https://www.twitch.tv/videos/40464143" />
+`embeds.playgrounds` covers CodePen, CodeSandbox, JSFiddle, Observable and
+Replit. Each accepts its own embed URL, so a sandbox can be shown running
+rather than described:
 
-<Twitch url="https://clips.twitch.tv/FriendlySlug" />
+```mdx
+<CodePen
+  url="https://codepen.io/miriamsuzanne/pen/BEvjbm"
+  title="Angled Background CSS-only Mixin"
+  author="@miriamsuzanne"
+  embed="https://codepen.io/miriamsuzanne/embed/BEvjbm"
+/>
+```
 
-<Twitch url="https://www.twitch.tv/twitchdev" />
+<CodePen url="https://codepen.io/miriamsuzanne/pen/BEvjbm" title="Angled Background CSS-only Mixin" author="@miriamsuzanne" language="HTML, CSS" embed="https://codepen.io/miriamsuzanne/embed/BEvjbm"></CodePen>
 
+<Observable url="https://observablehq.com/@d3/bar-chart" title="Bar chart" author="@d3" language="Observable JavaScript" embed="https://observablehq.com/embed/@d3/bar-chart"></Observable>
+
+<JSFiddle url="https://jsfiddle.net/zalun/NmudS/" title="JSFiddle embedding example" author="@zalun" language="JavaScript" embed="https://jsfiddle.net/zalun/NmudS/embedded/result,js,html,css/"></JSFiddle>
+
+CodeSandbox fetches nothing at all — the card is built from the URL and the
+attributes you pass, so a deleted sandbox still renders a card pointing at it
+rather than failing the build. It accepts all four ways a sandbox is named:
+`/s/{id}`, `/p/sandbox/{id}`, `/p/devbox/{id}` and `/embed/{id}`.
+
+<CodeSandbox url="https://codesandbox.io/s/new" title="React starter" author="CodeSandbox" runtime="Browser" language="JavaScript"></CodeSandbox>
+
+<Replit url="https://replit.com/@replit/Nodejs" title="Node.js" author="@replit" runtime="Node.js"></Replit>
+
+### Design files and slides
+
+`embeds.figma` and `embeds.googleSlides` take the provider's share URL. A
+Google Slides deck also takes its `/embed` URL and renders the deck in place:
+
+```mdx
+<GoogleSlides
+  url="https://docs.google.com/presentation/d/1EAYk.../edit"
+  title="Baby album"
+  slides="9"
+  embed="https://docs.google.com/presentation/d/1EAYk.../embed"
+/>
+```
+
+<GoogleSlides url="https://docs.google.com/presentation/d/1EAYk18WDjIG-zp_0vLm3CsfQh_i8eXc67Jo2O9C6Vuc/edit" title="Baby album" author="Google Slides sample" slides="9" embed="https://docs.google.com/presentation/d/1EAYk18WDjIG-zp_0vLm3CsfQh_i8eXc67Jo2O9C6Vuc/embed"></GoogleSlides>
+
+Figma accepts `file`, `design`, `board`, `proto`, `slides` and Community links.
+The file key is the segment after the kind; the human-readable slug after it is
+ignored:
+
+<Figma url="https://www.figma.com/community/file/1035203688168086460/material-3-design-kit" title="Material 3 Design Kit" author="Google" project="Material Design"></Figma>
+
+### Video and terminal recordings
+
+`embeds.vimeo`, `embeds.loom`, `embeds.asciinema` and `embeds.twitch` render
+video cards with `duration`, `views` and `status` metrics. Vimeo, Loom and
+asciinema accept a player URL as `embed`:
+
+```mdx
+<Vimeo url="https://vimeo.com/76979871" title="The New Vimeo Player" embed="https://player.vimeo.com/video/76979871" />
+```
+
+<Vimeo url="https://vimeo.com/76979871" title="The New Vimeo Player (You Know, For Videos)" author="Vimeo Staff" duration="1:03" embed="https://player.vimeo.com/video/76979871"></Vimeo>
+
+<Asciinema url="https://asciinema.org/a/569727" title="Star Wars: Episode IV" author="asciinema" duration="30:00" embed="https://asciinema.org/a/569727/iframe"></Asciinema>
+
+<Loom url="https://www.loom.com/share/09b1aa507cb846138847bf8e98b56a71" title="Loom product overview" author="Loom" embed="https://www.loom.com/embed/09b1aa507cb846138847bf8e98b56a71"></Loom>
+
+Twitch is the exception. Its player refuses to load unless the embedding domain
+is declared, so a player URL is only generated when `embeds.twitch.parent`
+names a safe domain. Without one the card stays static, and `title`, `channel`,
+`duration`, `status`, `views` and `image` are how you make it worth showing:
+
+<Twitch url="https://www.twitch.tv/twitchdev" title="TwitchDev" channel="twitchdev" status="Offline" views="1.4M"></Twitch>
+
+### Communities and social posts
+
+`embeds.discord`, `embeds.fediverse`, `embeds.facebook`, `embeds.threads` and
+`embeds.instagram` share one card shape: author, body, timestamp and reaction
+counts. `<Fediverse>`, `<Mastodon>`, `<Misskey>` and `<Mixi2>` are the same
+option, and the instance is read off the URL:
+
+```mdx
 <Mastodon
-  url="https://mastodon.social/@docs/111"
-  author="@docs@mastodon.social"
-  replies="3"
-  reposts="5"
-  likes="8"
+  url="https://mastodon.social/@Mastodon/117117221397911074"
+  author="@Mastodon@mastodon.social"
+  reposts="622"
+  likes="954"
 >
-  Fediverse release note.
+  A first sneak peek at Mastodon 5.0.
 </Mastodon>
 ```
+
+<Mastodon url="https://mastodon.social/@Mastodon/117117221397911074" author="@Mastodon@mastodon.social" reposts="622" likes="954" dateTime="2026-08-18" dateLabel="Aug 18, 2026">After publishing the results of Discovery Week, we can now give you a first sneak peek at Mastodon 5.0.</Mastodon>
+
+<Discord url="https://discord.com/invite/vue" title="Vue Land" server="Vue Land" channel="#vue-vapor">The community server for Vue and its ecosystem.</Discord>
+
+<Facebook url="https://www.facebook.com/facebook" title="Facebook" author="Facebook">Pass author, body and counts; the card never loads the Facebook SDK.</Facebook>
+
+<Threads url="https://www.threads.net/@instagram" title="@instagram on Threads" author="@instagram" replies="1.2K" likes="18K">Threads posts render through the same card as the rest.</Threads>
+
+<Instagram url="https://www.instagram.com/instagram/" title="@instagram" author="@instagram" likes="24K">Instagram cards stay static; no embed script is loaded.</Instagram>
+
+### Provider options
 
 | Option         | Default                       | Purpose                                          |
 | -------------- | ----------------------------- | ------------------------------------------------ |
@@ -572,11 +682,8 @@ The cards below render without a network request at build time:
 | `iframe`       | `false`                       | Add lazy playground/video iframe URLs.           |
 | `parent`       | `[]`                          | Twitch iframe parent domain or domains.          |
 
-CodeSandbox accepts all four ways a sandbox is named — `/s/{id}`,
-`/p/sandbox/{id}`, `/p/devbox/{id}`, and `/embed/{id}`. Unlike the other
-playgrounds it fetches nothing: the card is built from the URL and whatever
-attributes you pass, so a deleted sandbox still renders a card pointing at it
-rather than failing the build.
+`iframe` is about *derived* embeds: it lets a provider build a player URL from
+the page URL it was given. An explicit `embed` attribute works either way.
 
 `cache` alone lives for one build. `persistCache: true` writes metadata to disk
 as well, so a clean build or a fresh CI worker reuses what the last one fetched
@@ -585,20 +692,11 @@ remembered too — a provider that is down is not retried once per embed on ever
 build. Corrupt entries are discarded and re-fetched rather than failing a build,
 and the directory is keyed by hash, so a provider URL cannot reach outside it.
 
-`<Fediverse>`, `<Mastodon>`, `<Misskey>`, and `<Mixi2>` share the
-`embeds.fediverse` option. Google Maps accepts an optional safe Google Maps
-`embed` URL for a lazy iframe; otherwise it renders a link-only place card.
-Package registry cards support npm, crates.io, PyPI, and Docker Hub package
-URLs, including version or tag URLs where the provider exposes one. Unsupported
-schemes, credentials, non-provider hosts, and unavailable metadata fall back to
-the authored tag or a link-only card instead of failing the build; failed
-package metadata fetches also emit an `[ox-content]` warning with the status or
-error reason.
-Vimeo cards use Vimeo's public oEmbed endpoint for metadata. Twitch cards avoid
-authenticated API calls by default; pass `title`, `channel`, `duration`,
-`status`, `views`, or `image` when you want richer static metadata. Twitch
-player URLs are only generated when a safe `parent` domain is configured,
-matching Twitch's embed requirements.
+Unsupported schemes, credentials, non-provider hosts, and unavailable metadata
+fall back to the authored tag or a link-only card instead of failing the build;
+failed package metadata fetches also emit an `[ox-content]` warning with the
+status or error reason. Vimeo cards use Vimeo's public oEmbed endpoint for
+metadata, and Twitch cards avoid authenticated API calls by default.
 
 ## Spotify
 

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -443,7 +443,12 @@ fetch します。このサイトのように `fetch: false` にすると、カ�
 メトリクスとして描画されます。
 
 ```mdx
-<NpmPackage url="https://www.npmjs.com/package/vite" version="7.1.0" license="MIT" downloads="31M/week" />
+<NpmPackage
+  url="https://www.npmjs.com/package/vite"
+  version="7.1.0"
+  license="MIT"
+  downloads="31M/week"
+/>
 ```
 
 <NpmPackage url="https://www.npmjs.com/package/vite" name="vite" description="次世代フロントエンドツーリング" version="7.1.0" license="MIT" downloads="31M/week"></NpmPackage>
@@ -513,7 +518,11 @@ Figma は `file`、`design`、`board`、`proto`、`slides` と Community のリ�
 asciinema は player URL を `embed` として受け取れます。
 
 ```mdx
-<Vimeo url="https://vimeo.com/76979871" title="The New Vimeo Player" embed="https://player.vimeo.com/video/76979871" />
+<Vimeo
+  url="https://vimeo.com/76979871"
+  title="The New Vimeo Player"
+  embed="https://player.vimeo.com/video/76979871"
+/>
 ```
 
 <Vimeo url="https://vimeo.com/76979871" title="The New Vimeo Player (You Know, For Videos)" author="Vimeo Staff" duration="1:03" embed="https://player.vimeo.com/video/76979871"></Vimeo>
@@ -570,7 +579,7 @@ URL から読み取ります。
 | `iframe`       | `false`                       | playground / 動画の lazy iframe URL を付与        |
 | `parent`       | `[]`                          | Twitch iframe の parent ドメイン                  |
 
-`iframe` は *導出* される embed の話です。渡されたページ URL から provider が player
+`iframe` は _導出_ される embed の話です。渡されたページ URL から provider が player
 URL を組み立てられるようにします。明示的な `embed` 属性はどちらの設定でも効きます。
 
 `cache` だけなら 1 ビルド分の寿命です。`persistCache: true` にすると metadata を

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -374,96 +374,216 @@ oxContent({
 
 ## プロバイダカード
 
-プロバイダカードは、地図、記事、package、playground、動画、デザインリンク、
-スライド、コミュニティ、social post を静的な preview として描画します。既定で
-第三者スクリプトは読み込まず、安定した metadata は属性から直接渡せます。
+プロバイダカードは、地図、記事、package、playground、動画、デザインファイル、
+スライド、コミュニティ投稿を静的な preview として描画します。第三者の widget
+スクリプトは一切読み込みません。カードは transform が出力した HTML そのもので、
+値はビルド時に fetch したものか、属性で渡したもののどちらかです。
 
-次のカードはビルド時のネットワークリクエストなしで描画されます。
+provider が embed URL を公開しているカードは `embed` 属性も受け取ります。渡すと
+metadata の下に遅延読み込みの iframe が付き、リンクではなく現物がページに出ます。
+`embed` は provider ごとに検証され、その provider 自身の embed host と path だけを
+受け付けます。それ以外は描画せず捨てます。
 
-<CratesIo url="https://crates.io/crates/serde" name="serde" description="Rust のシリアライズフレームワーク" version="1.0.219" downloads="512M"></CratesIo>
+以下のカードはすべて実際に描画されたものです。各カードの上にあるタグがその出力元です。
 
-<PyPI url="https://pypi.org/project/requests" name="requests" description="HTTP for Humans" version="2.32.3"></PyPI>
+### 地図
 
-<DockerHub url="https://hub.docker.com/_/nginx" name="nginx" description="Nginx の公式ビルド"></DockerHub>
-
-<JSFiddle url="https://jsfiddle.net/ubugeeei/abc123/2/" title="レイアウト検証" author="ubugeeei"></JSFiddle>
-
-<Observable url="https://observablehq.com/@d3/bar-chart" title="棒グラフ" author="d3"></Observable>
+`embeds.googleMaps` は `place` と `address` から場所カードを描画します。Google Maps
+の embed URL を `embed` に渡すと、地図そのものを載せたカードになります。
 
 ```mdx
 <GoogleMaps
   url="https://www.google.com/maps/place/Tokyo+Station/"
-  place="Tokyo Station"
-  address="1 Chome Marunouchi, Chiyoda City"
+  place="東京駅"
+  address="東京都千代田区丸の内 1-9-1"
+  embed="https://www.google.com/maps/embed?pb=..."
 />
+```
 
+<GoogleMaps url="https://www.google.com/maps/place/Tokyo+Station/" place="東京駅" address="東京都千代田区丸の内 1-9-1" embed="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3241.2!2d139.7645!3d35.6812!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x60188bfbd89f700b%3A0x277c49ba34ed38!2z5p2x5Lqs6aeF!5e0!3m2!1sja!2sjp!4v1700000000000!5m2!1sja!2sjp"></GoogleMaps>
+
+`embed` を外すと同じタグがリンクのみのカードになります。閲覧時に Google へ
+リクエストを飛ばしたくないページ向けです。
+
+<GoogleMaps url="https://www.google.com/maps/place/Tokyo+Station/" place="東京駅" address="東京都千代田区丸の内 1-9-1"></GoogleMaps>
+
+`embed` として受け付けるのは `https://www.google.com/maps/embed…` だけです。場所 URL、
+`maps.app.goo.gl` の短縮リンク、その他の host は無視され、上のリンクのみのカードに
+フォールバックします。
+
+### 記事
+
+`embeds.qiita`、`embeds.zenn`、`embeds.note` は既定でタイトル・著者・カウントを
+fetch します。このサイトのように `fetch: false` にすると、カードは属性だけから
+組み立てられます。ビルドはオフラインのままで、数値も書いた値に固定されます。
+
+```mdx
 <Qiita
-  url="https://qiita.com/ubugeeei/items/abcdef123456"
-  title="Rust docs pipeline"
-  author="ubugeeei"
-  tags="Rust, Markdown"
-  likes="42"
+  url="https://qiita.com/ubugeeei/items/73a2416fd46cfe6311a8"
+  title="【日本語版】All we know about Vue 3’s Vapor Mode"
+  author="@ubugeeei"
+  tags="Vue.js, compiler, VaporMode"
+  likes="32"
+  dateTime="2023-12-17"
 >
-  Static cards keep builds predictable.
+  Vapor Mode は template を DOM 操作へ直接コンパイルします。
 </Qiita>
+```
 
-<NpmPackage url="https://www.npmjs.com/package/vite" />
-<CratesIo url="https://crates.io/crates/serde" />
-<PyPI url="https://pypi.org/project/requests" />
-<DockerHub url="https://hub.docker.com/_/nginx" />
+<Qiita url="https://qiita.com/ubugeeei/items/73a2416fd46cfe6311a8" title="【日本語版】All we know about Vue 3’s Vapor Mode" author="@ubugeeei" tags="Vue.js, compiler, VaporMode" likes="32" dateTime="2023-12-17" dateLabel="2023-12-17">Vapor Mode は仮想 DOM を組み立てず、template を DOM 操作へ直接コンパイルします。</Qiita>
 
-<CodePen url="https://codepen.io/ubugeeei/pen/abc123" />
-<CodeSandbox url="https://codesandbox.io/p/sandbox/vite-react-demo" />
+<Zenn url="https://zenn.dev/comm_vue_nuxt/articles/reactive-props-destructure" title="Reactive Props Destructure を支える技術" author="@ubugeeei" tags="Vue.js, reactivity" likes="58" dateTime="2024-09-08" dateLabel="2024-09-08">分割代入した props がなぜリアクティブなままでいられるのか。</Zenn>
 
-<JSFiddle url="https://jsfiddle.net/ubugeeei/abc123/2/" />
+<Note url="https://note.com/ubugeeei/n/n2ac2b02043da" title="【Vue Fes Japan】ハンズオン企画の裏テーマ！？" author="@ubugeeei" likes="11" dateTime="2024-10-31" dateLabel="2024-10-31">ハンズオンの題材に Nuxt Tutorial を選んだ理由。</Note>
 
-<Observable url="https://observablehq.com/@d3/bar-chart" />
+### パッケージレジストリ
 
-<Vimeo url="https://vimeo.com/123456789" />
+`embeds.packageRegistry` は npm、crates.io、PyPI、Docker Hub に対応し、provider が
+持つ version / tag URL も扱えます。`version`、`downloads`、`license`、`stars` は
+メトリクスとして描画されます。
 
-<Twitch url="https://www.twitch.tv/videos/40464143" />
+```mdx
+<NpmPackage url="https://www.npmjs.com/package/vite" version="7.1.0" license="MIT" downloads="31M/week" />
+```
 
-<Twitch url="https://clips.twitch.tv/FriendlySlug" />
+<NpmPackage url="https://www.npmjs.com/package/vite" name="vite" description="次世代フロントエンドツーリング" version="7.1.0" license="MIT" downloads="31M/week"></NpmPackage>
 
-<Twitch url="https://www.twitch.tv/twitchdev" />
+<CratesIo url="https://crates.io/crates/serde" name="serde" description="Rust のシリアライズフレームワーク" version="1.0.219" license="MIT OR Apache-2.0" downloads="512M"></CratesIo>
 
+<PyPI url="https://pypi.org/project/requests" name="requests" description="HTTP for Humans" version="2.32.3" license="Apache-2.0" downloads="1.2B/month"></PyPI>
+
+<DockerHub url="https://hub.docker.com/_/nginx" name="nginx" description="Nginx の公式ビルド" version="1.27-alpine" pulls="10B+"></DockerHub>
+
+### Playground
+
+`embeds.playgrounds` は CodePen、CodeSandbox、JSFiddle、Observable、Replit を
+まとめて扱います。それぞれ自身の embed URL を受け取れるので、説明ではなく
+動いている sandbox をそのまま見せられます。
+
+```mdx
+<CodePen
+  url="https://codepen.io/miriamsuzanne/pen/BEvjbm"
+  title="Angled Background CSS-only Mixin"
+  author="@miriamsuzanne"
+  embed="https://codepen.io/miriamsuzanne/embed/BEvjbm"
+/>
+```
+
+<CodePen url="https://codepen.io/miriamsuzanne/pen/BEvjbm" title="Angled Background CSS-only Mixin" author="@miriamsuzanne" language="HTML, CSS" embed="https://codepen.io/miriamsuzanne/embed/BEvjbm"></CodePen>
+
+<Observable url="https://observablehq.com/@d3/bar-chart" title="棒グラフ" author="@d3" language="Observable JavaScript" embed="https://observablehq.com/embed/@d3/bar-chart"></Observable>
+
+<JSFiddle url="https://jsfiddle.net/zalun/NmudS/" title="JSFiddle embedding example" author="@zalun" language="JavaScript" embed="https://jsfiddle.net/zalun/NmudS/embedded/result,js,html,css/"></JSFiddle>
+
+CodeSandbox だけは何も fetch しません。カードは URL と渡した属性だけから組み立てる
+ので、削除済みの sandbox でもビルドを落とさずカードを描画します。sandbox の
+指定方法は 4 通りすべて受け付けます（`/s/{id}`、`/p/sandbox/{id}`、
+`/p/devbox/{id}`、`/embed/{id}`）。
+
+<CodeSandbox url="https://codesandbox.io/s/new" title="React starter" author="CodeSandbox" runtime="Browser" language="JavaScript"></CodeSandbox>
+
+<Replit url="https://replit.com/@replit/Nodejs" title="Node.js" author="@replit" runtime="Node.js"></Replit>
+
+### デザインファイルとスライド
+
+`embeds.figma` と `embeds.googleSlides` は provider の共有 URL を受け取ります。
+Google Slides は `/embed` URL も受け取り、デッキをそのままページ内に描画します。
+
+```mdx
+<GoogleSlides
+  url="https://docs.google.com/presentation/d/1EAYk.../edit"
+  title="Baby album"
+  slides="9"
+  embed="https://docs.google.com/presentation/d/1EAYk.../embed"
+/>
+```
+
+<GoogleSlides url="https://docs.google.com/presentation/d/1EAYk18WDjIG-zp_0vLm3CsfQh_i8eXc67Jo2O9C6Vuc/edit" title="Baby album" author="Google Slides のサンプル" slides="9" embed="https://docs.google.com/presentation/d/1EAYk18WDjIG-zp_0vLm3CsfQh_i8eXc67Jo2O9C6Vuc/embed"></GoogleSlides>
+
+Figma は `file`、`design`、`board`、`proto`、`slides` と Community のリンクを
+受け付けます。ファイルキーは種別の次のセグメントで、その後ろの人間向け slug は
+無視されます。
+
+<Figma url="https://www.figma.com/community/file/1035203688168086460/material-3-design-kit" title="Material 3 Design Kit" author="Google" project="Material Design"></Figma>
+
+### 動画とターミナル録画
+
+`embeds.vimeo`、`embeds.loom`、`embeds.asciinema`、`embeds.twitch` は `duration`、
+`views`、`status` をメトリクスに持つ動画カードを描画します。Vimeo、Loom、
+asciinema は player URL を `embed` として受け取れます。
+
+```mdx
+<Vimeo url="https://vimeo.com/76979871" title="The New Vimeo Player" embed="https://player.vimeo.com/video/76979871" />
+```
+
+<Vimeo url="https://vimeo.com/76979871" title="The New Vimeo Player (You Know, For Videos)" author="Vimeo Staff" duration="1:03" embed="https://player.vimeo.com/video/76979871"></Vimeo>
+
+<Asciinema url="https://asciinema.org/a/569727" title="Star Wars: Episode IV" author="asciinema" duration="30:00" embed="https://asciinema.org/a/569727/iframe"></Asciinema>
+
+<Loom url="https://www.loom.com/share/09b1aa507cb846138847bf8e98b56a71" title="Loom product overview" author="Loom" embed="https://www.loom.com/embed/09b1aa507cb846138847bf8e98b56a71"></Loom>
+
+Twitch だけは例外です。player は埋め込み先ドメインを宣言しないと読み込みを拒否する
+ため、player URL は `embeds.twitch.parent` に安全なドメインを指定したときだけ生成
+されます。指定がなければカードは静的なままなので、`title`、`channel`、`duration`、
+`status`、`views`、`image` で見せる価値のあるカードにします。
+
+<Twitch url="https://www.twitch.tv/twitchdev" title="TwitchDev" channel="twitchdev" status="Offline" views="1.4M"></Twitch>
+
+### コミュニティと social post
+
+`embeds.discord`、`embeds.fediverse`、`embeds.facebook`、`embeds.threads`、
+`embeds.instagram` は同じカード形状を共有します（著者、本文、時刻、リアクション数）。
+`<Fediverse>`、`<Mastodon>`、`<Misskey>`、`<Mixi2>` は同じオプションで、instance は
+URL から読み取ります。
+
+```mdx
 <Mastodon
-  url="https://mastodon.social/@docs/111"
-  author="@docs@mastodon.social"
-  replies="3"
-  reposts="5"
-  likes="8"
+  url="https://mastodon.social/@Mastodon/117117221397911074"
+  author="@Mastodon@mastodon.social"
+  reposts="622"
+  likes="954"
 >
-  Fediverse release note.
+  Mastodon 5.0 の最初のお披露目。
 </Mastodon>
 ```
 
-| オプション | 既定      | 目的                                                  |
-| ---------- | --------- | ----------------------------------------------------- |
-| `fetch`    | `true`    | 記事 / package / playground / video metadata を取る。 |
-| `timeout`  | `10000`   | metadata リクエストのタイムアウト（ミリ秒）。         |
-| `cache`    | `true`    | このビルド中に取った metadata をメモリに残す。        |
-| `cacheTTL` | `3600000` | キャッシュの鮮度期間（ミリ秒）。                      |
-| `iframe`   | `false`   | playground/video の lazy iframe URL を追加する。      |
-| `parent`   | `[]`      | Twitch iframe の parent domain。                      |
+<Mastodon url="https://mastodon.social/@Mastodon/117117221397911074" author="@Mastodon@mastodon.social" reposts="622" likes="954" dateTime="2026-08-18" dateLabel="2026-08-18">Discovery Week の結果公開に続いて、Mastodon 5.0 を最初にお披露目します。</Mastodon>
 
-CodeSandbox はサンドボックスの 4 つの URL 形式すべてを受け付けます（`/s/{id}`、`/p/sandbox/{id}`、`/p/devbox/{id}`、`/embed/{id}`）。他のプレイグラウンドと違いフェッチは行いません。カードは URL と渡した属性だけから組み立てるので、削除済みのサンドボックスでもビルドを失敗させず、そこを指すカードを描画します。
+<Discord url="https://discord.com/invite/vue" title="Vue Land" server="Vue Land" channel="#vue-vapor">Vue とそのエコシステムのコミュニティサーバ。</Discord>
 
-`cache` だけならビルド 1 回分の寿命です。`persistCache: true` にするとメタデータをディスクにも書くので、クリーンビルドや新しい CI ワーカーでも、前回取得した内容を再利用して各プロバイダに問い合わせ直しません。何も見つからなかった照会も記憶するため、落ちているプロバイダを毎ビルド埋め込みごとに再試行することはありません。壊れたエントリはビルドを失敗させず破棄して取り直し、ディレクトリはハッシュをキーにするので、プロバイダ URL がその外に出ることはありません。
+<Facebook url="https://www.facebook.com/facebook" title="Facebook" author="Facebook">著者・本文・カウントを渡すだけで、Facebook の SDK は読み込みません。</Facebook>
 
-`<Fediverse>`、`<Mastodon>`、`<Misskey>`、`<Mixi2>` は
-`embeds.fediverse` を共有します。Google Maps は安全な Google Maps `embed`
-URL を渡したときだけ lazy iframe も出し、それ以外はリンクカードになります。
-package registry カードは npm、crates.io、PyPI、Docker Hub の package URL
-に対応し、provider が持つ version / tag URL も扱えます。未対応 scheme、
-認証情報つき URL、別 host の URL、取得できない metadata は、ビルドを落とさず
-元のタグかリンクカードへフォールバックします。package metadata fetch の失敗時は、
-status や error reason を含む `[ox-content]` warning も出します。
-Vimeo card は Vimeo の public oEmbed endpoint から metadata を取得します。
-Twitch card は既定では認証 API を呼ばないため、よりリッチな静的 metadata が必要なときは
-`title`、`channel`、`duration`、`status`、`views`、`image` を渡します。
-Twitch player URL は Twitch の embed 要件に合わせ、安全な `parent` domain が設定された
-ときだけ生成されます。
+<Threads url="https://www.threads.net/@instagram" title="@instagram on Threads" author="@instagram" replies="1.2K" likes="18K">Threads の投稿も同じカードで描画されます。</Threads>
+
+<Instagram url="https://www.instagram.com/instagram/" title="@instagram" author="@instagram" likes="24K">Instagram カードも静的なままで、embed スクリプトは読み込みません。</Instagram>
+
+### プロバイダのオプション
+
+| オプション     | 既定値                        | 用途                                              |
+| -------------- | ----------------------------- | ------------------------------------------------- |
+| `fetch`        | `true`                        | 記事・package・playground・動画の metadata を取得 |
+| `timeout`      | `10000`                       | metadata リクエストのタイムアウト (ms)            |
+| `cache`        | `true`                        | このビルド中、metadata をメモリにキャッシュ       |
+| `cacheTTL`     | `3600000`                     | 鮮度のウィンドウ (ms)                             |
+| `persistCache` | `false`                       | ビルドをまたいで metadata をディスクに保持        |
+| `cacheDir`     | `.cache/ox-content/providers` | 永続キャッシュのディレクトリ                      |
+| `iframe`       | `false`                       | playground / 動画の lazy iframe URL を付与        |
+| `parent`       | `[]`                          | Twitch iframe の parent ドメイン                  |
+
+`iframe` は *導出* される embed の話です。渡されたページ URL から provider が player
+URL を組み立てられるようにします。明示的な `embed` 属性はどちらの設定でも効きます。
+
+`cache` だけなら 1 ビルド分の寿命です。`persistCache: true` にすると metadata を
+ディスクにも書くので、クリーンビルドや新しい CI ワーカーが前回の取得結果を再利用します。
+見つからなかった lookup も記憶するため、落ちている provider をビルドのたびに embed の
+数だけ再試行することはありません。壊れたエントリはビルドを落とさず破棄して取り直し、
+ディレクトリは hash で鍵付けされるので、provider URL がその外へ出ることはありません。
+
+未対応 scheme、認証情報つき URL、別 host の URL、取得できない metadata は、ビルドを
+落とさず元のタグかリンクカードへフォールバックします。package metadata fetch の失敗時は、
+status や error reason を含む `[ox-content]` warning も出します。Vimeo card は Vimeo の
+public oEmbed endpoint から metadata を取得し、Twitch card は既定では認証 API を
+呼びません。
 
 ## Spotify
 


### PR DESCRIPTION
## Summary

- The **Provider Cards** section rendered five live cards and then dumped every other provider into one 60-line `mdx` fence. Google Maps, Qiita, Zenn, note, npm, the playgrounds, Figma, the video providers and the social cards existed only as code, and several URLs in that fence (`qiita.com/ubugeeei/items/abcdef123456`, `codepen.io/ubugeeei/pen/abc123`, `figma.com/design/AbC123xyz/Design-System`, …) pointed at nothing.
- Split it into one subsection per provider group — Maps, Articles, Package registries, Playgrounds, Design files and slides, Video and terminal recordings, Communities and social posts, Provider options — each with the tag that produced the card directly above the card itself.
- Every tag now uses a real, checked URL and carries the metadata that makes the card worth looking at (author, date, tags, likes, version, license, downloads, duration…).
- **Eight cards carry a live embed instead of a link**: Google Maps, CodePen, Observable, JSFiddle, Google Slides, Vimeo, asciinema, Loom. All eight were confirmed returning `200` and rendering in the dev build.
- Both `docs/content/built-in/embeds.md` and `docs/content/ja/built-in/embeds.md` are updated.

### One renderer change came with it

`render_figma` matched only `file`, `design`, `board`, `proto` and `slides` as the **first** path segment, so `figma.com/community/file/{key}/{slug}` — the link Figma hands you for a Community file, and the one people actually paste — did not render a card at all. It now accepts the Community form, which is what let the documented example become a real file.

### Two things I hit and worked around rather than fixed

1. **Attributes are read without decoding entities.** The renderer escapes `&` to `&amp;` on the way out, but the value it was handed had already been escaped upstream, so a URL written as `?a=1&b=2` reaches the browser as `?a=1&#x26;b=2`. That is why the Figma card here is metadata-only: its embed URL needs `embed_host` *and* `url`. The same applies to `'` in an attribute (`Vue 3's` → `Vue 3&#x27;s`), so the copy uses `’`.
2. Twitch still has no inline player, by design — its embed requires `embeds.twitch.parent`, which this site does not set.

Both are worth their own issues; neither is in scope here.

## Risk

- Risk level: low
- User or production impact: docs content, plus one widened URL match in the Figma card. Existing Figma URL shapes are untouched.
- Rollback plan: revert the commit.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_transform` (559 passed) with the Community URL added to `figma_file_design_and_prototype_all_render`; `vp run check:ts` (0 errors).
- [x] Manual verification completed: built the docs with `vp dev` and walked both locales. 25 cards render on each page, 0 tags left as raw text, 0 double-escaped entities in card text, and all 8 embed iframes return `200`. Screenshotted the Maps, Articles, Playgrounds and Communities sections.
- [x] Edge cases or failure modes considered: `.md` requires each tag to open and close on one line (no MDX here), so the live tags are single-line and the multi-line form appears only inside fences. The `fetch: false` providers build without network, which the section now says explicitly.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed. Every `embed` is still validated against the provider's own host and path; the Figma change widens a path match, not a host allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790588534&installation_model_id=422833&pr_number=1192&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1192&signature=d8bbef56536420539b9c2e766569009ad859fc01bc5abe3765cd3c584d0e2e24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Figma Community links now render as provider cards.
  * Provider cards support lazy-loaded, provider-validated embeds.
  * Added provider card support and examples for Note, Loom, asciinema, Figma, Google Slides, Replit, Discord, Facebook, Threads, and Instagram.
  * Google Maps and Twitch embed behavior and configuration options are now documented.

* **Documentation**
  * Expanded and reorganized provider card guidance in English and Japanese.
  * Clarified metadata, caching, network request, and embed failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->