### PR TITLE
fix(parser): stop nested brackets costing exponential time

### DIFF
--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -171,6 +171,22 @@ pub struct Parser<'a> {
     /// construction and must not be reinterpreted as setext underlines
     /// during the re-parse.
     lazy_lines: Option<std::rc::Rc<rustc_hash::FxHashSet<u32>>>,
+
+    /// Memoized "this bracket text already contains a link" verdicts,
+    /// keyed by the address and length of the bracketed slice.
+    ///
+    /// CommonMark forbids a link inside a link, so `parse_link` has to
+    /// parse the bracket text before it can decide whether the outer
+    /// bracket is a link at all. When it is not, the bracket stays literal
+    /// and the caller re-scans the same bytes, parsing that inner text a
+    /// second time. Without memoization every nesting level doubles the
+    /// work, so `[[[[a](u)](u)](u)]...` costs 2^depth — a 200-byte
+    /// document already runs for minutes.
+    ///
+    /// Every slice lives in the source or the arena, both of which outlive
+    /// the parser, so an address plus a length names one byte range for as
+    /// long as the cache exists.
+    link_probe_cache: std::cell::RefCell<rustc_hash::FxHashMap<(usize, usize), bool>>,
 }
 
 impl<'a> Parser<'a> {
@@ -192,6 +208,7 @@ impl<'a> Parser<'a> {
             definitions: None,
             footnote_labels: None,
             lazy_lines: None,
+            link_probe_cache: std::cell::RefCell::default(),
         };
         // A single fused pre-pass collects both the reference definitions
         // and the footnote labels (see `prepass.rs`).
@@ -222,6 +239,7 @@ impl<'a> Parser<'a> {
             // Most sub-sources are entered without any lazy continuation
             // line, and every block quote and list item builds one of these.
             lazy_lines: (!lazy_lines.is_empty()).then(|| std::rc::Rc::new(lazy_lines)),
+            link_probe_cache: std::cell::RefCell::default(),
         }
     }
 

--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -18,6 +18,7 @@ mod indented_code;
 mod inline;
 mod inline_helpers;
 mod inline_html;
+mod inline_link;
 mod leaf;
 mod line_scan;
 mod list;

--- a/crates/ox_content_parser/src/parser/inline_helpers.rs
+++ b/crates/ox_content_parser/src/parser/inline_helpers.rs
@@ -1,6 +1,6 @@
 use memchr::{memchr, memchr3};
 use ox_content_allocator::Vec;
-use ox_content_ast::{Image, Link, Node, Span, Text};
+use ox_content_ast::{Image, Node, Span, Text};
 
 use super::Parser;
 use crate::error::ParseResult;
