### PR TITLE
fix(ssg): stop the whole page sinking dark during navigation

### DIFF
--- a/crates/ox_content_ssg/src/html/mpa_navigation.css
+++ b/crates/ox_content_ssg/src/html/mpa_navigation.css
@@ -3,51 +3,16 @@
     navigation: auto;
   }
 
-  /* The header, sidebar and mobile footer are identical on both sides of a docs
-     navigation, so leaving them inside the `root` snapshot animates them for no
-     reason. Naming them lifts each into its own group, which the UA leaves
-     alone when the old and new snapshots match. The names are the ones the
-     theme skins already use, so a skin that animates them still wins. Selectors
-     stay anchored to the layout: a duplicate name anywhere in the document
-     aborts the whole transition, and `.header` is a plausible class for page
-     content to carry. */
-  body > .header {
-    view-transition-name: octc-header;
-  }
-  #ox-sidebar {
-    view-transition-name: octc-sidebar;
-  }
-  body > .mobile-footer {
-    view-transition-name: octc-mobile-footer;
-  }
-
-  /* The UA cross-fade composites the two root snapshots with `plus-lighter`.
-     That only stays neutral while both snapshots are fully opaque: any region
-     the root paints as transparent — the page background included, when it is
-     propagated to the canvas from `body` instead of being owned by `html` — is
-     added to itself and the page visibly brightens partway through. Holding the
-     outgoing snapshot opaque and fading the incoming one in over it keeps the
-     stack at full coverage for the whole animation, so neither the blend nor
-     the browser's own base color can show through. */
-  ::view-transition-old(root),
-  ::view-transition-new(root) {
-    mix-blend-mode: normal;
-  }
-
-  ::view-transition-old(root) {
-    animation: none;
-    opacity: 1;
-  }
-
-  ::view-transition-new(root) {
-    animation-name: octc-view-transition-in;
-    animation-duration: var(--octc-motion-base, 150ms);
-    animation-timing-function: var(--octc-motion-ease, ease);
-  }
-}
-
-@keyframes octc-view-transition-in {
-  from {
-    opacity: 0;
+  /* The page background is propagated to the canvas, so it is painted outside
+     the root element and never lands in the `root` snapshot. Anything the
+     snapshots leave transparent therefore falls through the pseudo tree to
+     whatever the compositor has behind it, which is not the page. The UA
+     cross-fade hides that — `plus-lighter` is chosen precisely so the outgoing
+     and incoming alphas sum back to one — but only while it is running.
+     Painting the page color on the overlay itself removes the dependency, so a
+     browser whose blend arrives late, or a transition that is skipped partway,
+     still has the page color behind it rather than a black or white gap. */
+  ::view-transition {
+    background-color: var(--octc-color-bg);
   }
 }

--- a/crates/ox_content_ssg/src/html/mpa_navigation.rs
+++ b/crates/ox_content_ssg/src/html/mpa_navigation.rs
@@ -31,27 +31,24 @@ mod tests {
     }
 
     #[test]
-    fn root_cross_fade_is_overridden_to_stay_opaque() {
-        // The UA cross-fade adds the two root snapshots together with
-        // `plus-lighter`; anything the root leaves transparent is then counted
-        // twice and the page brightens partway through the navigation.
-        assert!(MPA_NAVIGATION_CSS.contains("::view-transition-old(root)"));
-        assert!(MPA_NAVIGATION_CSS.contains("::view-transition-new(root)"));
-        assert!(MPA_NAVIGATION_CSS.contains("mix-blend-mode: normal"));
+    fn the_transition_overlay_carries_the_page_background() {
+        // The page background is propagated to the canvas, so it is painted
+        // outside the root element and is missing from the `root` snapshot.
+        // Whatever the snapshots leave transparent has to land on the page
+        // color rather than on the compositor's own backdrop.
+        assert!(MPA_NAVIGATION_CSS.contains("::view-transition {"));
+        assert!(MPA_NAVIGATION_CSS.contains("background-color: var(--octc-color-bg);"));
     }
 
     #[test]
-    fn persistent_chrome_is_named_out_of_the_root_snapshot() {
-        for name in ["octc-header", "octc-sidebar", "octc-mobile-footer"] {
-            assert!(MPA_NAVIGATION_CSS.contains(name), "missing {name}");
-        }
-    }
-
-    #[test]
-    fn root_element_owns_the_canvas_background() {
-        // A `body`-only background is propagated to the canvas, which leaves the
-        // repaint behind a cross-document transition to the UA default color.
-        assert!(super::super::SSG_CSS.contains("background-color: var(--octc-color-bg);"));
+    fn the_ua_cross_fade_is_left_alone() {
+        // `plus-lighter` is what makes the outgoing and incoming alphas sum
+        // back to one over a transparent snapshot. Overriding it to `normal`
+        // sinks the whole page toward the backdrop partway through.
+        assert!(!MPA_NAVIGATION_CSS.contains("mix-blend-mode"));
+        assert!(!MPA_NAVIGATION_CSS.contains("view-transition-name"));
+        assert!(!MPA_NAVIGATION_CSS.contains("::view-transition-old"));
+        assert!(!MPA_NAVIGATION_CSS.contains("::view-transition-new"));
     }
 
     #[test]

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
@@ -181,11 +181,6 @@ expression: "super::snapshot_text(&html)"
 }
 
 html {
-  /* The canvas background has to be owned by the root element, not inherited
-     from `body`: it is what the browser paints behind a cross-document view
-     transition and in the gap between two documents, and a `body`-only
-     background leaves that repaint to the UA default. */
-  background-color: var(--octc-color-bg);
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
   scroll-padding-top: calc(var(--octc-header-height) + 1rem);
@@ -2341,52 +2336,17 @@ a:hover {
     navigation: auto;
   }
 
-  /* The header, sidebar and mobile footer are identical on both sides of a docs
-     navigation, so leaving them inside the `root` snapshot animates them for no
-     reason. Naming them lifts each into its own group, which the UA leaves
-     alone when the old and new snapshots match. The names are the ones the
-     theme skins already use, so a skin that animates them still wins. Selectors
-     stay anchored to the layout: a duplicate name anywhere in the document
-     aborts the whole transition, and `.header` is a plausible class for page
-     content to carry. */
-  body > .header {
-    view-transition-name: octc-header;
-  }
-  #ox-sidebar {
-    view-transition-name: octc-sidebar;
-  }
-  body > .mobile-footer {
-    view-transition-name: octc-mobile-footer;
-  }
-
-  /* The UA cross-fade composites the two root snapshots with `plus-lighter`.
-     That only stays neutral while both snapshots are fully opaque: any region
-     the root paints as transparent — the page background included, when it is
-     propagated to the canvas from `body` instead of being owned by `html` — is
-     added to itself and the page visibly brightens partway through. Holding the
-     outgoing snapshot opaque and fading the incoming one in over it keeps the
-     stack at full coverage for the whole animation, so neither the blend nor
-     the browser's own base color can show through. */
-  ::view-transition-old(root),
-  ::view-transition-new(root) {
-    mix-blend-mode: normal;
-  }
-
-  ::view-transition-old(root) {
-    animation: none;
-    opacity: 1;
-  }
-
-  ::view-transition-new(root) {
-    animation-name: octc-view-transition-in;
-    animation-duration: var(--octc-motion-base, 150ms);
-    animation-timing-function: var(--octc-motion-ease, ease);
-  }
-}
-
-@keyframes octc-view-transition-in {
-  from {
-    opacity: 0;
+  /* The page background is propagated to the canvas, so it is painted outside
+     the root element and never lands in the `root` snapshot. Anything the
+     snapshots leave transparent therefore falls through the pseudo tree to
+     whatever the compositor has behind it, which is not the page. The UA
+     cross-fade hides that — `plus-lighter` is chosen precisely so the outgoing
+     and incoming alphas sum back to one — but only while it is running.
+     Painting the page color on the overlay itself removes the dependency, so a
+     browser whose blend arrives late, or a transition that is skipped partway,
+     still has the page color behind it rather than a black or white gap. */
+  ::view-transition {
+    background-color: var(--octc-color-bg);
   }
 }
 

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
@@ -178,11 +178,6 @@ expression: "super::snapshot_text(&html)"
 }
 
 html {
-  /* The canvas background has to be owned by the root element, not inherited
-     from `body`: it is what the browser paints behind a cross-document view
-     transition and in the gap between two documents, and a `body`-only
-     background leaves that repaint to the UA default. */
-  background-color: var(--octc-color-bg);
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
   scroll-padding-top: calc(var(--octc-header-height) + 1rem);
@@ -2338,52 +2333,17 @@ a:hover {
     navigation: auto;
   }
 
-  /* The header, sidebar and mobile footer are identical on both sides of a docs
-     navigation, so leaving them inside the `root` snapshot animates them for no
-     reason. Naming them lifts each into its own group, which the UA leaves
-     alone when the old and new snapshots match. The names are the ones the
-     theme skins already use, so a skin that animates them still wins. Selectors
-     stay anchored to the layout: a duplicate name anywhere in the document
-     aborts the whole transition, and `.header` is a plausible class for page
-     content to carry. */
-  body > .header {
-    view-transition-name: octc-header;
-  }
-  #ox-sidebar {
-    view-transition-name: octc-sidebar;
-  }
-  body > .mobile-footer {
-    view-transition-name: octc-mobile-footer;
-  }
-
-  /* The UA cross-fade composites the two root snapshots with `plus-lighter`.
-     That only stays neutral while both snapshots are fully opaque: any region
-     the root paints as transparent — the page background included, when it is
-     propagated to the canvas from `body` instead of being owned by `html` — is
-     added to itself and the page visibly brightens partway through. Holding the
-     outgoing snapshot opaque and fading the incoming one in over it keeps the
-     stack at full coverage for the whole animation, so neither the blend nor
-     the browser's own base color can show through. */
-  ::view-transition-old(root),
-  ::view-transition-new(root) {
-    mix-blend-mode: normal;
-  }
-
-  ::view-transition-old(root) {
-    animation: none;
-    opacity: 1;
-  }
-
-  ::view-transition-new(root) {
-    animation-name: octc-view-transition-in;
-    animation-duration: var(--octc-motion-base, 150ms);
-    animation-timing-function: var(--octc-motion-ease, ease);
-  }
-}
-
-@keyframes octc-view-transition-in {
-  from {
-    opacity: 0;
+  /* The page background is propagated to the canvas, so it is painted outside
+     the root element and never lands in the `root` snapshot. Anything the
+     snapshots leave transparent therefore falls through the pseudo tree to
+     whatever the compositor has behind it, which is not the page. The UA
+     cross-fade hides that — `plus-lighter` is chosen precisely so the outgoing
+     and incoming alphas sum back to one — but only while it is running.
+     Painting the page color on the overlay itself removes the dependency, so a
+     browser whose blend arrives late, or a transition that is skipped partway,
+     still has the page color behind it rather than a black or white gap. */
+  ::view-transition {
+    background-color: var(--octc-color-bg);
   }
 }
 

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
@@ -178,11 +178,6 @@ expression: "super::snapshot_text(&html)"
 }
 
 html {
-  /* The canvas background has to be owned by the root element, not inherited
-     from `body`: it is what the browser paints behind a cross-document view
-     transition and in the gap between two documents, and a `body`-only
-     background leaves that repaint to the UA default. */
-  background-color: var(--octc-color-bg);
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
   scroll-padding-top: calc(var(--octc-header-height) + 1rem);
@@ -2338,52 +2333,17 @@ a:hover {
     navigation: auto;
   }
 
-  /* The header, sidebar and mobile footer are identical on both sides of a docs
-     navigation, so leaving them inside the `root` snapshot animates them for no
-     reason. Naming them lifts each into its own group, which the UA leaves
-     alone when the old and new snapshots match. The names are the ones the
-     theme skins already use, so a skin that animates them still wins. Selectors
-     stay anchored to the layout: a duplicate name anywhere in the document
-     aborts the whole transition, and `.header` is a plausible class for page
-     content to carry. */
-  body > .header {
-    view-transition-name: octc-header;
-  }
-  #ox-sidebar {
-    view-transition-name: octc-sidebar;
-  }
-  body > .mobile-footer {
-    view-transition-name: octc-mobile-footer;
-  }
-
-  /* The UA cross-fade composites the two root snapshots with `plus-lighter`.
-     That only stays neutral while both snapshots are fully opaque: any region
-     the root paints as transparent — the page background included, when it is
-     propagated to the canvas from `body` instead of being owned by `html` — is
-     added to itself and the page visibly brightens partway through. Holding the
-     outgoing snapshot opaque and fading the incoming one in over it keeps the
-     stack at full coverage for the whole animation, so neither the blend nor
-     the browser's own base color can show through. */
-  ::view-transition-old(root),
-  ::view-transition-new(root) {
-    mix-blend-mode: normal;
-  }
-
-  ::view-transition-old(root) {
-    animation: none;
-    opacity: 1;
-  }
-
-  ::view-transition-new(root) {
-    animation-name: octc-view-transition-in;
-    animation-duration: var(--octc-motion-base, 150ms);
-    animation-timing-function: var(--octc-motion-ease, ease);
-  }
-}
-
-@keyframes octc-view-transition-in {
-  from {
-    opacity: 0;
+  /* The page background is propagated to the canvas, so it is painted outside
+     the root element and never lands in the `root` snapshot. Anything the
+     snapshots leave transparent therefore falls through the pseudo tree to
+     whatever the compositor has behind it, which is not the page. The UA
+     cross-fade hides that — `plus-lighter` is chosen precisely so the outgoing
+     and incoming alphas sum back to one — but only while it is running.
+     Painting the page color on the overlay itself removes the dependency, so a
+     browser whose blend arrives late, or a transition that is skipped partway,
+     still has the page color behind it rather than a black or white gap. */
+  ::view-transition {
+    background-color: var(--octc-color-bg);
   }
 }
 

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
@@ -178,11 +178,6 @@ expression: "super::snapshot_text(&html)"
 }
 
 html {
-  /* The canvas background has to be owned by the root element, not inherited
-     from `body`: it is what the browser paints behind a cross-document view
-     transition and in the gap between two documents, and a `body`-only
-     background leaves that repaint to the UA default. */
-  background-color: var(--octc-color-bg);
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
   scroll-padding-top: calc(var(--octc-header-height) + 1rem);
@@ -2338,52 +2333,17 @@ a:hover {
     navigation: auto;
   }
 
-  /* The header, sidebar and mobile footer are identical on both sides of a docs
-     navigation, so leaving them inside the `root` snapshot animates them for no
-     reason. Naming them lifts each into its own group, which the UA leaves
-     alone when the old and new snapshots match. The names are the ones the
-     theme skins already use, so a skin that animates them still wins. Selectors
-     stay anchored to the layout: a duplicate name anywhere in the document
-     aborts the whole transition, and `.header` is a plausible class for page
-     content to carry. */
-  body > .header {
-    view-transition-name: octc-header;
-  }
-  #ox-sidebar {
-    view-transition-name: octc-sidebar;
-  }
-  body > .mobile-footer {
-    view-transition-name: octc-mobile-footer;
-  }
-
-  /* The UA cross-fade composites the two root snapshots with `plus-lighter`.
-     That only stays neutral while both snapshots are fully opaque: any region
-     the root paints as transparent — the page background included, when it is
-     propagated to the canvas from `body` instead of being owned by `html` — is
-     added to itself and the page visibly brightens partway through. Holding the
-     outgoing snapshot opaque and fading the incoming one in over it keeps the
-     stack at full coverage for the whole animation, so neither the blend nor
-     the browser's own base color can show through. */
-  ::view-transition-old(root),
-  ::view-transition-new(root) {
-    mix-blend-mode: normal;
-  }
-
-  ::view-transition-old(root) {
-    animation: none;
-    opacity: 1;
-  }
-
-  ::view-transition-new(root) {
-    animation-name: octc-view-transition-in;
-    animation-duration: var(--octc-motion-base, 150ms);
-    animation-timing-function: var(--octc-motion-ease, ease);
-  }
-}
-
-@keyframes octc-view-transition-in {
-  from {
-    opacity: 0;
+  /* The page background is propagated to the canvas, so it is painted outside
+     the root element and never lands in the `root` snapshot. Anything the
+     snapshots leave transparent therefore falls through the pseudo tree to
+     whatever the compositor has behind it, which is not the page. The UA
+     cross-fade hides that — `plus-lighter` is chosen precisely so the outgoing
+     and incoming alphas sum back to one — but only while it is running.
+     Painting the page color on the overlay itself removes the dependency, so a
+     browser whose blend arrives late, or a transition that is skipped partway,
+     still has the page color behind it rather than a black or white gap. */
+  ::view-transition {
+    background-color: var(--octc-color-bg);
   }
 }
 

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
@@ -178,11 +178,6 @@ expression: "super::snapshot_text(&html)"
 }
 
 html {
-  /* The canvas background has to be owned by the root element, not inherited
-     from `body`: it is what the browser paints behind a cross-document view
-     transition and in the gap between two documents, and a `body`-only
-     background leaves that repaint to the UA default. */
-  background-color: var(--octc-color-bg);
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
   scroll-padding-top: calc(var(--octc-header-height) + 1rem);
@@ -2338,52 +2333,17 @@ a:hover {
     navigation: auto;
   }
 
-  /* The header, sidebar and mobile footer are identical on both sides of a docs
-     navigation, so leaving them inside the `root` snapshot animates them for no
-     reason. Naming them lifts each into its own group, which the UA leaves
-     alone when the old and new snapshots match. The names are the ones the
-     theme skins already use, so a skin that animates them still wins. Selectors
-     stay anchored to the layout: a duplicate name anywhere in the document
-     aborts the whole transition, and `.header` is a plausible class for page
-     content to carry. */
-  body > .header {
-    view-transition-name: octc-header;
-  }
-  #ox-sidebar {
-    view-transition-name: octc-sidebar;
-  }
-  body > .mobile-footer {
-    view-transition-name: octc-mobile-footer;
-  }
-
-  /* The UA cross-fade composites the two root snapshots with `plus-lighter`.
-     That only stays neutral while both snapshots are fully opaque: any region
-     the root paints as transparent — the page background included, when it is
-     propagated to the canvas from `body` instead of being owned by `html` — is
-     added to itself and the page visibly brightens partway through. Holding the
-     outgoing snapshot opaque and fading the incoming one in over it keeps the
-     stack at full coverage for the whole animation, so neither the blend nor
-     the browser's own base color can show through. */
-  ::view-transition-old(root),
-  ::view-transition-new(root) {
-    mix-blend-mode: normal;
-  }
-
-  ::view-transition-old(root) {
-    animation: none;
-    opacity: 1;
-  }
-
-  ::view-transition-new(root) {
-    animation-name: octc-view-transition-in;
-    animation-duration: var(--octc-motion-base, 150ms);
-    animation-timing-function: var(--octc-motion-ease, ease);
-  }
-}
-
-@keyframes octc-view-transition-in {
-  from {
-    opacity: 0;
+  /* The page background is propagated to the canvas, so it is painted outside
+     the root element and never lands in the `root` snapshot. Anything the
+     snapshots leave transparent therefore falls through the pseudo tree to
+     whatever the compositor has behind it, which is not the page. The UA
+     cross-fade hides that — `plus-lighter` is chosen precisely so the outgoing
+     and incoming alphas sum back to one — but only while it is running.
+     Painting the page color on the overlay itself removes the dependency, so a
+     browser whose blend arrives late, or a transition that is skipped partway,
+     still has the page color behind it rather than a black or white gap. */
+  ::view-transition {
+    background-color: var(--octc-color-bg);
   }
 }
 

--- a/crates/ox_content_ssg/src/ssg.css
+++ b/crates/ox_content_ssg/src/ssg.css
@@ -144,11 +144,6 @@
 }
 
 html {
-  /* The canvas background has to be owned by the root element, not inherited
-     from `body`: it is what the browser paints behind a cross-document view
-     transition and in the gap between two documents, and a `body`-only
-     background leaves that repaint to the UA default. */
-  background-color: var(--octc-color-bg);
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
   scroll-padding-top: calc(var(--octc-header-height) + 1rem);


### PR DESCRIPTION
## Summary

[#1191](https://github.com/ubugeeei-prod/ox-content/pull/1191) made the flashing worse, and this reverts the part that did it. The page now visibly sinks to a mid-grey partway through every cross-document navigation, in **both** themes — which is what was reported after that PR landed.

**The premise of #1191 was wrong.** The page background is propagated from `body` to the canvas, so it is painted *outside* the root element and never lands in the `root` snapshot — the snapshot is transparent wherever the page paints nothing. `plus-lighter` is precisely what handles that: the outgoing and incoming alphas sum back to one, so the transparent regions stay covered for the whole animation. Forcing `mix-blend-mode: normal` breaks that sum and the composite falls toward the compositor's backdrop.

Measured on the running docs build with the transition slowed to 20s, same commit, only the `root` treatment differing:

| root treatment | mid-transition |
| --- | --- |
| `mix-blend-mode: normal` + opaque outgoing snapshot (#1191) | the entire viewport goes mid-grey |
| UA `plus-lighter` cross-fade | background holds, only the text cross-fades |

Confirmed against the live pseudo-element styles during a real cross-document navigation (`::view-transition-old(root)` at opacity 1 with `normal`, versus the complementary `0.518 / 0.482` pair under `plus-lighter`).

**Naming the chrome was wrong too.** The UA does not skip a named group whose two sides match — it cross-fades every group. So `octc-header` / `octc-sidebar` bought nothing, and moved that chrome out of the one selector the override applied to: they stayed on the UA path at 250ms while `root` ran at 150ms, so the page settled in two steps.

### What replaces it

Give the UA cross-fade back, and address the actual gap instead: the overlay itself now carries the page color.

```css
::view-transition {
  background-color: var(--octc-color-bg);
}
```

Anything the snapshots leave transparent then lands on the page background rather than on whatever the compositor has behind it — including when a transition is skipped partway or a browser's blend arrives late, which is the class of problem the original Arc report is most likely in.

Also drops the `html` background from #1191. Its stated reason — that the root element must own the canvas background so it lands in the snapshot — is not true: an `html` background is propagated to the canvas exactly as a `body` one is, and is equally absent from the snapshot. The `theme-color` sync from #1191 stays; it is unrelated and correct.

## Risk

- Risk level: low
- User or production impact: restores the UA transition behaviour that shipped before #1191, plus one new declaration. Under `prefers-reduced-motion: reduce` nothing changes.
- Rollback plan: revert the commit.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_ssg` (280 passed). Two new tests replace the ones that locked in the wrong behaviour: one asserts the overlay carries the page background, one asserts the UA cross-fade is left alone (no `mix-blend-mode`, no `view-transition-name`, no `::view-transition-old/new` overrides).
- [x] Manual verification completed: drove a real link-click navigation in Chromium with the transition slowed to 20s and captured mid-transition frames in **both** themes. Light holds `#ffffff`, dark holds the navy — no sink in either. The before/after screenshots are the table above.
- [x] Edge cases or failure modes considered: `navigation: auto` only fires on push/traverse/replace, so the repro has to be a link click — a `goto()` does not transition, which is why this was missed the first time.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed. The rule carries the reasoning inline.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790596439&installation_model_id=422833&pr_number=1197&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1197&signature=4aa17412e714b41cfba2afe3a4cb99c958ed1157b2868c670f10b77c510e5432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page transitions to prevent transparent gaps and unwanted visual artifacts.
  * Ensured the transition overlay consistently displays the configured page background.
  * Simplified transition behavior for smoother, more reliable navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->