### PR TITLE
ci(publish): drop the duplicate NAPI build and move Linux jobs to Blacksmith

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,16 +26,16 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             platform: darwin-arm64
-          - os: ubuntu-22.04
+          - os: blacksmith-32vcpu-ubuntu-2404
             target: x86_64-unknown-linux-gnu
             platform: linux-x64-gnu
-          - os: ubuntu-22.04
+          - os: blacksmith-32vcpu-ubuntu-2404
             target: x86_64-unknown-linux-musl
             platform: linux-x64-musl
-          - os: ubuntu-22.04
+          - os: blacksmith-32vcpu-ubuntu-2404
             target: aarch64-unknown-linux-gnu
             platform: linux-arm64-gnu
-          - os: ubuntu-22.04
+          - os: blacksmith-32vcpu-ubuntu-2404
             target: aarch64-unknown-linux-musl
             platform: linux-arm64-musl
           - os: windows-2025
@@ -142,7 +142,7 @@ jobs:
 
   publish-napi:
     name: Publish @ox-content/napi
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     needs: build-napi
     # The npm environment is part of the trusted publisher identity: each
     # package's publisher on npmjs.com names this repository, the workflow file,
@@ -282,7 +282,7 @@ jobs:
 
   publish-packages:
     name: Publish npm packages
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     needs: publish-napi
     # The npm environment is part of the trusted publisher identity: each
     # package's publisher on npmjs.com names this repository, the workflow file,
@@ -318,19 +318,58 @@ jobs:
       - name: Install npm with trusted publishing support
         run: npm install -g npm@11.19.0 # zizmor: ignore[adhoc-packages]
 
