### PR TITLE
ci(publish): install wasm-pack from its prebuilt release

### DIFF
--- a/.github/actions/setup-wasm-pack/action.yml
+++ b/.github/actions/setup-wasm-pack/action.yml
@@ -1,0 +1,54 @@
+name: Setup wasm-pack
+description: Install a pinned, checksum-verified wasm-pack release binary.
+
+inputs:
+  version:
+    description: wasm-pack release to install, without the leading `v`.
+    default: "0.15.0"
+  sha256:
+    description: >-
+      SHA-256 of wasm-pack-v<version>-x86_64-unknown-linux-musl.tar.gz.
+      Refresh it together with `version`:
+      curl -sSL https://github.com/rustwasm/wasm-pack/releases/download/v<version>/wasm-pack-v<version>-x86_64-unknown-linux-musl.tar.gz | sha256sum
+    default: c09f971ecaed9a2efc80fdcea7a00ef6b53c7fadc8c57d1f61b53a6aa66b668a
+
+runs:
+  using: composite
+  steps:
+    # `cargo install wasm-pack --locked` compiled the tool from source on every
+    # release: ~70s of the publish job spent rebuilding a binary upstream
+    # already ships. The prebuilt musl tarball drops that to a couple of
+    # seconds, and it is a download rather than a cache, so there is no cache
+    # entry for anything to poison on the way into a provenance-signed publish.
+    # Pinning the version also stops a release from silently picking up
+    # whatever wasm-pack happens to be newest that day.
+    - name: Install wasm-pack
+      shell: bash
+      env:
+        WASM_PACK_VERSION: ${{ inputs.version }}
+        WASM_PACK_SHA256: ${{ inputs.sha256 }}
+      run: |
+        set -euo pipefail
+
+        if [ "$RUNNER_OS" != "Linux" ] || [ "$RUNNER_ARCH" != "X64" ]; then
+          echo "::error::setup-wasm-pack only pins the x86_64 Linux tarball, but this runner is $RUNNER_OS/$RUNNER_ARCH."
+          exit 1
+        fi
+
+        name="wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl"
+        url="https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/${name}.tar.gz"
+        tmp=$(mktemp -d)
+        trap 'rm -rf "$tmp"' EXIT
+
+        curl --fail --location --silent --show-error --retry 3 --retry-connrefused \
+          --output "$tmp/wasm-pack.tar.gz" "$url"
+        echo "${WASM_PACK_SHA256}  $tmp/wasm-pack.tar.gz" | sha256sum --check --status || {
+          echo "::error::Checksum mismatch for ${name}.tar.gz. Expected ${WASM_PACK_SHA256}, got $(sha256sum "$tmp/wasm-pack.tar.gz" | cut -d' ' -f1)."
+          exit 1
+        }
+
+        tar -xzf "$tmp/wasm-pack.tar.gz" -C "$tmp"
+        install -Dm755 "$tmp/${name}/wasm-pack" "$HOME/.cargo/bin/wasm-pack"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+        "$HOME/.cargo/bin/wasm-pack" --version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -359,10 +359,8 @@ jobs:
       # Only the WASM package still needs Rust here. The native binding was
       # built by `build-napi` and published by `publish-napi`; the npm package
       # builds treat `@ox-content/napi` as external, so they never load it.
-      # No sticky cache to warm it either: those disks exist only on Blacksmith
-      # hosts, and this job has to stay GitHub-hosted for provenance.
       - name: Install wasm-pack
-        run: cargo install wasm-pack --locked
+        uses: ./.github/actions/setup-wasm-pack
 
       # `build:npm` would pull in `build:napi` through the task graph, which is
       # the duplicate release compile this job used to pay for twice.
@@ -372,6 +370,9 @@ jobs:
         # packages is not a good trade on a runner this size.
         run: vp run --concurrency-limit 12 --filter './npm/**' build
 
+      # Compiled cold every release: the sticky disks that would warm it exist
+      # only on Blacksmith hosts, and this job has to stay GitHub-hosted for
+      # provenance.
       - name: Build WASM package
         run: vp run build:wasm
 

--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -77,8 +77,28 @@ jobs:
       - name: Build material theme package
         run: vp exec --filter @ox-content/theme-color-material -- vp pack
 
+      # Deliberately not `uses: ./.github/actions/setup-wasm-pack`: this job
+      # checks out `inputs.tag`, so a local action resolves to the copy in that
+      # tag, and every tag published so far predates the action. Keep this block
+      # in sync with `.github/actions/setup-wasm-pack/action.yml` - same pinned
+      # release, same checksum.
       - name: Install wasm-pack
