### PR TITLE
docs(embeds): spell the YouTube tag like every other embed

### DIFF
--- a/crates/ox_content_transform/src/youtube/tests.rs
+++ b/crates/ox_content_transform/src/youtube/tests.rs
@@ -150,3 +150,17 @@ fn non_privacy_and_no_fullscreen_no_lazy() {
         r#"<div class="ox-youtube" style="aspect-ratio: 4/3;"><iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="YouTube video dQw4w9WgXcQ" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin"></iframe></div>"#
     );
 }
+
+#[test]
+fn the_tag_is_matched_however_it_is_cased() {
+    // Every other embed is authored PascalCase, and the docs spell this one
+    // `<YouTube>` to match. HTML tag names are case-insensitive, so both have
+    // to reach the same iframe.
+    let lower = transform_youtube(r#"<youtube id="dQw4w9WgXcQ"></youtube>"#, &opts());
+    let pascal = transform_youtube(r#"<YouTube id="dQw4w9WgXcQ"></YouTube>"#, &opts());
+    let self_closing = transform_youtube(r#"<YouTube id="dQw4w9WgXcQ" />"#, &opts());
+
+    assert!(lower.contains("ox-youtube"), "{lower}");
+    assert_eq!(pascal, lower);
+    assert_eq!(self_closing, lower);
+}

--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -313,10 +313,10 @@ uses privacy-enhanced mode (`youtube-nocookie.com`) and lazy loading by
 default:
 
 ```mdx
-<youtube id="Ny8pjacNIv8" title="An Evening with Ron Carter at Emmet’s Place" />
+<YouTube id="Ny8pjacNIv8" title="An Evening with Ron Carter at Emmet’s Place" />
 ```
 
-<youtube id="Ny8pjacNIv8" title="An Evening with Ron Carter at Emmet’s Place" />
+<YouTube id="Ny8pjacNIv8" title="An Evening with Ron Carter at Emmet’s Place" />
 
 `id`, `url`, and `href` attributes are accepted; `youtu.be`, `watch?v=`,
 `shorts`, and `embed` URL shapes are all recognized. `start` accepts a
@@ -325,7 +325,7 @@ URL. Invalid, negative, fractional, overflowing, or duplicated values are
 ignored. Omitting `start` leaves the previous URL unchanged.
 
 ```mdx
-<youtube id="Ny8pjacNIv8" title="An Evening with Ron Carter at Emmet’s Place" start="4190" />
+<YouTube id="Ny8pjacNIv8" title="An Evening with Ron Carter at Emmet’s Place" start="4190" />
 ```
 
 ## Twitter/X

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -256,15 +256,15 @@ pnpm vite preview</code></pre>
 YouTube 埋め込みは SSG ビルドと dev preview で常に処理されます。iframe はプライバシー強化モード（`youtube-nocookie.com`）と遅延読み込みが既定です。
 
 ```mdx
-<youtube id="Ny8pjacNIv8" title="An Evening with Ron Carter at Emmet’s Place" />
+<YouTube id="Ny8pjacNIv8" title="An Evening with Ron Carter at Emmet’s Place" />
 ```
 
-<youtube id="Ny8pjacNIv8" title="An Evening with Ron Carter at Emmet’s Place" />
+<YouTube id="Ny8pjacNIv8" title="An Evening with Ron Carter at Emmet’s Place" />
 
 `id`、`url`、`href` 属性を受け付けます。`youtu.be`、`watch?v=`、`shorts`、`embed` の URL 形はどれも認識します。`start` は非負整数の秒で、iframe URL に `?start=` を付けます。不正、負、小数、オーバーフロー、重複した値は無視します。`start` を省略すると、これまでの URL のままです。
 
 ```mdx
-<youtube id="Ny8pjacNIv8" title="An Evening with Ron Carter at Emmet’s Place" start="4190" />
+<YouTube id="Ny8pjacNIv8" title="An Evening with Ron Carter at Emmet’s Place" start="4190" />
 ```
 
 ## Twitter / X


### PR DESCRIPTION
## Summary

`<youtube>` was the only lowercase embed tag in the docs. `GitHub`, `OgCard`, `Tweet`, `GoogleMaps` and the rest are all PascalCase, so the odd one out reads as a different kind of tag rather than the same authoring model.

HTML tag names are case-insensitive and the parser lowercases before matching, so `<YouTube>` has always resolved to the same iframe — this is a docs change plus a test that pins the behaviour, not a parser change.

Frozen version snapshots under `docs/versions/` are left alone.

## Risk

- Risk level: low
- User or production impact: docs prose only; the emitted HTML is identical.
- Rollback plan: revert the commit.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_transform youtube` (14 passed). The new test asserts `<youtube>`, `<YouTube>` and the self-closing `<YouTube />` all produce byte-identical output.
- [x] Manual verification completed: read the parser — `youtube/parser.rs` lowercases the tag name before comparing, and the TS marker check is `/<youtube/i`, so both ends were already case-insensitive.
- [x] Edge cases or failure modes considered: the self-closing form, and the generated API docs (left as-is — those comments describe the element in rendered HTML, where lowercase is the correct spelling).

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed. EN and JA `built-in/embeds.md` both updated.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790599561&installation_model_id=422833&pr_number=1200&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1200&signature=ea2abfb3aa93605bcb7d983e3f3e5f4ccc15f431d939a0c75c92bdf75f3f7b60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->