### PR TITLE
perf(parser): stop rescanning to the blank line per reference definition

### DIFF
--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -224,6 +224,18 @@ pub struct Parser<'a> {
     /// the parser, so an address plus a length names one byte range for as
     /// long as the cache exists.
     link_probe_cache: std::cell::RefCell<rustc_hash::FxHashMap<(usize, usize), bool>>,
+
+    /// The last `[scanned_from, blank_line)` window found while bounding a
+    /// link reference definition, so a run of them costs one scan in total.
+    ///
+    /// A definition may not contain a blank line, so `try_parse_definition_node`
+    /// cuts its candidate region at the next one. Scanning for that from each
+    /// definition made a document that is nothing but definitions quadratic:
+    /// 16,000 of them (197 KB) took 567 ms against 0.3 ms for the same bytes
+    /// of prose. Every definition in one run shares the same boundary, and
+    /// block parsing walks forward, so the previous answer stays valid for
+    /// any start inside the window.
+    definition_region: Option<(usize, usize)>,
 }
 
 impl<'a> Parser<'a> {
@@ -246,6 +258,7 @@ impl<'a> Parser<'a> {
             footnote_labels: None,
             lazy_lines: None,
             link_probe_cache: std::cell::RefCell::default(),
+            definition_region: None,
         };
         // A single fused pre-pass collects both the reference definitions
         // and the footnote labels (see `prepass.rs`).
@@ -283,6 +296,7 @@ impl<'a> Parser<'a> {
             // line, and every block quote and list item builds one of these.
             lazy_lines: (!lazy_lines.is_empty()).then(|| std::rc::Rc::new(lazy_lines)),
             link_probe_cache: std::cell::RefCell::default(),
+            definition_region: None,
         }
     }
 

--- a/crates/ox_content_parser/src/parser/reference.rs
+++ b/crates/ox_content_parser/src/parser/reference.rs
@@ -172,8 +172,10 @@ impl<'a> Parser<'a> {
         let start = self.position;
         // Definitions cannot contain blank lines; cut the candidate region
         // at the next one so the destination/title scanners stay in
-        // paragraph bounds.
-        let region_end = next_blank_line(self.source.as_bytes(), start);
+        // paragraph bounds. Consecutive definitions share that boundary, so
+        // reuse the last one rather than re-scanning to it per definition —
+        // that scan is what made a definition-only document quadratic.
+        let region_end = self.definition_region_end(start);
         let parsed = self.parse_reference_definition(&self.source[start..region_end])?;
 
         let identifier =
@@ -187,6 +189,21 @@ impl<'a> Parser<'a> {
             title: parsed.title,
             span: Span::new(start as u32, end as u32),
         })))
+    }
+
+    /// Position of the first blank line at or after `start`, reusing the
+    /// previous scan whenever `start` falls inside the window it covered.
+    fn definition_region_end(&mut self, start: usize) -> usize {
+        if let Some((scanned_from, blank_line)) = self.definition_region
+            && (scanned_from..=blank_line).contains(&start)
+        {
+            // No blank line lies in `scanned_from..blank_line`, so the first
+            // one at or after any `start` in that window is the same one.
+            return blank_line;
+        }
+        let blank_line = next_blank_line(self.source.as_bytes(), start);
+        self.definition_region = Some((start, blank_line));
+        blank_line
     }
 
     /// Joins the block-quote-stripped lines of the paragraph chunk that

