### PR TITLE
fix(parser): bound every nesting path, not just block quotes

### DIFF
--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -34,9 +34,10 @@ mod tests;
 
 /// Parser options.
 ///
-/// `Default::default()` keeps optional Markdown extensions disabled. Use
-/// [`ParserOptions::gfm`] to enable the GitHub Flavored Markdown profile.
-#[derive(Debug, Clone, Default)]
+/// `Default::default()` keeps optional Markdown extensions disabled but
+/// still bounds nesting. Use [`ParserOptions::gfm`] to enable the GitHub
+/// Flavored Markdown profile.
+#[derive(Debug, Clone)]
 pub struct ParserOptions {
     /// Enable the GFM convenience profile.
     ///
@@ -103,10 +104,45 @@ pub struct ParserOptions {
 
     /// Maximum nesting depth for block elements.
     ///
-    /// `0` means unlimited. [`ParserOptions::gfm`] and [`ParserOptions::mdx`]
-    /// set this to `100`.
+    /// Every construct that re-enters the parser on a sub-source — block
+    /// quotes, list items, footnote definitions, and JSX children — counts
+    /// one level, so the cap bounds the recursion depth of a parse no
+    /// matter how the constructs are combined.
+    ///
+    /// `0` means unlimited, which lets a deeply nested document exhaust the
+    /// stack and take the host process down with it. Prefer a finite cap on
+    /// any input you did not write yourself.
+    ///
+    /// Default: `100`, including [`ParserOptions::gfm`] and
+    /// [`ParserOptions::mdx`].
     pub max_nesting_depth: usize,
 }
+
+impl Default for ParserOptions {
+    fn default() -> Self {
+        Self {
+            gfm: false,
+            footnotes: false,
+            task_lists: false,
+            tables: false,
+            strikethrough: false,
+            autolinks: false,
+            cjk_emphasis: false,
+            mdx: false,
+            // Not `0`: an unbounded parse of hostile input overflows the
+            // stack, and a stack overflow aborts rather than unwinds, so
+            // no caller can recover from it.
+            max_nesting_depth: DEFAULT_MAX_NESTING_DEPTH,
+        }
+    }
+}
+
+/// Block nesting levels allowed before a parse fails with
+/// [`ParseError::NestingTooDeep`](crate::ParseError::NestingTooDeep).
+///
+/// Deep enough that no hand-written document reaches it, shallow enough
+/// that the recursion it permits fits in a default thread stack.
+const DEFAULT_MAX_NESTING_DEPTH: usize = 100;
 
 impl ParserOptions {
     /// Creates new parser options with GFM extensions enabled.
@@ -122,14 +158,14 @@ impl ParserOptions {
             // Not part of GFM: GitHub renders these runs per CommonMark too.
             cjk_emphasis: false,
             mdx: false,
-            max_nesting_depth: 100,
+            max_nesting_depth: DEFAULT_MAX_NESTING_DEPTH,
         }
     }
 
     /// Creates parser options with MDX enabled and GFM left off.
     #[must_use]
     pub fn mdx() -> Self {
-        Self { mdx: true, max_nesting_depth: 100, ..Self::default() }
+        Self { mdx: true, ..Self::default() }
     }
 }
 
@@ -201,11 +237,17 @@ impl<'a> Parser<'a> {
         parser
     }
 
-    /// Creates a parser for re-parsing a stripped sub-source (block quote
-    /// or list item content) that shares this parser's reference
-    /// definitions instead of re-collecting them.
+    /// Creates a parser for re-parsing a stripped sub-source (block quote,
+    /// list item, footnote body, or JSX child content) that shares this
+    /// parser's reference definitions instead of re-collecting them.
     /// Sub-parser that also knows which of its lines were added by lazy
     /// continuation (offsets into `source`).