+      # Trusted publishing cannot bootstrap a name that has never been
+      # published: there is no package for npm to attach a publisher to, so the
+      # OIDC exchange falls back to asking for a token and the step dies with
+      # ENEEDAUTH. That happened to v3.0.0-alpha.17 and v3.0.0-alpha.18, both
+      # times after most of the release had already gone out. Thirty seconds
+      # here beats twenty minutes and a half-published tag.
+      - name: Check every package name exists on the registry
+        run: |
+          shopt -s nullglob
+          missing=()
+          for dir in npm/ox-content-islands npm/ox-content-code-play \
+                     npm/unplugin-ox-content npm/vite-plugin-ox-content \
+                     npm/vite-plugin-ox-content-react npm/vite-plugin-ox-content-solid \
+                     npm/vite-plugin-ox-content-svelte npm/vite-plugin-ox-content-vue \
+                     npm/theme/* npm/theme-color/*; do
+            [ -f "$dir/package.json" ] || continue
+            name=$(node -p "require('$PWD/$dir/package.json').name")
+            npm view "$name" name >/dev/null 2>&1 || missing+=("$name")
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::${#missing[@]} package name(s) have never been published, so there is no trusted publisher to authorise them:"
+            printf '::error::  %s\n' "${missing[@]}"
+            echo "::error::Publish each once by hand, then name this repository, .github/workflows/publish.yml and the npm environment as its trusted publisher."
+            exit 1
+          fi
+          echo "Every package name already exists on the registry"
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Build NAPI (for local use)
-        run: vp run build:napi
+      # Only the WASM package still needs Rust here. The native binding was
+      # built by `build-napi` and published by `publish-napi`; the npm package
+      # builds treat `@ox-content/napi` as external, so they never load it.
+      - name: Mount sticky cache
+        uses: ./.github/actions/mount-sticky-cache
+        with:
+          key-prefix: ${{ github.repository }}-publish-${{ github.job }}
+          cargo: "true"
+          target: target
 
       - name: Install wasm-pack
         run: cargo install wasm-pack --locked
 
+      # `build:npm` would pull in `build:napi` through the task graph, which is
+      # the duplicate release compile this job used to pay for twice.
       - name: Build packages
-        run: vp run build:npm
+        # The limit matches the one CI passes through
+        # `OX_CONTENT_VP_PACKAGE_BUILD_CONCURRENCY`; unbounded fan-out over ~80
+        # packages is not a good trade on a 32-vCPU runner.
+        run: vp run --concurrency-limit 12 --filter './npm/**' build
 
       - name: Build WASM package
         run: vp run build:wasm
@@ -511,7 +550,7 @@ jobs:
 
   publish-crates:
     name: Publish to crates.io
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     environment: crates.io
     permissions:
       contents: read
@@ -590,7 +629,7 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     needs: [publish-packages, publish-crates]
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Three things, all in `publish.yml`.

### 1. The npm job built the native binding twice

`publish-packages` ran `vp run build:napi` — a full release compile — even though `build-napi` had already built and uploaded that exact target, and `publish-napi` had already shipped it.

Nothing in the npm package builds actually reads the binding: every consumer lists `@ox-content/napi` in `neverBundle` / `external`, so the bundler only has to resolve the specifier. **Verified** by deleting the built `.node` and running the package builds — all 89 succeed without it.

Calling the package builds directly instead of through `build:npm` is what skips the `build:napi` dependency that was paying for the second compile. The concurrency limit is passed explicitly to match what CI sets through `OX_CONTENT_VP_PACKAGE_BUILD_CONCURRENCY`.

### 2. Every Linux job moves to `blacksmith-32vcpu-ubuntu-2404`

The tier the rest of the repository already uses (32 vCPU is Blacksmith's largest Ubuntu tier). `publish-napi`, `publish-packages`, `publish-crates` and `create-release` were on `ubuntu-latest`; the four Linux matrix legs were on `ubuntu-22.04`.

Moving the matrix also **switches on a cache that was already written and never firing**: `build-napi`'s `Mount sticky cache` step is guarded by `startsWith(matrix.os, 'blacksmith-')`, which no leg satisfied. The glibc floor comes from cargo-zigbuild's explicit `--target …gnu.2.17`, not from the host image, so the runner is free to move — and the existing "Verify Linux native dependencies" step still checks it. macOS and Windows legs are untouched.

The npm job gets the same sticky cache, so `cargo install wasm-pack` and the WASM build stop starting from nothing every release.

### 3. Fail fast on a package name that has never been published

This is what actually broke the last two releases.

Trusted publishing cannot bootstrap a new name: there is no package for npm to attach a publisher to, so the OIDC exchange falls back to asking for a token and the step dies with `ENEEDAUTH`. `@ox-content/theme-color-material` is a 404 on the registry, and it took down **v3.0.0-alpha.17 and v3.0.0-alpha.18** — both times ~20 minutes in, after most of the release had already gone out, leaving a half-published tag and no GitHub release.

A preflight now checks every name against the registry before anything is built or published, and fails in seconds with the list and the remediation.

> **This does not fix the underlying account state.** `@ox-content/theme-color-material` still needs one manual publish, after which this repository, `.github/workflows/publish.yml` and the `npm` environment can be named as its trusted publisher. Until then this check will (correctly) block the release instead of half-completing it.

## Risk

- Risk level: medium — it is the publish path, and it cannot be exercised outside a real tag push.
- User or production impact: none until the next release. The publish *steps* are unchanged; what changed is where they run, one build command, and a new gate in front.
- Rollback plan: revert the commit. The previous behaviour is a strictly slower superset.

## Validation

- [x] Automated tests or checks run: `vp test scripts/verify-publish-targets.test.ts` (3 passed — the release script's own target verification still matches the workflow), `bash -n` on the new preflight, YAML parses and every job resolves to the expected runner.
- [x] Manual verification completed: moved `crates/ox_content_napi/ox-content.node` out of the tree and ran `vp run --filter './npm/**' build` — 89 package builds, all green, which is the claim the de-duplication rests on. Confirmed `@ox-content/theme-color-material` returns 404 from the registry while every other theme and theme-color package returns 200.
- [ ] **Not verifiable before merge:** the workflow itself only runs on a `v*` tag. The runner-label change is the main untested surface; the label is already in use by `ci.yml`, `benchmark.yml` and others in this repository.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed. Each change carries its reasoning inline, including why the matrix image is free to move.
- [x] Configuration, migration, or environment changes documented, or not needed — the npm account action needed for `theme-color-material` is called out above.
- [x] Observability, logging, and alerting impact considered, or not needed. The failure that has been recurring now reports itself with a named list instead of one `ENEEDAUTH` line buried in ~80 packages of `npm notice` output.
- [x] Security, privacy, and dependency impact considered, or not needed. No new actions or dependencies; the preflight only does unauthenticated registry reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790601665&installation_model_id=422833&pr_number=1201&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1201&signature=2c5144593b48bd693091d935da9ccf4a5eda1dc64a5043c7c14ff61b565d2f14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflows to use faster Linux build infrastructure.
  * Added validation to ensure all npm packages exist before publishing.
  * Improved build performance with caching and controlled concurrency.
  * Updated release creation and crates.io publishing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->