### PR TITLE
docs(embeds): name every package-registry metric

### DIFF
--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -551,8 +551,9 @@ numbers stay pinned to whatever you wrote:
 ### Package registries
 
 `embeds.packageRegistry` covers npm, crates.io, PyPI and Docker Hub, including
-version and tag URLs where the provider exposes one. `version`, `downloads`,
-`license` and `stars` render as metrics:
+version and tag URLs where the provider exposes one. `version`, `license`,
+`repository`, `downloads` and `stars` render as metrics, and `downloads` also
+answers to `pulls` — which is what the Docker Hub card below passes:
 
 ```mdx
 <NpmPackage

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -439,8 +439,9 @@ fetch します。このサイトのように `fetch: false` にすると、カ�
 ### パッケージレジストリ
 
 `embeds.packageRegistry` は npm、crates.io、PyPI、Docker Hub に対応し、provider が
-持つ version / tag URL も扱えます。`version`、`downloads`、`license`、`stars` は
-メトリクスとして描画されます。
+持つ version / tag URL も扱えます。`version`、`license`、`repository`、`downloads`、
+`stars` がメトリクスとして描画されます。`downloads` は `pulls` という綴りでも受け取り、
+下の Docker Hub カードはそちらを渡しています。
 
 ```mdx
 <NpmPackage


### PR DESCRIPTION
## Summary

Follow-up to [#1192](https://github.com/ubugeeei-prod/ox-content/pull/1192), from a CodeRabbit comment that landed after it merged.

The Package registries section listed `version`, `downloads`, `license` and `stars` as the metrics a card renders, but `package_cards.rs` also emits `Repository`, and the Docker Hub example two lines below passes `pulls` — an attribute the prose never mentioned, which made the example look like it used something undocumented. `pulls` is one of the four spellings `downloads` accepts (`downloads`, `downloadCount`, `pulls`, `pullCount`) and renders under the same **Downloads** label.

Both language versions now list all five metrics and say that `pulls` is the spelling the Docker Hub card uses.

## Risk

- Risk level: low
- User or production impact: two sentences of docs prose. No code, no rendering change.
- Rollback plan: revert the commit.

## Validation

- [x] Automated tests or checks run: `vp check` (0 errors) — the Markdown formatter runs in that job, which is what caught the earlier formatting miss on #1192.
- [x] Manual verification completed: read the metric list back off `crates/ox_content_transform/src/media_embeds/package_cards.rs` — `Version`, `License`, `Repository`, `Downloads`, `Stars`, with `downloads` resolved from `["downloads", "downloadCount", "pulls", "pullCount"]`.
- [x] Edge cases or failure modes considered: none — prose only.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790592928&installation_model_id=422833&pr_number=1194&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1194&signature=c82208ae926d46311f32ef0fa0116eee981d82cc1b1d70d147f075fcf55c5057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated package registry embed documentation to include the `repository` metric.
  * Clarified that `downloads` can also be specified as `pulls`, including in the Docker Hub example.
  * Added details about supported provider version/tag URLs in the Japanese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->