+    ///
+    /// Every sub-source is one block level deeper than its parent, so the
+    /// depth is raised here rather than at each call site: this is the only
+    /// way a block construct re-enters the parser, and counting it in one
+    /// place is what makes [`ParserOptions::max_nesting_depth`] apply to
+    /// all of them.
     pub(crate) fn sub_parser_with_lazy_lines(
         &self,
         source: &'a str,
@@ -216,7 +258,7 @@ impl<'a> Parser<'a> {
             source,
             options: self.options.clone(),
             position: 0,
-            nesting_depth: self.nesting_depth,
+            nesting_depth: self.nesting_depth + 1,
             definitions: self.definitions.clone(),
             footnote_labels: self.footnote_labels.clone(),
             // Most sub-sources are entered without any lazy continuation

--- a/crates/ox_content_parser/src/parser/block.rs
+++ b/crates/ox_content_parser/src/parser/block.rs
@@ -15,8 +15,10 @@ impl<'a> Parser<'a> {
             return Ok(None);
         }
 
-        // `max_nesting_depth == 0` means unlimited. Sub-parsers inherit depth,
-        // so a positive cap actually applies to quotes and list items.
+        // `max_nesting_depth == 0` means unlimited. Every sub-source parser
+        // is built one level deeper than its parent, so a positive cap
+        // applies to quotes, list items, footnote bodies, and JSX children
+        // alike, however they are combined.
         if self.options.max_nesting_depth > 0 && self.nesting_depth > self.options.max_nesting_depth
         {
             return Err(ParseError::NestingTooDeep {

--- a/crates/ox_content_parser/src/parser/block_quote.rs
+++ b/crates/ox_content_parser/src/parser/block_quote.rs
@@ -16,7 +16,6 @@ impl<'a> Parser<'a> {
     /// arena storage before recursive parsing.
     pub(super) fn parse_block_quote(&mut self, start: usize) -> ParseResult<Option<Node<'a>>> {
         profile_span!("parser::parse_block_quote");
-        self.nesting_depth += 1;
 
         // Collect lines belonging to this block quote and strip the `>` prefix.
         // Write straight into a bump-allocated `String` so we don't pay for
@@ -133,8 +132,6 @@ impl<'a> Parser<'a> {
         let inner_str = inner.into_bump_str();
         let sub_parser = self.sub_parser_with_lazy_lines(inner_str, lazy_lines);
         let sub_doc = sub_parser.parse()?;
-
-        self.nesting_depth -= 1;
 
         let span = Span::new(start as u32, self.position as u32);
         Ok(Some(Node::BlockQuote(

--- a/crates/ox_content_parser/src/parser/mdx_jsx.rs
+++ b/crates/ox_content_parser/src/parser/mdx_jsx.rs
@@ -121,9 +121,8 @@ impl<'a> Parser<'a> {
         }
         let inner = &self.source[inner_start..inner_end];
         let child_source = children::normalize_indentation(self.allocator, inner);
-        let mut sub =
+        let sub =
             self.sub_parser_with_lazy_lines(child_source.source, rustc_hash::FxHashSet::default());
-        sub.nesting_depth = self.nesting_depth + 1;
         let mut children = sub.parse()?.children;
         for child in &mut children {
             if let Some(offsets) = &child_source.offsets {

--- a/crates/ox_content_parser/tests/nesting_depth.rs
+++ b/crates/ox_content_parser/tests/nesting_depth.rs
@@ -1,0 +1,145 @@
+//! `max_nesting_depth` has to bound every construct that re-enters the
+//! parser, not just block quotes.
+//!
+//! A stack overflow aborts the process instead of unwinding, so no caller
+//! can recover from one. Each case here nests far past the cap; if the cap
+//! stops applying to that construct the test does not fail, it kills the
+//! test binary — which is the point.
+
+use ox_content_allocator::Allocator;
+use ox_content_ast::Node;
+use ox_content_parser::{ParseError, Parser, ParserOptions};
+
+const OVER_LIMIT: usize = 500;
+
+fn parse_result(source: &str, options: ParserOptions) -> Result<(), ParseError> {
+    let allocator = Allocator::new();
+    Parser::with_options(&allocator, source, options).parse().map(|_| ())
+}
+
+fn assert_too_deep(label: &str, source: &str, options: ParserOptions) {
+    match parse_result(source, options) {
+        Err(ParseError::NestingTooDeep { max_depth: 100, .. }) => {}
+        Err(other) => panic!("{label}: expected NestingTooDeep, got {other}"),
+        Ok(()) => panic!("{label}: expected NestingTooDeep, parsed instead"),
+    }
+}
+
+fn nested_lists(depth: usize) -> String {
+    let mut source = String::new();
+    for level in 0..depth {
+        source.push_str(&" ".repeat(level * 2));
+        source.push_str("- item\n");
+    }
+    source
+}
+
+fn nested_quotes(depth: usize) -> String {
+    "> ".repeat(depth) + "item\n"
+}
+
+fn nested_footnote_definitions(depth: usize) -> String {
+    let mut source = String::new();
+    for level in 0..depth {
+        source.push_str(&" ".repeat(level * 4));
+        source.push_str("[^");
+        source.push_str(&level.to_string());
+        source.push_str("]:\n");
+    }
+    source.push_str(&" ".repeat(depth * 4));
+    source.push_str("body\n");
+    source
+}
+
+fn nested_quotes_around_lists(depth: usize) -> String {
+    let mut source = String::new();
+    for level in 0..depth {
+        source.push_str(&"> ".repeat(level + 1));
+        source.push_str("- item\n");
+    }
+    source
+}
+
+#[test]
+fn deeply_nested_lists_fail_closed() {
+    assert_too_deep("lists", &nested_lists(OVER_LIMIT), ParserOptions::gfm());
+}
+
+#[test]
+fn deeply_nested_quotes_fail_closed() {
+    assert_too_deep("quotes", &nested_quotes(OVER_LIMIT), ParserOptions::gfm());
+}
+
+#[test]
+fn deeply_nested_footnote_definitions_fail_closed() {
+    assert_too_deep("footnotes", &nested_footnote_definitions(OVER_LIMIT), ParserOptions::gfm());
+}
+
+#[test]
+fn deeply_nested_quotes_around_lists_fail_closed() {
+    assert_too_deep("quoted lists", &nested_quotes_around_lists(OVER_LIMIT), ParserOptions::gfm());
+}
+
+#[test]
+fn the_cap_applies_without_the_gfm_profile() {
+    // `ParserOptions::default()` used to leave nesting unlimited, so the
+    // plain-CommonMark path could take the host process down.
+    assert_eq!(ParserOptions::default().max_nesting_depth, 100);
+    assert_too_deep("plain lists", &nested_lists(OVER_LIMIT), ParserOptions::default());
+    assert_too_deep("plain quotes", &nested_quotes(OVER_LIMIT), ParserOptions::default());
+}
+
+#[test]
+fn the_cap_applies_in_mdx_mode() {
+    assert_eq!(ParserOptions::mdx().max_nesting_depth, 100);
+    assert_too_deep("mdx lists", &nested_lists(OVER_LIMIT), ParserOptions::mdx());
+}
+
+#[test]
+fn nesting_within_the_cap_still_parses() {
+    let allocator = Allocator::new();
+    let source = nested_lists(40);
+    let document = Parser::with_options(&allocator, &source, ParserOptions::gfm())
+        .parse()
+        .expect("40 levels are well inside the cap");
+
+    // Walk the whole chain so the depth is measured, not assumed.
+    let mut node = document.children.first().expect("one root list");
+    let mut levels = 1;
+    while let Node::List(list) = node {
+        let item = list.children.first().expect("each list has an item");
+        match item.children.iter().find(|child| matches!(child, Node::List(_))) {
+            Some(inner) => {
+                node = inner;
+                levels += 1;
+            }
+            None => break,
+        }
+    }
+    assert_eq!(levels, 40, "every source level should survive as a nested list");
+}
+
+#[test]
+fn a_custom_cap_is_honored_for_every_construct() {
+    let options = ParserOptions { max_nesting_depth: 3, ..ParserOptions::gfm() };
+    for (label, source) in [
+        ("lists", nested_lists(12)),
+        ("quotes", nested_quotes(12)),
+        ("footnotes", nested_footnote_definitions(12)),
+    ] {
+        match parse_result(&source, options.clone()) {
+            Err(ParseError::NestingTooDeep { max_depth: 3, .. }) => {}
+            other => panic!("{label}: expected the custom cap to bite, got {other:?}"),
+        }
+    }
+    assert!(parse_result(&nested_lists(2), options.clone()).is_ok());
+    assert!(parse_result(&nested_quotes(2), options).is_ok());
+}
+
+#[test]
+fn zero_still_means_unlimited() {
+    // Documented escape hatch: shallow input must keep parsing with it.
+    let options = ParserOptions { max_nesting_depth: 0, ..ParserOptions::gfm() };
+    assert!(parse_result(&nested_lists(120), options.clone()).is_ok());
+    assert!(parse_result(&nested_quotes(120), options).is_ok());
+}

--- a/docs/content/ja/panic-prevention.md
+++ b/docs/content/ja/panic-prevention.md
@@ -39,7 +39,7 @@ CI は `.github/workflows/ci.yml` の `Panic constructs` ジョブでゲート�
 - **SSG パス**: `strip_markdown_extension` は末尾 N バイトを `&str` スライスで比較していました。4 バイトの絵文字パス（`😀`）は、比較の前に文字境界以外で panic していました。ヘルパーは ASCII 接尾辞をバイト列で比較します。
 - **SSG エントリリンク**: `.md` の除去も同じバイト安全な接尾辞チェックです。
 - **パーサーの list / emphasis**: 初期化後や retain 後の局所 `expect` は `get_or_insert_with` / `if let` になりました。
-- **パーサーの入れ子**: 引用と list item のサブパーサーは `nesting_depth` を引き継ぐので、`max_nesting_depth` が実際に効きます。
+- **パーサーの入れ子**: サブソースのパーサー（引用・list item・脚注本文・JSX の子）はすべて親より 1 段深い深さで生成されるので、構文の組み合わせによらず `max_nesting_depth` が再帰の深さを縛ります。GFM プロファイルなしでも既定値は 100 です。`0`（無制限）だと深く入れ子になった文書がスタックを溢れさせ、スタックオーバーフローは巻き戻しではなく abort になるためです。
 - **レンダラー / SWAR スキャン**: 長さ確認後の 8 バイト `try_into().unwrap()` はスタック配列へのコピーです。
 - **N-API キャッシュ**: 変換済みファイルの欠落は `expect` ではなく `Result` エラーです。
 - **N-API FFI**: `parse`、`parse_and_render`、`transform` は unwind ビルドで想定外 panic から回復します。

--- a/docs/content/panic-prevention.md
+++ b/docs/content/panic-prevention.md
@@ -39,7 +39,7 @@ Test-only `unwrap` / `expect` / `panic!` are out of scope.
 - **SSG paths**: `strip_markdown_extension` compared the last N bytes with a `&str` slice. A 4-byte emoji path (`😀`) panicked at a non-character boundary before the comparison ran. The helper now compares ASCII suffixes on bytes.
 - **SSG entry links**: `.md` stripping uses the same byte-safe suffix check.
 - **Parser lists / emphasis**: local `expect`s after initialization or retain are now `get_or_insert_with` / `if let`.
-- **Parser nesting**: quote and list item sub-parsers inherit `nesting_depth`, so `max_nesting_depth` is actually enforced.
+- **Parser nesting**: every sub-source parser — block quote, list item, footnote body, JSX children — is built one level deeper than its parent, so `max_nesting_depth` bounds the recursion of a parse however the constructs are combined. It defaults to 100 even without the GFM profile, because `0` (unlimited) lets a deeply nested document overflow the stack, and a stack overflow aborts rather than unwinds.
 - **Renderer / SWAR scans**: 8-byte `try_into().unwrap()` copies into a stack array after a length check.
 - **N-API cache**: a missing transformed file is a `Result` error, not `expect`.
 - **N-API FFI**: `parse`, `parse_and_render`, and `transform` recover from unexpected panics in unwind builds.


### PR DESCRIPTION
## Summary

- `max_nesting_depth` was raised in `parse_block_quote` and in the JSX child parser only, so it never counted the other two constructs that re-enter the parser: **list items** and **footnote bodies**. A 500-level nested list overflowed the stack and aborted the process, even under `ParserOptions::gfm()`.
- The depth is now raised in `sub_parser_with_lazy_lines`. That is the only way a block construct re-enters the parser, so the cap holds for quotes, list items, footnote bodies, and JSX children in any combination — and the two hand-maintained call-site increments go away.
- `ParserOptions::default()` derived `max_nesting_depth: 0` (unlimited), so plain-CommonMark parsing — `Parser::new`, and `transform` without `gfm` — could still be walked off the stack. It now defaults to 100 like the GFM and MDX profiles.

`docs/content/panic-prevention.md` claimed list item sub-parsers inherit `nesting_depth` "so `max_nesting_depth` is actually enforced". They inherited it but never raised it; the page is corrected in both languages.

### Reproduction on `main`

```rust
let source = (0..500).map(|i| format!("{}- item\n", " ".repeat(i * 2))).collect::<String>();
Parser::with_options(&Allocator::new(), &source, ParserOptions::gfm()).parse();
// thread has overflowed its stack / fatal runtime error: stack overflow, aborting
```

Release binaries use `panic = "abort"`, and a stack overflow does not unwind in any profile, so this is unrecoverable for the host — the failure mode #774 exists to remove.

## Risk

- Risk level: low
- User or production impact: documents nested deeper than 100 block levels now return `ParseError::NestingTooDeep` instead of parsing (previously: aborting). Nothing hand-written reaches that; `max_nesting_depth: 0` remains the documented escape hatch and still means unlimited.
- Rollback plan: revert the commit.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_parser -p ox_content_renderer -p ox_content_transform` (1057 pass, including the CommonMark 0.31.2 and GFM spec suites), `cargo clippy -p ox_content_parser --all-targets -- -D warnings`, `cargo fmt --all --check`, `node scripts/check-panic-constructs.mjs`.
- [x] Manual verification completed: parsed and rendered all 349 Markdown/MDX files under `docs/`, `examples/`, `npm/`, and `crates/` in GFM, MDX, and plain modes, before and after — output hashes identical.
- [x] Edge cases or failure modes considered: nested lists, nested quotes, nested footnote definitions, quotes wrapped around lists, MDX mode, a custom cap of 3, and `0` still meaning unlimited.

New `crates/ox_content_parser/tests/nesting_depth.rs` covers all of the above, plus a positive case that walks a 40-level list to confirm every source level still survives as a nested `List`. On `main` the suite does not merely fail — it aborts the test binary with a stack overflow, which is the behaviour being fixed.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated: `docs/content/panic-prevention.md` and its Japanese translation, plus the option's rustdoc.
- [x] Configuration, migration, or environment changes documented, or not needed — none.
- [x] Observability, logging, and alerting impact considered, or not needed — none.
- [x] Security, privacy, and dependency impact considered: removes an unrecoverable denial-of-service path on untrusted Markdown. No new dependencies.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790685886&installation_model_id=422833&pr_number=1211&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1211&signature=fb4cb42af52719671f652c50ef91303d3d0eda456e238464d1388eabdd63b68e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->