### PR TITLE
ci(publish): drop the long-lived npm token from release recovery

### DIFF
--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   publish-missing-npm:
     name: Publish missing npm artifacts
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     environment: npm
     permissions:
       contents: read
@@ -39,20 +39,15 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Configure npm token
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
-            echo "::error::NPM_TOKEN is not configured"
-            exit 1
-          fi
-          {
-            echo "registry=https://registry.npmjs.org"
-            echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}"
-          } > "$RUNNER_TEMP/npmrc"
-          echo "NPM_CONFIG_USERCONFIG=$RUNNER_TEMP/npmrc" >> "$GITHUB_ENV"
+      - name: Setup npm registry
+        run: npm config set registry https://registry.npmjs.org
+
+      # Same trusted-publishing path as publish.yml: npm detects the Actions
+      # OIDC token and exchanges it for a short-lived publish credential, and
+      # generates provenance on that path. No long-lived token takes part in
+      # publishing anywhere in this repository.
+      - name: Install npm with trusted publishing support
+        run: npm install -g npm@11.19.0 # zizmor: ignore[adhoc-packages]
 
       - name: Determine npm tag
         env:
@@ -83,9 +78,12 @@ jobs:
       - name: Build WASM package
         run: vp run build:wasm
 
+      # A package name that has never been published cannot be recovered here:
+      # trusted publishing has no package to attach a publisher to, so npm
+      # rejects the OIDC exchange. Bootstrapping a new name is a one-time human
+      # publish followed by `npm trust github <pkg> --file publish.yml
+      # --repo <owner/repo> --env npm`, after which every release is OIDC again.
       - name: Publish missing npm packages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -113,7 +111,7 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     needs: publish-missing-npm
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

`publish.yml` says, in a comment, that the OIDC exchange "is the only credential in play — there is no long-lived npm token in the repository's secrets."

**That was not true.** `release-recovery.yml` wrote `secrets.NPM_TOKEN` into an npmrc and published with it — a standing credential, and a second, weaker path to the same registry than the one the release itself uses.

It did not even work. I dispatched that recovery for `v3.0.0-alpha.18` earlier today: the token authenticated and then failed

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@ox-content%2ftheme-color-material
```

— it cannot create a new package in the scope. So the token bought nothing except exposure. That is on me: I ran a workflow that contradicts the repository's own stated posture without checking what it used.

## What changes

Recovery takes the same trusted-publishing path as the release. The job already declared `id-token: write` and `environment: npm` and then overrode them with the token; now it configures the registry and pins npm 11.19.0 exactly like `publish.yml`, and publishes with nothing but the Actions OIDC token.

`NPM_TOKEN` is now referenced nowhere in the repository (`VSCE_PAT`, for the VS Code Marketplace, is unrelated and untouched). **The secret should be deleted once this merges** — I have not deleted it, since removing a repository secret is yours to make.

Also moves the job to `blacksmith-32vcpu-ubuntu-2404`, matching #1201.

## The one thing OIDC cannot do

A package name that has *never* been published cannot be created from CI: trusted publishing has no package to attach a publisher to, so npm rejects the exchange. This is npm's constraint, not a gap here.

Bootstrapping a new name is therefore a one-time human step, and it is written down at the publish step:

1. publish the package once by hand (2FA, `--provenance=false` since there is no CI provider locally)
2. `npm trust github <pkg> --file publish.yml --repo <owner/repo> --env npm`

After that the name is OIDC forever. `@ox-content/theme-color-material` is the one package in this state today; it is why `v3.0.0-alpha.17` and `v3.0.0-alpha.18` both ended half-published.

## Risk

- Risk level: low
- User or production impact: recovery can no longer publish a brand-new name, which it could not actually do anyway (the 404 above). Everything else it recovers already exists on the registry and has a trusted publisher, so it takes the OIDC path unchanged.
- Rollback plan: revert the commit — though that reinstates the credential, so prefer fixing forward.

## Validation

- [x] Automated tests or checks run: YAML parses; the job resolves to `blacksmith-32vcpu-ubuntu-2404` with `id-token: write` and `environment: npm`; `grep` finds no `NPM_TOKEN` or `NODE_AUTH_TOKEN` anywhere under `.github/`.
- [x] Manual verification completed: confirmed against the failed run that the token authenticates but cannot create a package, and that `NPM_TOKEN` was referenced only by this workflow.
- [ ] **Not verifiable before merge:** the workflow only runs on dispatch. The publishing steps are unchanged apart from where the credential comes from.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed. The bootstrap procedure is now a comment at the publish step rather than tribal knowledge.
- [x] Configuration, migration, or environment changes documented, or not needed — deleting the `NPM_TOKEN` secret is called out above.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed. This removes a long-lived registry credential from CI; nothing gains access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790602906&installation_model_id=422833&pr_number=1202&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1202&signature=e8febb718ceed2c7cdd8bbd18696ce792ee87e1a407cc3724a3cc442ffaa15c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->