--- a/crates/ox_content_parser/tests/reference_definitions.rs
+++ b/crates/ox_content_parser/tests/reference_definitions.rs
@@ -1,0 +1,151 @@
+//! A link reference definition may not contain a blank line, so the parser
+//! cuts each candidate at the next one. Scanning for that boundary from
+//! every definition made a document that is mostly definitions quadratic;
+//! the boundary is now remembered for the run that shares it.
+//!
+//! These tests pin the shape of the run (the cache must not leak a
+//! boundary across a blank line) and the cost of it.
+
+use std::time::{Duration, Instant};
+
+use ox_content_allocator::Allocator;
+use ox_content_ast::Node;
+use ox_content_parser::{Parser, ParserOptions};
+use ox_content_renderer::HtmlRenderer;
+
+fn render(source: &str) -> String {
+    let allocator = Allocator::new();
+    let document = Parser::with_options(&allocator, source, ParserOptions::gfm())
+        .parse()
+        .expect("source should parse");
+    HtmlRenderer::new().render(&document).trim().to_string()
+}
+
+fn definitions(source: &str) -> Vec<(String, String, Option<String>)> {
+    let allocator = Allocator::new();
+    let document = Parser::with_options(&allocator, source, ParserOptions::gfm())
+        .parse()
+        .expect("source should parse");
+    document
+        .children
+        .iter()
+        .filter_map(|node| match node {
+            Node::Definition(definition) => Some((
+                definition.identifier.to_string(),
+                definition.url.to_string(),
+                definition.title.map(str::to_string),
+            )),
+            _ => None,
+        })
+        .collect()
+}
+
+fn definition_run(count: usize) -> String {
+    let mut source = String::new();
+    for index in 0..count {
+        source.push_str("[r");
+        source.push_str(&index.to_string());
+        source.push_str("]: /u");
+        source.push_str(&index.to_string());
+        source.push('\n');
+    }
+    source
+}
+
+fn time_parse(source: &str) -> Duration {
+    let allocator = Allocator::new();
+    let start = Instant::now();
+    let parsed = Parser::with_options(&allocator, source, ParserOptions::gfm()).parse();
+    let elapsed = start.elapsed();
+    assert!(parsed.is_ok(), "source should parse");
+    elapsed
+}
+
+#[test]
+fn every_definition_in_a_long_run_is_collected() {
+    let collected = definitions(&definition_run(2_000));
+    assert_eq!(collected.len(), 2_000);
+    assert_eq!(collected[0], ("r0".into(), "/u0".into(), None));
+    assert_eq!(collected[1_999], ("r1999".into(), "/u1999".into(), None));
+}
+
+#[test]
+fn references_in_a_long_run_still_resolve() {
+    let source = definition_run(1_000) + "\n[link][r0] and [link][r999]\n";
+    assert_eq!(render(&source), "<p><a href=\"/u0\">link</a> and <a href=\"/u999\">link</a></p>");
+}
+
+#[test]
+fn a_blank_line_ends_the_remembered_region() {
+    // The second run starts past the first boundary, so the cached window
+    // must not be reused for it.
+    let source = "[a]: /a\n[b]: /b\n\n[c]: /c\n[d]: /d\n\n[x][a][x][b][x][c][x][d]\n";
+    assert_eq!(
+        definitions(source).iter().map(|(id, url, _)| format!("{id}={url}")).collect::<Vec<_>>(),
+        ["a=/a", "b=/b", "c=/c", "d=/d"]
+    );
+}
+
+#[test]
+fn a_definition_after_a_paragraph_gets_a_fresh_region() {
+    // Prose between two runs moves the position past the cached window
+    // without any definition consuming it.
+    let source = "[a]: /a\n\nprose\n\n[b]: /b\n[c]: /c\n\n[x][a] [x][b] [x][c]\n";
+    assert_eq!(
+        render(source),
+        "<p>prose</p>\n<p><a href=\"/a\">x</a> <a href=\"/b\">x</a> <a href=\"/c\">x</a></p>"
+    );
+}
+
+#[test]
+fn a_failed_candidate_does_not_poison_the_definitions_after_it() {
+    // `[nope]` has no colon, so the run becomes a paragraph; the real
+    // definitions that follow the blank line still have to register.
+    let source = "[nope] plain text\n[still]: text\n\n[real]: /real\n\n[x][real]\n";
+    assert_eq!(definitions(source), [("real".to_string(), "/real".to_string(), None)]);
+    assert!(render(source).contains("<a href=\"/real\">x</a>"));
+}
+
+#[test]
+fn multiline_definitions_inside_a_run_keep_their_titles() {
+    let source = concat!(
+        "[a]: /a\n",
+        "[b]: /b\n   \"B title\"\n",
+        "[c]: /c \"C title\"\n",
+        "[d]: /d\n",
+        "\n[x][b] [x][c]\n"
+    );
+    assert_eq!(
+        definitions(source),
+        [
+            ("a".to_string(), "/a".to_string(), None),
+            ("b".to_string(), "/b".to_string(), Some("B title".to_string())),
+            ("c".to_string(), "/c".to_string(), Some("C title".to_string())),
+            ("d".to_string(), "/d".to_string(), None),
+        ]
+    );
+}
+
+#[test]
+fn definition_runs_inside_a_block_quote_resolve() {
+    // The quote's sub-parser has its own source, so it must not inherit
+    // the outer parser's remembered offsets.
+    let source = "> [a]: /a\n> [b]: /b\n>\n> [x][a] [y][b]\n";
+    assert_eq!(
+        render(source),
+        "<blockquote>\n<p><a href=\"/a\">x</a> <a href=\"/b\">y</a></p>\n</blockquote>"
+    );
+}
+
+#[test]
+fn a_run_of_definitions_costs_linear_time() {
+    // Four times the definitions used to cost sixteen times the work.
+    // Anything under eight proves the per-definition rescan is gone
+    // without pinning an absolute time on a shared runner.
+    let small = time_parse(&definition_run(4_000)).max(Duration::from_micros(1));
+    let large = time_parse(&definition_run(16_000));
+    assert!(
+        large < small * 8,
+        "16,000 definitions took {large:?} against {small:?} for 4,000; the rescan is back"
+    );
+}