@@ -8,154 +8,6 @@ use crate::error::ParseResult;
 use crate::profile_span_detail;
 
 impl<'a> Parser<'a> {
-    pub(super) fn parse_link(
-        &self,
-        content: &'a str,
-        offset: usize,
-        children: &mut Vec<'a, Node<'a>>,
-        pos: &mut usize,
-    ) -> ParseResult<()> {
-        profile_span_detail!("parser::inline_link");
-        let bytes = content.as_bytes();
-        let link_start = *pos;
-
-        // `[^label]` is a footnote reference when the extension is on and
-        // a definition exists; otherwise it falls through to normal link
-        // handling and may still be a link label.
-        if self.options.footnotes
-            && bytes.get(*pos + 1) == Some(&b'^')
-            && self.try_parse_footnote_reference(content, offset, children, pos)
-        {
-            return Ok(());
-        }
-
-        *pos += 1;
-        let text_start = *pos;
-        *pos = Self::scan_balanced(content, *pos, b'[', b']');
-
-        if *pos < content.len() && bytes[*pos] == b']' {
-            let close = *pos;
-            let link_text = &content[text_start..close];
-            // Links may not contain other links; when the bracket text
-            // parses to one, the outer bracket stays literal and the
-            // inner (re-parsed after the fallback) wins.
-            //
-            // The probe needs the parsed children, and so does every
-            // accepting branch below, so parse once and hand the nodes on.
-            // The verdict is memoized because the literal-bracket fallback
-            // makes the caller re-scan these same bytes; re-probing there
-            // is what turns nested brackets into exponential work.
-            let mut inner_nodes = None;
-            let inner_has_link = memchr::memchr(b'[', link_text.as_bytes()).is_some()
-                && self.probe_link_text(link_text, offset + text_start, &mut inner_nodes);
-
-            // Inline form: [text](dest "title")
-            if !inner_has_link
-                && bytes.get(close + 1) == Some(&b'(')
-                && let Some(target) = self.parse_link_target(content, close + 1)
-            {
-                let children_nodes = match inner_nodes.take() {
-                    Some(nodes) => nodes,
-                    None => self.parse_inline(link_text, offset + text_start)?,
-                };
-                children.push(Node::Link(self.allocator.boxed(Link {
-                    url: target.url,
-                    title: target.title,
-                    children: children_nodes,
-                    span: Span::new((offset + link_start) as u32, (offset + target.end) as u32),
-                })));
-                *pos = target.end;
-                return Ok(());
-            }
-
-            // Full [text][label] and collapsed [text][] reference forms.
-            let mut well_formed_reference = false;
-            if !inner_has_link && bytes.get(close + 1) == Some(&b'[') {
-                let label_start = close + 2;
-                let label_end = Self::scan_balanced(content, label_start, b'[', b']');
-                if label_end < content.len() && bytes[label_end] == b']' {
-                    well_formed_reference = true;
-                    let raw_label = &content[label_start..label_end];
-                    let key = if raw_label.trim().is_empty() { link_text } else { raw_label };
-                    if let Some(reference) = self.lookup_reference(key) {
-                        let (url, title) = (reference.url, reference.title);
-                        let children_nodes = match inner_nodes.take() {
-                            Some(nodes) => nodes,
-                            None => self.parse_inline(link_text, offset + text_start)?,
-                        };
-                        children.push(Node::Link(self.allocator.boxed(Link {
-                            url,
-                            title,
-                            children: children_nodes,
-                            span: Span::new(
-                                (offset + link_start) as u32,
-                                (offset + label_end + 1) as u32,
-                            ),
-                        })));
-                        *pos = label_end + 1;
-                        return Ok(());
-                    }
-                }
-            }
-
-            // Shortcut form: [label]. Suppressed when an explicit (but
-            // unknown) [label] followed, which must stay literal.
-            if !inner_has_link
-                && !well_formed_reference
-                && let Some(reference) = self.lookup_reference(link_text)
-            {
-                let (url, title) = (reference.url, reference.title);
-                let children_nodes = match inner_nodes.take() {
-                    Some(nodes) => nodes,
-                    None => self.parse_inline(link_text, offset + text_start)?,
-                };
-                children.push(Node::Link(self.allocator.boxed(Link {
-                    url,
-                    title,
-                    children: children_nodes,
-                    span: Span::new((offset + link_start) as u32, (offset + close + 1) as u32),
-                })));
-                *pos = close + 1;
-                return Ok(());
-            }
-        }
-
-        // No valid inline link here: the bracket is literal text and the
-        // rest of the bracketed run is re-parsed for other inline markup.
-        Self::push_text(children, "[", offset + link_start, offset + link_start + 1);
-        *pos = link_start + 1;
-        Ok(())
-    }
-
-    /// Reports whether `link_text` already parses to something containing a
-    /// link, so the surrounding bracket cannot become one.
-    ///
-    /// On a cache miss the parsed nodes are handed back through `nodes`,
-    /// because an accepting branch in `parse_link` needs exactly those
-    /// children and would otherwise parse the same bytes a second time.
-    fn probe_link_text(
-        &self,
-        link_text: &'a str,
-        offset: usize,
-        nodes: &mut Option<Vec<'a, Node<'a>>>,
-    ) -> bool {
-        let key = (link_text.as_ptr() as usize, link_text.len());
-        // Borrow only for the lookup: the parse below re-enters this method.
-        let cached = self.link_probe_cache.borrow().get(&key).copied();
-        if let Some(verdict) = cached {
-            return verdict;
-        }
-        let Ok(parsed) = self.parse_inline(link_text, offset) else {
-            // A failing sub-parse cannot yield a link, and the caller's own
-            // parse of the same text surfaces the error.
-            return false;
-        };
-        let verdict = contains_link(&parsed);
-        self.link_probe_cache.borrow_mut().insert(key, verdict);
-        *nodes = Some(parsed);
-        verdict
-    }
-
     pub(super) fn parse_image(
         &self,
         content: &'a str,
@@ -293,7 +145,7 @@ impl<'a> Parser<'a> {
     /// backslash escapes, code spans (an unmatched opener stays literal),
     /// autolinks, and inline raw HTML. This is what makes
     /// `[not a `link](/foo`)` a code span instead of a link.
-    fn scan_balanced(content: &str, mut cursor: usize, open: u8, close: u8) -> usize {
+    pub(super) fn scan_balanced(content: &str, mut cursor: usize, open: u8, close: u8) -> usize {
         let bytes = content.as_bytes();
         let mut depth = 1;
         while cursor < bytes.len() {
@@ -348,17 +200,6 @@ impl<'a> Parser<'a> {
         }
         cursor
     }
-}
-
-/// Does any node in the tree contain a link?
-fn contains_link(nodes: &[Node<'_>]) -> bool {
-    nodes.iter().any(|node| match node {
-        Node::Link(_) => true,
-        Node::Emphasis(n) => contains_link(&n.children),
-        Node::Strong(n) => contains_link(&n.children),
-        Node::Delete(n) => contains_link(&n.children),
-        _ => false,
-    })
 }
 
 /// Flattens inline nodes to their plain-text content (image `alt` rules).

--- a/crates/ox_content_parser/src/parser/inline_helpers.rs
+++ b/crates/ox_content_parser/src/parser/inline_helpers.rs
@@ -39,17 +39,25 @@ impl<'a> Parser<'a> {
             // Links may not contain other links; when the bracket text
             // parses to one, the outer bracket stays literal and the
             // inner (re-parsed after the fallback) wins.
-            let inner_has_link = memchr::memchr(b'[', link_text.as_bytes()).is_some_and(|_| {
-                self.parse_inline(link_text, offset + text_start)
-                    .is_ok_and(|nodes| contains_link(&nodes))
-            });
+            //
+            // The probe needs the parsed children, and so does every
+            // accepting branch below, so parse once and hand the nodes on.
+            // The verdict is memoized because the literal-bracket fallback
+            // makes the caller re-scan these same bytes; re-probing there
+            // is what turns nested brackets into exponential work.
+            let mut inner_nodes = None;
+            let inner_has_link = memchr::memchr(b'[', link_text.as_bytes()).is_some()
+                && self.probe_link_text(link_text, offset + text_start, &mut inner_nodes);
 
             // Inline form: [text](dest "title")
             if !inner_has_link
                 && bytes.get(close + 1) == Some(&b'(')
                 && let Some(target) = self.parse_link_target(content, close + 1)
             {
-                let children_nodes = self.parse_inline(link_text, offset + text_start)?;
+                let children_nodes = match inner_nodes.take() {
+                    Some(nodes) => nodes,
+                    None => self.parse_inline(link_text, offset + text_start)?,
+                };
                 children.push(Node::Link(self.allocator.boxed(Link {
                     url: target.url,
                     title: target.title,
@@ -71,7 +79,10 @@ impl<'a> Parser<'a> {
                     let key = if raw_label.trim().is_empty() { link_text } else { raw_label };
                     if let Some(reference) = self.lookup_reference(key) {
                         let (url, title) = (reference.url, reference.title);
-                        let children_nodes = self.parse_inline(link_text, offset + text_start)?;
+                        let children_nodes = match inner_nodes.take() {
+                            Some(nodes) => nodes,
+                            None => self.parse_inline(link_text, offset + text_start)?,
+                        };
                         children.push(Node::Link(self.allocator.boxed(Link {
                             url,
                             title,
@@ -94,7 +105,10 @@ impl<'a> Parser<'a> {
                 && let Some(reference) = self.lookup_reference(link_text)
             {
                 let (url, title) = (reference.url, reference.title);
-                let children_nodes = self.parse_inline(link_text, offset + text_start)?;
+                let children_nodes = match inner_nodes.take() {
+                    Some(nodes) => nodes,
+                    None => self.parse_inline(link_text, offset + text_start)?,
+                };
                 children.push(Node::Link(self.allocator.boxed(Link {
                     url,
                     title,
@@ -111,6 +125,35 @@ impl<'a> Parser<'a> {
         Self::push_text(children, "[", offset + link_start, offset + link_start + 1);
         *pos = link_start + 1;
         Ok(())
+    }
+
+    /// Reports whether `link_text` already parses to something containing a
+    /// link, so the surrounding bracket cannot become one.
+    ///
+    /// On a cache miss the parsed nodes are handed back through `nodes`,
+    /// because an accepting branch in `parse_link` needs exactly those
+    /// children and would otherwise parse the same bytes a second time.
+    fn probe_link_text(
+        &self,
+        link_text: &'a str,
+        offset: usize,
+        nodes: &mut Option<Vec<'a, Node<'a>>>,
+    ) -> bool {
+        let key = (link_text.as_ptr() as usize, link_text.len());
+        // Borrow only for the lookup: the parse below re-enters this method.
+        let cached = self.link_probe_cache.borrow().get(&key).copied();
+        if let Some(verdict) = cached {
+            return verdict;
+        }
+        let Ok(parsed) = self.parse_inline(link_text, offset) else {
+            // A failing sub-parse cannot yield a link, and the caller's own
+            // parse of the same text surfaces the error.
+            return false;
+        };
+        let verdict = contains_link(&parsed);
+        self.link_probe_cache.borrow_mut().insert(key, verdict);
+        *nodes = Some(parsed);
+        verdict
     }
 
     pub(super) fn parse_image(

--- a/crates/ox_content_parser/src/parser/inline_link.rs
+++ b/crates/ox_content_parser/src/parser/inline_link.rs
@@ -1,0 +1,174 @@
+//! Inline link parsing.
+//!
+//! Split out of `inline_helpers` because CommonMark's "a link may not
+//! contain a link" rule makes this the one inline construct that has to
+//! parse its own text before it can decide what it is.
+
+use ox_content_allocator::Vec;
+use ox_content_ast::{Link, Node, Span};
+
+use super::Parser;
+use crate::error::ParseResult;
+#[allow(unused_imports)]
+use crate::profile_span_detail;
+
+impl<'a> Parser<'a> {
+    pub(super) fn parse_link(
+        &self,
+        content: &'a str,
+        offset: usize,
+        children: &mut Vec<'a, Node<'a>>,
+        pos: &mut usize,
+    ) -> ParseResult<()> {
+        profile_span_detail!("parser::inline_link");
+        let bytes = content.as_bytes();
+        let link_start = *pos;
+
+        // `[^label]` is a footnote reference when the extension is on and
+        // a definition exists; otherwise it falls through to normal link
+        // handling and may still be a link label.
+        if self.options.footnotes
+            && bytes.get(*pos + 1) == Some(&b'^')
+            && self.try_parse_footnote_reference(content, offset, children, pos)
+        {
+            return Ok(());
+        }
+
+        *pos += 1;
+        let text_start = *pos;
+        *pos = Self::scan_balanced(content, *pos, b'[', b']');
+
+        if *pos < content.len() && bytes[*pos] == b']' {
+            let close = *pos;
+            let link_text = &content[text_start..close];
+            // Links may not contain other links; when the bracket text
+            // parses to one, the outer bracket stays literal and the
+            // inner (re-parsed after the fallback) wins.
+            //
+            // The probe needs the parsed children, and so does every
+            // accepting branch below, so parse once and hand the nodes on.
+            // The verdict is memoized because the literal-bracket fallback
+            // makes the caller re-scan these same bytes; re-probing there
+            // is what turns nested brackets into exponential work.
+            let mut inner_nodes = None;
+            let inner_has_link = memchr::memchr(b'[', link_text.as_bytes()).is_some()
+                && self.probe_link_text(link_text, offset + text_start, &mut inner_nodes);
+
+            // Inline form: [text](dest "title")
+            if !inner_has_link
+                && bytes.get(close + 1) == Some(&b'(')
+                && let Some(target) = self.parse_link_target(content, close + 1)
+            {
+                let children_nodes = match inner_nodes.take() {
+                    Some(nodes) => nodes,
+                    None => self.parse_inline(link_text, offset + text_start)?,
+                };
+                children.push(Node::Link(self.allocator.boxed(Link {
+                    url: target.url,
+                    title: target.title,
+                    children: children_nodes,
+                    span: Span::new((offset + link_start) as u32, (offset + target.end) as u32),
+                })));
+                *pos = target.end;
+                return Ok(());
+            }
+
+            // Full [text][label] and collapsed [text][] reference forms.
+            let mut well_formed_reference = false;
+            if !inner_has_link && bytes.get(close + 1) == Some(&b'[') {
+                let label_start = close + 2;
+                let label_end = Self::scan_balanced(content, label_start, b'[', b']');
+                if label_end < content.len() && bytes[label_end] == b']' {
+                    well_formed_reference = true;
+                    let raw_label = &content[label_start..label_end];
+                    let key = if raw_label.trim().is_empty() { link_text } else { raw_label };
+                    if let Some(reference) = self.lookup_reference(key) {
+                        let (url, title) = (reference.url, reference.title);
+                        let children_nodes = match inner_nodes.take() {
+                            Some(nodes) => nodes,
+                            None => self.parse_inline(link_text, offset + text_start)?,
+                        };
+                        children.push(Node::Link(self.allocator.boxed(Link {
+                            url,
+                            title,
+                            children: children_nodes,
+                            span: Span::new(
+                                (offset + link_start) as u32,
+                                (offset + label_end + 1) as u32,
+                            ),
+                        })));
+                        *pos = label_end + 1;
+                        return Ok(());
+                    }
+                }
+            }
+
+            // Shortcut form: [label]. Suppressed when an explicit (but
+            // unknown) [label] followed, which must stay literal.
+            if !inner_has_link
+                && !well_formed_reference
+                && let Some(reference) = self.lookup_reference(link_text)
+            {
+                let (url, title) = (reference.url, reference.title);
+                let children_nodes = match inner_nodes.take() {
+                    Some(nodes) => nodes,
+                    None => self.parse_inline(link_text, offset + text_start)?,
+                };
+                children.push(Node::Link(self.allocator.boxed(Link {
+                    url,
+                    title,
+                    children: children_nodes,
+                    span: Span::new((offset + link_start) as u32, (offset + close + 1) as u32),
+                })));
+                *pos = close + 1;
+                return Ok(());
+            }
+        }
+
+        // No valid inline link here: the bracket is literal text and the
+        // rest of the bracketed run is re-parsed for other inline markup.
+        Self::push_text(children, "[", offset + link_start, offset + link_start + 1);
+        *pos = link_start + 1;
+        Ok(())
+    }
+
+    /// Reports whether `link_text` already parses to something containing a
+    /// link, so the surrounding bracket cannot become one.
+    ///
+    /// On a cache miss the parsed nodes are handed back through `nodes`,
+    /// because an accepting branch in `parse_link` needs exactly those
+    /// children and would otherwise parse the same bytes a second time.
+    fn probe_link_text(
+        &self,
+        link_text: &'a str,
+        offset: usize,
+        nodes: &mut Option<Vec<'a, Node<'a>>>,
+    ) -> bool {
+        let key = (link_text.as_ptr() as usize, link_text.len());
+        // Borrow only for the lookup: the parse below re-enters this method.
+        let cached = self.link_probe_cache.borrow().get(&key).copied();
+        if let Some(verdict) = cached {
+            return verdict;
+        }
+        let Ok(parsed) = self.parse_inline(link_text, offset) else {
+            // A failing sub-parse cannot yield a link, and the caller's own
+            // parse of the same text surfaces the error.
+            return false;
+        };
+        let verdict = contains_link(&parsed);
+        self.link_probe_cache.borrow_mut().insert(key, verdict);
+        *nodes = Some(parsed);
+        verdict
+    }
+}
+
+/// Does any node in the tree contain a link?
+fn contains_link(nodes: &[Node<'_>]) -> bool {
+    nodes.iter().any(|node| match node {
+        Node::Link(_) => true,
+        Node::Emphasis(n) => contains_link(&n.children),
+        Node::Strong(n) => contains_link(&n.children),
+        Node::Delete(n) => contains_link(&n.children),
+        _ => false,
+    })
+}

--- a/crates/ox_content_parser/tests/nested_links.rs
+++ b/crates/ox_content_parser/tests/nested_links.rs
@@ -1,0 +1,149 @@
+//! CommonMark forbids a link inside a link, so `parse_link` parses the
+//! bracket text before it can tell whether the outer bracket is a link at
+//! all. When it is not, the bracket stays literal and the caller re-scans
+//! the same bytes — so every nesting level used to parse its inner text
+//! twice, and `[[[[a](/u)](/u)]...` cost 2^depth.
+//!
+//! These tests pin both halves of the fix: the run has to finish, and it
+//! has to keep producing exactly the nesting the spec asks for.
+
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use ox_content_allocator::Allocator;
+use ox_content_parser::{Parser, ParserOptions};
+use ox_content_renderer::HtmlRenderer;
+
+/// Generous enough that a slow shared runner never trips it, and far below
+/// what the old exponential path needed: at depth 64 that path was 2^44
+/// times the depth-20 cost, which already measured 45 ms.
+const BUDGET: Duration = Duration::from_secs(15);
+
+fn render(source: &str, options: ParserOptions) -> String {
+    let allocator = Allocator::new();
+    let document =
+        Parser::with_options(&allocator, source, options).parse().expect("source should parse");
+    HtmlRenderer::new().render(&document).trim().to_string()
+}
+
+/// Parses `source` on a worker thread so a regression fails the suite in
+/// bounded time instead of hanging it. Returns how long the parse took.
+fn parse_within_budget(source: String) -> Duration {
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        let started = Instant::now();
+        let allocator = Allocator::new();
+        let parsed =
+            Parser::with_options(&allocator, &source, ParserOptions::gfm()).parse().is_ok();
+        let _ = sender.send((parsed, started.elapsed()));
+    });
+    let (parsed, elapsed) = receiver
+        .recv_timeout(BUDGET)
+        .expect("nested brackets should parse in bounded time, not exponential time");
+    assert!(parsed, "nested brackets should parse to a document");
+    elapsed
+}
+
+fn nested_inline_links(depth: usize) -> String {
+    "[".repeat(depth) + "a" + &"](/u)".repeat(depth)
+}
+
+fn nested_reference_links(depth: usize) -> String {
+    "[".repeat(depth) + "a" + &"][r]".repeat(depth) + "\n\n[r]: /r\n"
+}
+
+#[test]
+fn deeply_nested_inline_links_finish_in_bounded_time() {
+    parse_within_budget(nested_inline_links(64));
+}
+
+#[test]
+fn deeply_nested_reference_links_finish_in_bounded_time() {
+    parse_within_budget(nested_reference_links(64));
+}
+
+#[test]
+fn deeply_nested_unclosed_brackets_finish_in_bounded_time() {
+    // The closing run is one short, so no bracket ever becomes a link and
+    // every level takes the literal-text fallback.
+    parse_within_budget("[".repeat(64) + "a" + &"](/u)".repeat(63));
+}
+
+#[test]
+fn deeply_nested_images_in_links_finish_in_bounded_time() {
+    parse_within_budget("[![".repeat(48) + "a" + &"](/i)](/u)".repeat(48));
+}
+
+#[test]
+fn nested_bracket_cost_grows_far_slower_than_it_doubles() {
+    // Each added level used to double the work. Sixteen more levels would
+    // therefore cost 65536x; anything under 100x proves the doubling is
+    // gone without pinning an absolute time on a shared runner.
+    let shallow = parse_within_budget(nested_inline_links(32)).max(Duration::from_micros(1));
+    let deep = parse_within_budget(nested_inline_links(48));
+    assert!(
+        deep < shallow * 100,
+        "depth 48 took {deep:?} against {shallow:?} at depth 32; the doubling is back"
+    );
+}
+
+#[test]
+fn only_the_innermost_inline_link_survives() {
+    assert_eq!(
+        render("[a [b [c](/c)](/b)](/a)", ParserOptions::gfm()),
+        "<p>[a [b <a href=\"/c\">c</a>](/b)](/a)</p>"
+    );
+}
+
+#[test]
+fn only_the_innermost_reference_link_survives() {
+    assert_eq!(
+        render("[a [b [c][ref]][ref]][ref]\n\n[ref]: /r", ParserOptions::gfm()),
+        "<p>[a [b <a href=\"/r\">c</a>]<a href=\"/r\">ref</a>]<a href=\"/r\">ref</a></p>"
+    );
+}
+
+#[test]
+fn bracket_text_without_a_link_still_becomes_link_children() {
+    // The reused probe nodes have to be the same children a fresh parse
+    // would have produced, brackets and emphasis included.
+    assert_eq!(
+        render("[a [b] *c*](/u)", ParserOptions::gfm()),
+        "<p><a href=\"/u\">a [b] <em>c</em></a></p>"
+    );
+}
+
+#[test]
+fn an_image_inside_link_text_is_still_allowed() {
+    assert_eq!(
+        render("[![alt](img.png)](/u)", ParserOptions::gfm()),
+        "<p><a href=\"/u\"><img src=\"img.png\" alt=\"alt\"></a></p>"
+    );
+}
+
+#[test]
+fn identical_bracket_text_is_judged_per_occurrence() {
+    // The memoized verdict is keyed by the slice, so repeating the same
+    // characters in a different position must not inherit an answer.
+    assert_eq!(
+        render("[same](/1) and [same](/2) and [[same](/3)](/4)", ParserOptions::gfm()),
+        concat!(
+            "<p><a href=\"/1\">same</a> and <a href=\"/2\">same</a> ",
+            "and [<a href=\"/3\">same</a>](/4)</p>"
+        )
+    );
+}
+
+#[test]
+fn nesting_inside_a_block_quote_and_a_list_item_behaves_the_same() {
+    // Sub-parsers get their own cache; the verdict must not change.
+    assert_eq!(
+        render("> [a [b](/b)](/a)", ParserOptions::gfm()),
+        "<blockquote>\n<p>[a <a href=\"/b\">b</a>](/a)</p>\n</blockquote>"
+    );
+    assert_eq!(
+        render("- [a [b](/b)](/a)", ParserOptions::gfm()),
+        "<ul>\n<li>[a <a href=\"/b\">b</a>](/a)</li>\n</ul>"
+    );
+}


### PR DESCRIPTION
## Summary

- `parse_link` parsed the bracket text up to three times per nesting level, so `[[[[a](/u)](/u)]...` cost 2^depth. Depth 20 is a 101-byte document and already took 45 ms; depth 40 does not finish.
- The bracket text is now parsed once and handed to whichever branch accepts the link, and the "this text already contains a link" verdict is memoized by slice address so the literal-bracket fallback does not re-probe what the level above just answered.
- Depth 64 goes from "never" to 2 ms. The 215-file docs corpus renders byte-identically in both GFM and plain modes.

### Why it was exponential

CommonMark forbids a link inside a link, so before the outer bracket can become a link the parser has to know whether its text already parses to one. The old code answered that by parsing the text and discarding the result, then parsed it again for the children on the accepting path. When the answer was "yes" the bracket became literal text and the caller re-scanned the same bytes from `link_start + 1` — parsing them a third time. Probe plus re-scan is a factor of two per level.

## Risk

- Risk level: low
- User or production impact: a hostile or merely odd 200-byte Markdown file could hang a build, an editor, or any service that parses untrusted content. This is the class of defect tracked by #774 (malformed Markdown must not take the host process down).
- Rollback plan: revert the commit; the change is contained to `parse_link` and one new `Parser` field.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_parser -p ox_content_renderer` (all green, including the CommonMark 0.31.2 and GFM spec suites), `cargo clippy -p ox_content_parser --all-targets -- -D warnings`, `cargo fmt --check`, `node scripts/check-panic-constructs.mjs`.
- [x] Manual verification completed: rendered all 215 `docs/content` Markdown files through parser + renderer in GFM and plain modes, before and after — output hashes identical.
- [x] Edge cases or failure modes considered: inline, full-reference, collapsed and shortcut link forms; images inside link text; unclosed bracket runs that never form a link; block quote and list item sub-parsers, which get their own cache.

New `crates/ox_content_parser/tests/nested_links.rs` covers both halves. The five timing tests parse on a worker thread with a 15 s budget so a regression fails the suite instead of hanging it — on `main` those five fail; the six output tests pass on both branches and pin the nesting behaviour.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed — the reason for the cache is documented on the field.
- [x] Configuration, migration, or environment changes documented, or not needed — none.
- [x] Observability, logging, and alerting impact considered, or not needed — none.
- [x] Security, privacy, and dependency impact considered, or not needed: this removes an input-size-independent denial-of-service path. No new dependencies.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790685307&installation_model_id=422833&pr_number=1210&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1210&signature=6150aceddbd88e826a4cd5f7ba1bbcd78515a1204baf330dc53316787f4b6c85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance when parsing deeply nested links and brackets, preventing exponential slowdowns.
  * Preserved correct handling of nested links, reference links, images, and unclosed brackets.
  * Ensured consistent parsing behavior within block quotes and list items.

* **Tests**
  * Added regression coverage for deeply nested and complex link scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->