### PR TITLE
fix(ssg): give the docs a real mobile type scale and rhythm

### DIFF
--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
@@ -2032,11 +2032,52 @@ a:hover {
   .ox-breadcrumbs-item:not(:last-child)::after {
     margin-inline: 0.25rem;
   }
+  /* The desktop rhythm scaled for a phone: body blocks 0.875rem apart, framed
+   * blocks 1rem, headings still clearing more above than below. The steps keep
+   * the same relationships, just sized for a 360-420px column. */
   .content h1 {
     font-size: 1.5rem;
+    /* 1.08 is a display line-height for a title that never wraps. A mobile
+     * title almost always wraps, and at 24px those lines collide. */
+    line-height: 1.25;
+    letter-spacing: -0.02em;
+    margin-bottom: 0.75rem;
   }
   .content h2 {
-    font-size: 1.2rem;
+    font-size: 1.25rem;
+    margin-top: 2rem;
+    margin-bottom: 0.6rem;
+  }
+  /* h2 was scaled down here and h3 was not, so an h3 rendered larger than the
+   * h2 above it and the section hierarchy read backwards. */
+  .content h3 {
+    font-size: 1.0625rem;
+    margin-top: 1.5rem;
+    margin-bottom: 0.4rem;
+  }
+  .content h2 + h3 {
+    margin-top: 1rem;
+  }
+  .content h4 {
+    font-size: 0.9375rem;
+    margin-top: 1.15rem;
+    margin-bottom: 0.3rem;
+  }
+  .content p {
+    margin-bottom: 0.875rem;
+  }
+  .content ul,
+  .content ol {
+    margin: 0.875rem 0;
+    padding-left: 1.25rem;
+  }
+  .content blockquote,
+  .content table,
+  .content figure,
+  /* The code wrapper is also styled by a sheet concatenated after this one, so
+   * it needs the extra specificity to win. */
+  .content .ox-code {
+    margin-block: 1rem;
   }
   .content code {
     font-size: 0.82em;
@@ -2248,6 +2289,17 @@ a:hover {
   }
   .content h1 {
     font-size: 1.35rem;
+  }
+  .content h2 {
+    font-size: 1.15rem;
+    margin-top: 1.75rem;
+  }
+  .content h3 {
+    font-size: 1rem;
+    margin-top: 1.25rem;
+  }
+  .content h4 {
+    font-size: 0.9rem;
   }
   .content code {
     font-size: 0.8em;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
@@ -2029,11 +2029,52 @@ a:hover {
   .ox-breadcrumbs-item:not(:last-child)::after {
     margin-inline: 0.25rem;
   }
+  /* The desktop rhythm scaled for a phone: body blocks 0.875rem apart, framed
+   * blocks 1rem, headings still clearing more above than below. The steps keep
+   * the same relationships, just sized for a 360-420px column. */
   .content h1 {
     font-size: 1.5rem;
+    /* 1.08 is a display line-height for a title that never wraps. A mobile
+     * title almost always wraps, and at 24px those lines collide. */
+    line-height: 1.25;
+    letter-spacing: -0.02em;
+    margin-bottom: 0.75rem;
   }
   .content h2 {
-    font-size: 1.2rem;
+    font-size: 1.25rem;
+    margin-top: 2rem;
+    margin-bottom: 0.6rem;
+  }
+  /* h2 was scaled down here and h3 was not, so an h3 rendered larger than the
+   * h2 above it and the section hierarchy read backwards. */
+  .content h3 {
+    font-size: 1.0625rem;
+    margin-top: 1.5rem;
+    margin-bottom: 0.4rem;
+  }
+  .content h2 + h3 {
+    margin-top: 1rem;
+  }
+  .content h4 {
+    font-size: 0.9375rem;
+    margin-top: 1.15rem;
+    margin-bottom: 0.3rem;
+  }
+  .content p {
+    margin-bottom: 0.875rem;
+  }
+  .content ul,
+  .content ol {
+    margin: 0.875rem 0;
+    padding-left: 1.25rem;
+  }
+  .content blockquote,
+  .content table,
+  .content figure,
+  /* The code wrapper is also styled by a sheet concatenated after this one, so
+   * it needs the extra specificity to win. */
+  .content .ox-code {
+    margin-block: 1rem;
   }
   .content code {
     font-size: 0.82em;
@@ -2245,6 +2286,17 @@ a:hover {
   }
   .content h1 {
     font-size: 1.35rem;
+  }
+  .content h2 {
+    font-size: 1.15rem;
+    margin-top: 1.75rem;
+  }
+  .content h3 {
+    font-size: 1rem;
+    margin-top: 1.25rem;
+  }
+  .content h4 {
+    font-size: 0.9rem;
   }
   .content code {
     font-size: 0.8em;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
@@ -2029,11 +2029,52 @@ a:hover {
   .ox-breadcrumbs-item:not(:last-child)::after {
     margin-inline: 0.25rem;
   }
+  /* The desktop rhythm scaled for a phone: body blocks 0.875rem apart, framed
+   * blocks 1rem, headings still clearing more above than below. The steps keep
+   * the same relationships, just sized for a 360-420px column. */
   .content h1 {
     font-size: 1.5rem;
+    /* 1.08 is a display line-height for a title that never wraps. A mobile
+     * title almost always wraps, and at 24px those lines collide. */
+    line-height: 1.25;
+    letter-spacing: -0.02em;
+    margin-bottom: 0.75rem;
   }
   .content h2 {
-    font-size: 1.2rem;
+    font-size: 1.25rem;
+    margin-top: 2rem;
+    margin-bottom: 0.6rem;
+  }
+  /* h2 was scaled down here and h3 was not, so an h3 rendered larger than the
+   * h2 above it and the section hierarchy read backwards. */
+  .content h3 {
+    font-size: 1.0625rem;
+    margin-top: 1.5rem;
+    margin-bottom: 0.4rem;
+  }
+  .content h2 + h3 {
+    margin-top: 1rem;
+  }
+  .content h4 {
+    font-size: 0.9375rem;
+    margin-top: 1.15rem;
+    margin-bottom: 0.3rem;
+  }
+  .content p {
+    margin-bottom: 0.875rem;
+  }
+  .content ul,
+  .content ol {
+    margin: 0.875rem 0;
+    padding-left: 1.25rem;
+  }
+  .content blockquote,
+  .content table,
+  .content figure,
+  /* The code wrapper is also styled by a sheet concatenated after this one, so
+   * it needs the extra specificity to win. */
+  .content .ox-code {
+    margin-block: 1rem;
   }
   .content code {
     font-size: 0.82em;
@@ -2245,6 +2286,17 @@ a:hover {
   }
   .content h1 {
     font-size: 1.35rem;
+  }
+  .content h2 {
+    font-size: 1.15rem;
+    margin-top: 1.75rem;
+  }
+  .content h3 {
+    font-size: 1rem;
+    margin-top: 1.25rem;
+  }
+  .content h4 {
+    font-size: 0.9rem;
   }
   .content code {
     font-size: 0.8em;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
@@ -2029,11 +2029,52 @@ a:hover {
   .ox-breadcrumbs-item:not(:last-child)::after {
     margin-inline: 0.25rem;
   }
+  /* The desktop rhythm scaled for a phone: body blocks 0.875rem apart, framed
+   * blocks 1rem, headings still clearing more above than below. The steps keep
+   * the same relationships, just sized for a 360-420px column. */
   .content h1 {
     font-size: 1.5rem;
+    /* 1.08 is a display line-height for a title that never wraps. A mobile
+     * title almost always wraps, and at 24px those lines collide. */
+    line-height: 1.25;
+    letter-spacing: -0.02em;
+    margin-bottom: 0.75rem;
   }
   .content h2 {
-    font-size: 1.2rem;
+    font-size: 1.25rem;
+    margin-top: 2rem;
+    margin-bottom: 0.6rem;
+  }
+  /* h2 was scaled down here and h3 was not, so an h3 rendered larger than the
+   * h2 above it and the section hierarchy read backwards. */
+  .content h3 {
+    font-size: 1.0625rem;
+    margin-top: 1.5rem;
+    margin-bottom: 0.4rem;
+  }
+  .content h2 + h3 {
+    margin-top: 1rem;
+  }
+  .content h4 {
+    font-size: 0.9375rem;
+    margin-top: 1.15rem;
+    margin-bottom: 0.3rem;
+  }
+  .content p {
+    margin-bottom: 0.875rem;
+  }
+  .content ul,
+  .content ol {
+    margin: 0.875rem 0;
+    padding-left: 1.25rem;
+  }
+  .content blockquote,
+  .content table,
+  .content figure,
+  /* The code wrapper is also styled by a sheet concatenated after this one, so
+   * it needs the extra specificity to win. */
+  .content .ox-code {
+    margin-block: 1rem;
   }
   .content code {
     font-size: 0.82em;
@@ -2245,6 +2286,17 @@ a:hover {
   }
   .content h1 {
     font-size: 1.35rem;
+  }
+  .content h2 {
+    font-size: 1.15rem;
+    margin-top: 1.75rem;
+  }
+  .content h3 {
+    font-size: 1rem;
+    margin-top: 1.25rem;
+  }
+  .content h4 {
+    font-size: 0.9rem;
   }
   .content code {
     font-size: 0.8em;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
@@ -2029,11 +2029,52 @@ a:hover {
   .ox-breadcrumbs-item:not(:last-child)::after {
     margin-inline: 0.25rem;
   }
+  /* The desktop rhythm scaled for a phone: body blocks 0.875rem apart, framed
+   * blocks 1rem, headings still clearing more above than below. The steps keep
+   * the same relationships, just sized for a 360-420px column. */
   .content h1 {
     font-size: 1.5rem;
+    /* 1.08 is a display line-height for a title that never wraps. A mobile
+     * title almost always wraps, and at 24px those lines collide. */
+    line-height: 1.25;
+    letter-spacing: -0.02em;
+    margin-bottom: 0.75rem;
   }
   .content h2 {
-    font-size: 1.2rem;
+    font-size: 1.25rem;
+    margin-top: 2rem;
+    margin-bottom: 0.6rem;
+  }
+  /* h2 was scaled down here and h3 was not, so an h3 rendered larger than the
+   * h2 above it and the section hierarchy read backwards. */
+  .content h3 {
+    font-size: 1.0625rem;
+    margin-top: 1.5rem;
+    margin-bottom: 0.4rem;
+  }
+  .content h2 + h3 {
+    margin-top: 1rem;
+  }
+  .content h4 {
+    font-size: 0.9375rem;
+    margin-top: 1.15rem;
+    margin-bottom: 0.3rem;
+  }
+  .content p {
+    margin-bottom: 0.875rem;
+  }
+  .content ul,
+  .content ol {
+    margin: 0.875rem 0;
+    padding-left: 1.25rem;
+  }
+  .content blockquote,
+  .content table,
+  .content figure,
+  /* The code wrapper is also styled by a sheet concatenated after this one, so
+   * it needs the extra specificity to win. */
+  .content .ox-code {
+    margin-block: 1rem;
   }
   .content code {
     font-size: 0.82em;
@@ -2245,6 +2286,17 @@ a:hover {
   }
   .content h1 {
     font-size: 1.35rem;
+  }
+  .content h2 {
+    font-size: 1.15rem;
+    margin-top: 1.75rem;
+  }
+  .content h3 {
+    font-size: 1rem;
+    margin-top: 1.25rem;
+  }
+  .content h4 {
+    font-size: 0.9rem;
   }
   .content code {
     font-size: 0.8em;

--- a/crates/ox_content_ssg/src/ssg.css
+++ b/crates/ox_content_ssg/src/ssg.css
@@ -1963,11 +1963,52 @@ a:hover {
   .ox-breadcrumbs-item:not(:last-child)::after {
     margin-inline: 0.25rem;
   }
+  /* The desktop rhythm scaled for a phone: body blocks 0.875rem apart, framed
+   * blocks 1rem, headings still clearing more above than below. The steps keep
+   * the same relationships, just sized for a 360-420px column. */
   .content h1 {
     font-size: 1.5rem;
+    /* 1.08 is a display line-height for a title that never wraps. A mobile
+     * title almost always wraps, and at 24px those lines collide. */
+    line-height: 1.25;
+    letter-spacing: -0.02em;
+    margin-bottom: 0.75rem;
   }
   .content h2 {
-    font-size: 1.2rem;
+    font-size: 1.25rem;
+    margin-top: 2rem;
+    margin-bottom: 0.6rem;
+  }
+  /* h2 was scaled down here and h3 was not, so an h3 rendered larger than the
+   * h2 above it and the section hierarchy read backwards. */
+  .content h3 {
+    font-size: 1.0625rem;
+    margin-top: 1.5rem;
+    margin-bottom: 0.4rem;
+  }
+  .content h2 + h3 {
+    margin-top: 1rem;
+  }
+  .content h4 {
+    font-size: 0.9375rem;
+    margin-top: 1.15rem;
+    margin-bottom: 0.3rem;
+  }
+  .content p {
+    margin-bottom: 0.875rem;
+  }
+  .content ul,
+  .content ol {
+    margin: 0.875rem 0;
+    padding-left: 1.25rem;
+  }
+  .content blockquote,
+  .content table,
+  .content figure,
+  /* The code wrapper is also styled by a sheet concatenated after this one, so
+   * it needs the extra specificity to win. */
+  .content .ox-code {
+    margin-block: 1rem;
   }
   .content code {
     font-size: 0.82em;
@@ -2179,6 +2220,17 @@ a:hover {
   }
   .content h1 {
     font-size: 1.35rem;
+  }
+  .content h2 {
+    font-size: 1.15rem;
+    margin-top: 1.75rem;
+  }
+  .content h3 {
+    font-size: 1rem;
+    margin-top: 1.25rem;
+  }
+  .content h4 {
+    font-size: 0.9rem;
   }
   .content code {
     font-size: 0.8em;


### PR DESCRIPTION
## Summary

Below 768px the stylesheet resized `h1` and `h2` and left everything else at its desktop value, so a phone got a desktop rhythm in a 360px column.

- **`h3` rendered larger than the `h2` above it** — 1.25rem against 1.2rem — so section hierarchy read backwards. `h3` and `h4` now have mobile sizes and the scale stays monotonic at every width: **24 / 20 / 17 / 15** at 768px and **21.6 / 18.4 / 16 / 14.4** at 480px.
- **`h1` kept the 1.08 display line-height**, which only works for a title that never wraps. A mobile title almost always wraps, and at 24px the two lines collided. Now 1.25, with the tracking relaxed from -0.045em to -0.02em to match the smaller size.
- **Heading clearance was desktop-sized**: 2.75rem above an `h2`, 2rem above an `h3`. Now 2rem / 1.5rem, and 1.75rem / 1.25rem below 480px — keeping the "clear more above than below" relationship the desktop rhythm is built on.
- **Block spacing scaled proportionally**: body blocks 1rem → 0.875rem, framed blocks (quotes, tables, figures, code) 1.25rem → 1rem. Same ratio as desktop, sized for the narrower column.
- List indent 1.5rem → 1.25rem, which was pure lost width at 360px.

Nothing above 768px changes.

### Left out on purpose

A wide table still scrolls with no visual affordance on touch, where the browser hides the scrollbar — it just looks cropped. The obvious fix is the local/scroll gradient shadow, but `default_theme_surfaces_stay_flat` bans gradients and shadows from the default theme, and picking a flat alternative is a design call rather than a spacing one. Worth its own issue.

## Risk

- Risk level: low
- User or production impact: CSS only, and only inside `@media (max-width: 768px)` and `(max-width: 480px)`. Desktop rendering is byte-identical.
- Rollback plan: revert the commit.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_ssg` (278 passed); the five HTML snapshots are regenerated.
- [x] Manual verification completed: built the docs with `vp dev` and measured computed styles at 360, 390, 768 and 1024px across the entry page, `getting-started`, `built-in/markdown`, `built-in/cards` and `built-in/embeds`. Confirmed the scale is monotonic at each width, that `document.scrollWidth === innerWidth` at 360px (no horizontal overflow), and that 1024px still reports the pre-change values (h1 49.6px, h2 24/44px, h3 20/32px).
- [x] Edge cases or failure modes considered: `.ox-code` is styled by a sheet concatenated after this one, so the wrapper override needs `.content .ox-code` to win the cascade — verified as 16px rather than 20px in the running build. The entry page already has its own mobile pass and is untouched.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed. The mobile block now carries the same rhythm comment the desktop rules do.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790589250&installation_model_id=422833&pr_number=1193&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1193&signature=08fb1204d6f0491d0e96d681725ab8261f1c54d33079eda6e6987e343d4b9262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->