### PR DESCRIPTION
## Summary

- A link reference definition may not contain a blank line, so `try_parse_definition_node` cuts its candidate region at the next one — by scanning for it from every definition. Every definition in a run shares that boundary, so a document that is mostly definitions was **quadratic**: 16,000 of them (197 KB) took **567 ms**, against 0.3 ms for the same number of bytes of prose.
- The window the last scan covered is now remembered and reused while the block position is still inside it. Block parsing walks forward, so the previous answer stays valid; a blank line, a paragraph, or a backwards jump all fall outside the window and rescan.

| definitions | before | after |
| ----------- | -----: | ----: |
| 4,000       |  19 ms | 0.7 ms |
| 8,000       |  70 ms | 1.5 ms |
| 16,000      | 567 ms | 3.2 ms |
| 32,000      |      — | 8.1 ms |

Reference-heavy pages are exactly what generated API documentation looks like, and a large site multiplies the cost by its page count.

## Risk

- Risk level: low
- User or production impact: parse-time only; no output changes.
- Rollback plan: revert the commit. The change is one `Parser` field and one helper.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_parser -p ox_content_renderer -p ox_content_transform` (1056 pass, including the CommonMark 0.31.2 and GFM spec suites), `cargo clippy -p ox_content_parser --all-targets -- -D warnings`, `cargo fmt --all --check`, `node scripts/check-panic-constructs.mjs`, `node scripts/check-file-lines.ts`.
- [x] Manual verification completed: parsed and rendered all 354 Markdown/MDX files under `docs/`, `examples/`, `npm/`, and `crates/` in GFM, MDX, and plain modes, before and after — output hashes identical.
- [x] Edge cases or failure modes considered: a blank line ending the run, prose between two runs, a failed candidate that turns the run into a paragraph, multi-line definitions with titles on the following line, and definition runs inside a block quote (whose sub-parser has its own source and must not inherit offsets).

New `crates/ox_content_parser/tests/reference_definitions.rs` covers each of those, plus a growth assertion: 4x the definitions must cost less than 8x the time, which the old per-definition rescan could not satisfy.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed — the reason for the cache is documented on the field and the helper.
- [x] Configuration, migration, or environment changes documented, or not needed — none.
- [x] Observability, logging, and alerting impact considered, or not needed — none.
- [x] Security, privacy, and dependency impact considered: removes a super-linear path reachable from ordinary content. No new dependencies.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790686507&installation_model_id=422833&pr_number=1212&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1212&signature=c447169fd5e5d9222a0429063a79c36e1263e121ca8325daa19fd6b9e21a59d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->