-        run: cargo install wasm-pack --locked
+        env:
+          WASM_PACK_VERSION: "0.15.0"
+          WASM_PACK_SHA256: c09f971ecaed9a2efc80fdcea7a00ef6b53c7fadc8c57d1f61b53a6aa66b668a
+        run: |
+          set -euo pipefail
+          name="wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl"
+          url="https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/${name}.tar.gz"
+          tmp=$(mktemp -d)
+          trap 'rm -rf "$tmp"' EXIT
+          curl --fail --location --silent --show-error --retry 3 --retry-connrefused \
+            --output "$tmp/wasm-pack.tar.gz" "$url"
+          echo "${WASM_PACK_SHA256}  $tmp/wasm-pack.tar.gz" | sha256sum --check --status
+          tar -xzf "$tmp/wasm-pack.tar.gz" -C "$tmp"
+          install -Dm755 "$tmp/${name}/wasm-pack" "$HOME/.cargo/bin/wasm-pack"
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          "$HOME/.cargo/bin/wasm-pack" --version
 
       - name: Build WASM package
         run: vp run build:wasm


### PR DESCRIPTION
## Summary

- `cargo install wasm-pack --locked` rebuilt wasm-pack from source on every release. Measured on run [33257873436](https://github.com/ubugeeei-prod/ox-content/actions/runs/33257873436), the `Install wasm-pack` step of `publish-packages` cost **68s** (75s on the v3.0.0-alpha.16 run) out of a ~5 min job.
- Replaced it with the pinned prebuilt musl tarball upstream already ships, verified by SHA-256. Locally the same script runs in **0.5s**; on the runner it should be a couple of seconds.
- Chose a download over a cache on purpose: no cache entry means nothing to poison on the way into a provenance-signed publish, and no cache key to keep in sync.
- Pinning to 0.15.0 also closes a reproducibility gap. The old step installed whatever wasm-pack was newest on release day; 0.15.0 is exactly what the last releases resolved to, so this is not a version bump.
- New composite action `.github/actions/setup-wasm-pack`. `release-recovery.yml` keeps the same logic inline instead of calling it, because that job checks out `inputs.tag` and `uses: ./...` would resolve to the copy in that tag - every tag published so far predates the action, so a local action would break recovery for exactly the releases it exists to rescue.

Not touched here: `Build WASM package` (71s) still compiles cold, because the sticky disks that would warm it are Blacksmith-only and this job has to stay GitHub-hosted for provenance. Fixing that means bringing a restore-and-save cache into the release job, which is a separate call.

## Risk

- Risk level: low
- User or production impact: none on published artifacts. Same wasm-pack version (0.15.0) as the last releases produced, so `@ox-content/wasm` output is unchanged. If the download or checksum fails, the release stops at that step with an explicit `::error::` rather than continuing with a bad binary.
- Rollback plan: revert the commit; the step goes back to `cargo install wasm-pack --locked`.

## Validation

- [x] Automated tests or checks run: all three YAML files parse. zizmor is unaffected - it only scans `.github/workflows/` and runs with `--no-exit-codes`.
- [x] Manual verification completed: ran the action's script end to end against a real release tarball - it installs, prints `wasm-pack 0.15.0`, and writes `$GITHUB_PATH`. With a corrupted expected hash it fails with the `::error::` line and exit 1.
- [x] Edge cases or failure modes considered: guards on `RUNNER_OS`/`RUNNER_ARCH` and fails loudly on anything other than Linux x64, since only that tarball's checksum is pinned. `curl --fail --retry 3` covers a flaky download; `install -D` creates `~/.cargo/bin` if the toolchain step has not.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed. Both workflow comments were refreshed, and the duplication in `release-recovery.yml` carries a comment explaining why it is not the composite action.
- [x] Configuration, migration, or environment changes documented, or not needed. Dependabot does not track a pinned release URL, so version bumps are manual - the refresh command lives in the action's `sha256` input description. Local dev is unaffected; `nix develop` still supplies wasm-pack.
- [x] Observability, logging, and alerting impact considered, or not needed. The step still prints the installed version.
- [x] Security, privacy, and dependency impact considered, or not needed. Net reduction: no new third-party action, one fewer from-source build in the OIDC publish job, and the binary is now checksum-verified and version-pinned instead of floating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790607407&installation_model_id=422833&pr_number=1205&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1205&signature=ec8fcb989cda591e6b4d0b53ca78ac25972990c94ad577e4f494d2ae71c67bff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability of release and publishing workflows by using a verified, pinned `wasm-pack` release.
  * Added platform validation and checksum verification during WASM tooling setup.
  * Updated release recovery to use the same verified installation process.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->