### PR TITLE
fix(ci): publish npm from GitHub-hosted runners again

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -142,7 +142,12 @@ jobs:
 
   publish-napi:
     name: Publish @ox-content/napi
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    # npm verifies the provenance bundle against the runner environment and
+    # rejects anything minted outside a GitHub-hosted runner. Blacksmith hosts
+    # register as "self-hosted", so every provenance publish in this job fails
+    # with a 422. Keep this job on the GitHub-hosted tier; the build jobs and
+    # the crates.io publish are free to stay on Blacksmith.
+    runs-on: ubuntu-latest
     needs: build-napi
     # The npm environment is part of the trusted publisher identity: each
     # package's publisher on npmjs.com names this repository, the workflow file,
@@ -282,7 +287,8 @@ jobs:
 
   publish-packages:
     name: Publish npm packages
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    # GitHub-hosted for the same provenance reason as `publish-napi`.
+    runs-on: ubuntu-latest
     needs: publish-napi
     # The npm environment is part of the trusted publisher identity: each
     # package's publisher on npmjs.com names this repository, the workflow file,
@@ -353,13 +359,8 @@ jobs:
       # Only the WASM package still needs Rust here. The native binding was
       # built by `build-napi` and published by `publish-napi`; the npm package
       # builds treat `@ox-content/napi` as external, so they never load it.
-      - name: Mount sticky cache
-        uses: ./.github/actions/mount-sticky-cache
-        with:
-          key-prefix: ${{ github.repository }}-publish-${{ github.job }}
-          cargo: "true"
-          target: target
-
+      # No sticky cache to warm it either: those disks exist only on Blacksmith
+      # hosts, and this job has to stay GitHub-hosted for provenance.
       - name: Install wasm-pack
         run: cargo install wasm-pack --locked
 
@@ -368,7 +369,7 @@ jobs:
       - name: Build packages
         # The limit matches the one CI passes through
         # `OX_CONTENT_VP_PACKAGE_BUILD_CONCURRENCY`; unbounded fan-out over ~80
-        # packages is not a good trade on a 32-vCPU runner.
+        # packages is not a good trade on a runner this size.
         run: vp run --concurrency-limit 12 --filter './npm/**' build
 
       - name: Build WASM package

--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -16,7 +16,12 @@ env:
 jobs:
   publish-missing-npm:
     name: Publish missing npm artifacts
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    # npm verifies the provenance bundle against the runner environment and
+    # rejects anything minted outside a GitHub-hosted runner. Blacksmith hosts
+    # register as "self-hosted", so every provenance publish in this job fails
+    # with a 422. Keep this job on the GitHub-hosted tier; the build jobs and
+    # the crates.io publish are free to stay on Blacksmith.
+    runs-on: ubuntu-latest
     environment: npm
     permissions:
       contents: read


### PR DESCRIPTION
`v3.0.0-beta.0` reached crates.io and never reached npm. The first binding
package died with:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@ox-content%2fbinding-darwin-arm64
Error verifying sigstore provenance bundle: Unsupported GitHub Actions runner environment:
"self-hosted". Only "github-hosted" runners are supported when publishing with provenance.
```

npm verifies the sigstore provenance bundle against the runner environment and
rejects anything minted outside a GitHub-hosted runner. #1201 moved the npm
publish jobs onto `blacksmith-32vcpu-ubuntu-2404`, which registers as
`self-hosted`, so every `npm publish --provenance` in the release fails. This is
the same half-published tag the registry precheck was added to prevent, one
step earlier in the job.

`publish-napi`, `publish-packages`, and the recovery workflow's
`publish-missing-npm` go back to `ubuntu-latest`. The sticky cache goes with
them: those disks exist only on Blacksmith hosts, which is why `build-napi`
guards its own mount on the host prefix. Everything else #1201 bought — no
duplicate NAPI compile, the registry precheck, the bounded package fan-out —
stays.

The build matrix and the crates.io publish stay on Blacksmith. Neither signs an
npm provenance bundle, and crates.io's own trusted publishing accepted the
Blacksmith host in [the same run](https://github.com/ubugeeei-prod/ox-content/actions/runs/33256581455).

Recovery for `v3.0.0-beta.0` after this merges: the tag has to be re-pointed at
a commit carrying the fix, because a tag-triggered run uses the workflow file at
the tag. `release-recovery.yml` cannot cover this one — it only republishes
`@ox-content/theme-color-material` and the WASM package, which is what alpha.17
and alpha.18 were missing, not a release where npm got nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790605128&installation_model_id=422833&pr_number=1204&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1204&signature=ec543604e7828181fcfc3652f7ed0a514f702eac5eacbb30e15554c51c668a0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release publishing workflows to use GitHub-hosted runners where required for npm provenance validation.
  * Removed unsupported sticky-cache configuration from the package publishing workflow.
  * Updated recovery publishing to use the supported runner environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->