### PR TITLE
perf(parser): make emphasis pairing linear in delimiter count

### DIFF
--- a/crates/ox_content_parser/src/parser/inline/emphasis.rs
+++ b/crates/ox_content_parser/src/parser/inline/emphasis.rs
@@ -8,7 +8,7 @@
 //! text nodes in place. Unpaired runs simply stay literal text.
 
 use ox_content_allocator::Vec;
-use ox_content_ast::{Node, Span};
+use ox_content_ast::{Node, Span, Text};
 
 use crate::parser::Parser;
 #[allow(unused_imports)]
@@ -65,15 +65,21 @@ impl<'a> Parser<'a> {
     }
 
     /// Pairs delimiters and restructures `children` into the emphasis
-    /// tree, spec algorithm "process emphasis" (without the
-    /// openers_bottom optimization; delimiter counts per sequence are
-    /// small in practice).
+    /// tree, spec algorithm "process emphasis".
+    ///
+    /// Two things keep it linear on delimiter-dense sequences. Paired
+    /// nodes are lifted out of `children` in place, leaving empty text
+    /// slots behind, so `node_index` never moves and no pairing has to
+    /// walk the vector fixing indices up. And a failed opener search
+    /// records how far down it looked (`openers_bottom`), so the next
+    /// closer of the same class does not repeat it.
     pub(in crate::parser) fn process_emphasis(
         &self,
         children: &mut Vec<'a, Node<'a>>,
         delimiters: &mut Vec<'a, Delimiter>,
     ) {
         profile_span!("parser::process_emphasis");
+        let mut openers_bottom = OpenersBottom::default();
         let mut closer_idx = 0;
         while closer_idx < delimiters.len() {
             if !delimiters[closer_idx].can_close || delimiters[closer_idx].remaining == 0 {
@@ -81,12 +87,17 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            let Some(opener_idx) = find_opener(delimiters, closer_idx) else {
+            let bottom = openers_bottom.get(&delimiters[closer_idx]);
+            let Some(opener_idx) = find_opener(delimiters, closer_idx, bottom) else {
+                // Nothing below this closer can pair with a later closer of
+                // the same class either, so remember where to stop next time.
+                openers_bottom.set(&delimiters[closer_idx]);
                 if !delimiters[closer_idx].can_open {
-                    delimiters.remove(closer_idx);
-                } else {
-                    closer_idx += 1;
+                    // It cannot open and has just failed to close: retire it
+                    // rather than shifting the rest of the vector down.
+                    delimiters[closer_idx].remaining = 0;
                 }
+                closer_idx += 1;
                 continue;
             };
 
@@ -99,16 +110,18 @@ impl<'a> Parser<'a> {
             let opener_node = delimiters[opener_idx].node_index;
             let closer_node = delimiters[closer_idx].node_index;
 
-            // Move the nodes between the delimiters into the new
-            // emphasis node, inserted right after the opener's text node.
-            // Delimiter text nodes emptied by earlier (inner) pairings are
-            // dropped on the way — they render as nothing.
+            // Lift the nodes between the delimiters into the new emphasis
+            // node and leave empty text behind, so every index stays put.
+            // Text nodes emptied by earlier (inner) pairings are dropped on
+            // the way — they render as nothing. The range is never empty:
+            // two runs of the same marker cannot be adjacent children.
             let mut inner = self.allocator.new_vec();
-            inner.extend(
-                children
-                    .drain(opener_node + 1..closer_node)
-                    .filter(|node| !matches!(node, Node::Text(text) if text.value.is_empty())),
-            );
+            for slot in &mut children[opener_node + 1..closer_node] {
+                let node = core::mem::replace(slot, empty_text());
+                if !matches!(&node, Node::Text(text) if text.value.is_empty()) {
+                    inner.push(node);
+                }
+            }
             let span = inner_span(&inner, use_delims);
             let node = if use_delims == 2 {
                 Node::Strong(self.allocator.boxed(ox_content_ast::Strong { children: inner, span }))
@@ -117,51 +130,26 @@ impl<'a> Parser<'a> {
                     self.allocator.boxed(ox_content_ast::Emphasis { children: inner, span }),
                 )
             };
-            children.insert(opener_node + 1, node);
+            children[opener_node + 1] = node;
 
             // Trim the delimiter text nodes in place (they may end up
             // empty, which renders as nothing).
             trim_text_tail(&mut children[opener_node], use_delims);
-            let closer_node_now = opener_node + 2;
-            trim_text_head(&mut children[closer_node_now], use_delims);
+            trim_text_head(&mut children[closer_node], use_delims);
 
-            // Drop delimiters between the pair and fix indices right of it.
-            let removed_nodes = closer_node - opener_node - 2;
-            delimiters.retain(|delimiter| {
-                delimiter.node_index <= opener_node || delimiter.node_index >= closer_node
-            });
-            for delimiter in delimiters.iter_mut() {
-                if delimiter.node_index >= closer_node {
-                    delimiter.node_index -= removed_nodes;
-                }
+            // Delimiters strictly inside the pair are now unreachable, and
+            // the pair itself has spent `use_delims` characters. Retiring an
+            // entry means zeroing `remaining`: both the loop above and
+            // `find_opener` already skip those, and erasing it from the
+            // vector instead would shift every later entry down — which is
+            // what made a paragraph full of emphasis quadratic.
+            for delimiter in &mut delimiters[opener_idx + 1..closer_idx] {
+                delimiter.remaining = 0;
             }
-
-            let Some(opener_pos) = delimiters.iter().position(|d| d.node_index == opener_node)
-            else {
-                closer_idx += 1;
-                continue;
-            };
-            let Some(closer_pos) = delimiters.iter().position(|d| d.node_index == closer_node_now)
-            else {
-                closer_idx += 1;
-                continue;
-            };
-            delimiters[opener_pos].remaining -= use_delims as usize;
-            delimiters[closer_pos].remaining -= use_delims as usize;
-
-            // Remove exhausted entries, higher index first so the lower
-            // one stays valid. The next iteration resumes at the closer
-            // (which may retry with a new opener if it has characters
-            // left) or at its successor.
-            let mut next_closer = closer_pos;
-            if delimiters[closer_pos].remaining == 0 {
-                delimiters.remove(closer_pos);
-            }
-            if delimiters[opener_pos].remaining == 0 {
-                delimiters.remove(opener_pos);
-                next_closer -= 1;
-            }
-            closer_idx = next_closer;
+            delimiters[opener_idx].remaining -= use_delims as usize;
+            delimiters[closer_idx].remaining -= use_delims as usize;
+            // Stay on the closer: with characters left it retries against an
+            // earlier opener, and otherwise the top of the loop steps over it.
         }
 
         // Emptied delimiter text nodes at this level render as nothing;
@@ -170,10 +158,54 @@ impl<'a> Parser<'a> {
     }
 }
 
-fn find_opener(delimiters: &[Delimiter], closer_idx: usize) -> Option<usize> {
+/// Placeholder left where a node has been lifted into an emphasis node.
+/// Empty text renders as nothing and is dropped once pairing is done.
+fn empty_text<'a>() -> Node<'a> {
+    Node::Text(Text { value: "", span: Span::new(0, 0) })
+}
+
+/// Lowest opener still worth examining, per closer class.
+///
+/// The spec keys this on the delimiter character, the closer's original
+/// run length modulo three, and whether the closer can also open — the
+/// three things the rule of three consults. The stored value is a
+/// `node_index`, which no longer moves, so it stays a valid bound for the
+/// whole sequence.
+#[derive(Default)]
+struct OpenersBottom {
+    star: [[Option<usize>; 2]; 3],
+    underscore: [[Option<usize>; 2]; 3],
+}
+
+impl OpenersBottom {
+    fn slot(&mut self, closer: &Delimiter) -> &mut Option<usize> {
+        let table = if closer.marker == b'_' { &mut self.underscore } else { &mut self.star };
+        &mut table[closer.orig_len % 3][usize::from(closer.can_open)]
+    }
+
+    fn get(&mut self, closer: &Delimiter) -> Option<usize> {
+        *self.slot(closer)
+    }
+
+    fn set(&mut self, closer: &Delimiter) {
+        *self.slot(closer) = Some(closer.node_index);
+    }
+}
+
+/// Nearest opener that may pair with `delimiters[closer_idx]`, stopping at
+/// `bottom` — a `node_index` a previous failed search for this closer class
+/// already proved nothing below could match.
+fn find_opener(
+    delimiters: &[Delimiter],
+    closer_idx: usize,
+    bottom: Option<usize>,
+) -> Option<usize> {
     let closer = &delimiters[closer_idx];
     for opener_idx in (0..closer_idx).rev() {
         let opener = &delimiters[opener_idx];
+        if bottom.is_some_and(|bottom| opener.node_index < bottom) {
+            return None;
+        }
         if opener.marker != closer.marker || !opener.can_open || opener.remaining == 0 {
             continue;
         }

--- a/crates/ox_content_parser/tests/emphasis_pairing.rs
+++ b/crates/ox_content_parser/tests/emphasis_pairing.rs
@@ -1,0 +1,166 @@
+//! Emphasis pairing rewrites `children` in place: paired nodes are lifted
+//! out and empty text is left in their slots, so `node_index` never moves
+//! and spent delimiters are retired by zeroing their count rather than by
+//! erasing them from the vector.
+//!
+//! Both of those are invisible in the HTML when they work and catastrophic
+//! when they do not, so these tests check the tree as well as the output —
+//! no placeholder may survive, and pairing must stay linear.
+
+use std::time::{Duration, Instant};
+
+use ox_content_allocator::Allocator;
+use ox_content_ast::Node;
+use ox_content_parser::{Parser, ParserOptions};
+use ox_content_renderer::HtmlRenderer;
+
+fn render(source: &str) -> String {
+    let allocator = Allocator::new();
+    let document = Parser::with_options(&allocator, source, ParserOptions::gfm())
+        .parse()
+        .expect("source should parse");
+    HtmlRenderer::new().render(&document).trim().to_string()
+}
+
+fn children_of<'a, 'b: 'a>(node: &'a Node<'b>) -> Option<&'a [Node<'b>]> {
+    match node {
+        Node::Paragraph(n) => Some(&n.children),
+        Node::Heading(n) => Some(&n.children),
+        Node::Emphasis(n) => Some(&n.children),
+        Node::Strong(n) => Some(&n.children),
+        Node::Delete(n) => Some(&n.children),
+        Node::Link(n) => Some(&n.children),
+        Node::BlockQuote(n) => Some(&n.children),
+        _ => None,
+    }
+}
+
+/// Empty text nodes are placeholders left behind by pairing; none may
+/// reach a consumer, at any depth.
+fn assert_no_empty_text(nodes: &[Node<'_>], source: &str) {
+    for node in nodes {
+        if let Node::Text(text) = node {
+            assert!(!text.value.is_empty(), "empty text node survived pairing in {source:?}");
+        }
+        if let Some(children) = children_of(node) {
+            assert_no_empty_text(children, source);
+        }
+    }
+}
+
+fn assert_spans_inside(nodes: &[Node<'_>], limit: u32, source: &str) {
+    for node in nodes {
+        if let Node::Emphasis(n) = node {
+            assert!(n.span.start <= n.span.end && n.span.end <= limit, "bad span in {source:?}");
+        }
+        if let Node::Strong(n) = node {
+            assert!(n.span.start <= n.span.end && n.span.end <= limit, "bad span in {source:?}");
+        }
+        if let Some(children) = children_of(node) {
+            assert_spans_inside(children, limit, source);
+        }
+    }
+}
+
+fn check_tree(source: &str) {
+    let allocator = Allocator::new();
+    let document = Parser::with_options(&allocator, source, ParserOptions::gfm())
+        .parse()
+        .expect("source should parse");
+    assert_no_empty_text(&document.children, source);
+    assert_spans_inside(&document.children, source.len() as u32, source);
+}
+
+fn time_parse(source: &str) -> Duration {
+    let allocator = Allocator::new();
+    let start = Instant::now();
+    let parsed = Parser::with_options(&allocator, source, ParserOptions::gfm()).parse();
+    let elapsed = start.elapsed();
+    assert!(parsed.is_ok(), "source should parse");
+    elapsed
+}
+
+const NESTING_CASES: [(&str, &str); 12] = [
+    ("*a **b** c*", "<p><em>a <strong>b</strong> c</em></p>"),
+    ("**a *b* c**", "<p><strong>a <em>b</em> c</strong></p>"),
+    ("***abc***", "<p><em><strong>abc</strong></em></p>"),
+    ("*a *b* c*", "<p><em>a <em>b</em> c</em></p>"),
+    ("_a_b_c_", "<p><em>a_b_c</em></p>"),
+    ("a*b*c*d*e", "<p>a<em>b</em>c<em>d</em>e</p>"),
+    ("**a**b**c**", "<p><strong>a</strong>b<strong>c</strong></p>"),
+    ("*(**foo**)*", "<p><em>(<strong>foo</strong>)</em></p>"),
+    ("foo***bar***baz", "<p>foo<em><strong>bar</strong></em>baz</p>"),
+    ("*a `b` c*", "<p><em>a <code>b</code> c</em></p>"),
+    ("**[l](u)**", "<p><strong><a href=\"u\">l</a></strong></p>"),
+    ("*foo **bar** baz*", "<p><em>foo <strong>bar</strong> baz</em></p>"),
+];
+
+#[test]
+fn nested_pairs_keep_their_shape() {
+    for (source, expected) in NESTING_CASES {
+        assert_eq!(render(source), expected, "for {source:?}");
+        check_tree(source);
+    }
+}
+
+#[test]
+fn retired_delimiters_never_pair_across_a_finished_span() {
+    // The inner `*` runs are consumed by the inner pair; if they stayed
+    // available they would reach past the closing `*` and re-pair.
+    assert_eq!(render("*a *b* c* d*"), "<p><em>a <em>b</em> c</em> d*</p>");
+    assert_eq!(render("**a *b* c** d*"), "<p><strong>a <em>b</em> c</strong> d*</p>");
+    check_tree("*a *b* c* d*");
+}
+
+#[test]
+fn a_failed_search_does_not_hide_a_later_opener() {
+    // The first `*` cannot close; the search that fails for it must not
+    // bound the search for the closers that follow.
+    assert_eq!(render("* a *b* c"), "<ul>\n<li>a <em>b</em> c</li>\n</ul>");
+    assert_eq!(render("a* b *c* d"), "<p>a* b <em>c</em> d</p>");
+    assert_eq!(render("_a _b_ c"), "<p>_a <em>b</em> c</p>");
+    // Rule of three: `**` cannot close `*`, but the `*` after it can.
+    assert_eq!(render("*foo**bar*"), "<p><em>foo**bar</em></p>");
+}
+
+#[test]
+fn every_pair_in_a_long_sequence_is_formed() {
+    let source = "**bold** and *ital* ".repeat(400);
+    let rendered = render(&source);
+    assert_eq!(rendered.matches("<strong>").count(), 400);
+    assert_eq!(rendered.matches("<em>").count(), 400);
+    check_tree(&source);
+}
+
+#[test]
+fn a_long_sequence_of_unpairable_delimiters_stays_literal() {
+    // Space on both sides means each run can neither open nor close, so
+    // every opener search fails — the path `openers_bottom` short-circuits.
+    let source = "x * ".repeat(400);
+    let rendered = render(&source);
+    assert_eq!(rendered.matches("<em>").count(), 0);
+    assert_eq!(rendered.matches("<strong>").count(), 0);
+    assert_eq!(rendered.matches('*').count(), 400, "every marker stays literal");
+    check_tree(&source);
+
+    // Intraword `_` cannot open or close either.
+    let source = "a_b".repeat(400);
+    let rendered = render(&source);
+    assert_eq!(rendered.matches("<em>").count(), 0);
+    assert_eq!(rendered.matches('_').count(), 400);
+    check_tree(&source);
+}
+
+#[test]
+fn emphasis_pairing_costs_linear_time() {
+    // Four times the delimiters used to cost sixteen times the work, both
+    // when they pair and when they cannot. Anything under eight proves the
+    // per-pairing vector walk is gone without pinning an absolute time.
+    let builds: [fn(usize) -> String; 3] =
+        [|n| "**bold** and *ital* ".repeat(n), |n| "x * ".repeat(n), |n| "*_".repeat(n) + "a"];
+    for build in builds {
+        let small = time_parse(&build(1_000)).max(Duration::from_micros(1));
+        let large = time_parse(&build(4_000));
+        assert!(large < small * 8, "4x the delimiters took {large:?} against {small:?}");
+    }
+}


### PR DESCRIPTION
## Summary

Emphasis pairing was quadratic in the number of delimiters in a sequence, in two independent ways.

**Every successful pairing walked everything.** `children.drain` + `insert` shifted the child nodes, a fixup loop re-based every `node_index` to the right of the pair, two `position()` scans re-found the pair afterwards, and `Vec::remove` shifted the delimiter tail twice. A paragraph full of emphasis paid all of that per pair.

**Every failed search rescanned the stack.** `find_opener` walks back over every earlier delimiter, and the spec's `openers_bottom` bound was missing — the old comment said so ("without the openers_bottom optimization; delimiter counts per sequence are small in practice"). A run of unpairable markers rescanned the same stack for every closer.

The fix:

- Lift the paired nodes out of `children` in place, leaving empty text in their slots. `node_index` never moves, so the fixup loop and both `position()` scans go away. The placeholders are dropped by the sweep that already existed for emptied delimiter text.
- Retire a spent delimiter by zeroing its count instead of erasing it from the vector — the closer loop and `find_opener` already skip zero-count entries, so the semantics are unchanged and no tail shifts.
- Add `openers_bottom`, keyed the way the spec keys it (delimiter character, closer run length mod 3, whether the closer can also open), on the now-stable `node_index`.

| input | before | after |
| ----- | -----: | ----: |
| 80 KB of `**bold** and *ital*` | 293 ms | 1.1 ms |
| 160 KB of the same | ~1.2 s | 1.1 ms |
| 16 KB of unpairable `*_` markers | 107 ms | 0.4 ms |
| 80 KB of ordinary prose, 5 emphasis pairs per paragraph | 1.07 ms | 0.49 ms |

Ordinary emphasis-light prose gets faster too; the quadratic term was never the only cost being paid.

## Risk

- Risk level: medium — this is the CommonMark delimiter stack, the subtlest part of inline parsing. The output is unchanged and heavily verified (below).
- User or production impact: parse time only. Long emphasis-dense sequences — a big table row, a dense heading, generated prose — stop being super-linear.
- Rollback plan: revert the commit; the change is confined to `process_emphasis` and `find_opener`.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_parser -p ox_content_renderer -p ox_content_transform` (1054 pass, including all 652 CommonMark 0.31.2 examples in both modes and the 23 GFM extension examples), `cargo clippy -p ox_content_parser --all-targets -- -D warnings`, `cargo fmt --all --check`, `node scripts/check-panic-constructs.mjs`, `node scripts/check-file-lines.ts`.
- [x] Manual verification completed:
  - **240,000 randomized inputs** over four delimiter-dense alphabets (bare runs, CJK punctuation neighbours, mixed inline constructs, pre-formed emphasis), each rendered under GFM, plain, and `cjk_emphasis` options — **byte-identical** before and after.
  - The 354-file Markdown/MDX corpus under `docs/`, `examples/`, `npm/`, and `crates/`, rendered in GFM, MDX, plain, and CJK modes — **byte-identical**.
- [x] Edge cases or failure modes considered: nested and adjacent pairs, rule-of-three, intraword `_`, emphasis wrapping code spans and links, delimiters retired inside a finished span, and failed searches that must not hide a later opener.

New `crates/ox_content_parser/tests/emphasis_pairing.rs` checks the tree as well as the HTML, because both halves of this change are invisible in the output when they work: it asserts no placeholder empty-text node survives at any depth and that emphasis spans stay in bounds. The timing test fails on `main` (16.6x growth for 4x the delimiters, against the 8x it allows).

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated: the module and function comments now describe what keeps pairing linear; the stale "without the openers_bottom optimization" note is gone.
- [x] Configuration, migration, or environment changes documented, or not needed — none.
- [x] Observability, logging, and alerting impact considered, or not needed — none.
- [x] Security, privacy, and dependency impact considered: removes a super-linear path reachable from ordinary content. No new dependencies.
