### PR TITLE
fix(sanitize): stop truncating unquoted attribute values at the first slash

### DIFF
--- a/crates/ox_content_transform/src/sanitize/parser.rs
+++ b/crates/ox_content_transform/src/sanitize/parser.rs
@@ -34,9 +34,29 @@ impl<'a> ParsedTag<'a> {
             return None;
         }
         let attr_text = raw[cursor..].trim();
-        let self_closing = attr_text.ends_with('/');
-        let attr_text = attr_text.trim_end_matches('/').trim();
+        // A trailing `/` only marks self-closing when it stands on its own.
+        // Against an unquoted attribute value it is part of that value —
+        // `<img src=a.png/>` is `src="a.png/"` to a browser — so stripping
+        // every trailing slash truncated URLs such as `href=/docs/page/`.
+        let self_closing = closes_tag(attr_text);
+        let attr_text =
+            if self_closing { attr_text[..attr_text.len() - 1].trim_end() } else { attr_text };
         Some(Self { name, closing, self_closing, attrs: parse_attrs(attr_text) })
+    }
+}
+
+/// Whether the attribute text ends in a self-closing `/`.
+///
+/// It does when the slash is the whole text (`<br/>`) or when whitespace or
+/// a closing quote separates it from what came before (`<img src="a"/>`).
+/// A slash glued to an unquoted value belongs to that value.
+fn closes_tag(attr_text: &str) -> bool {
+    let Some(rest) = attr_text.strip_suffix('/') else {
+        return false;
+    };
+    match rest.chars().next_back() {
+        None => true,
+        Some(ch) => ch.is_whitespace() || ch == '"' || ch == '\'',
     }
 }
 
@@ -52,7 +72,6 @@ fn parse_attrs(mut raw: &str) -> Vec<ParsedAttr<'_>> {
         while name_end < bytes.len()
             && !bytes[name_end].is_ascii_whitespace()
             && bytes[name_end] != b'='
-            && bytes[name_end] != b'/'
         {
             name_end += 1;
         }
@@ -78,10 +97,11 @@ fn parse_attrs(mut raw: &str) -> Vec<ParsedAttr<'_>> {
                     raw = "";
                 }
             } else {
-                let value_end = raw
-                    .bytes()
-                    .position(|byte| byte.is_ascii_whitespace() || byte == b'/')
-                    .unwrap_or(raw.len());
+                // An unquoted value runs to the next whitespace. `/` does not
+                // end it — HTML only stops on whitespace or `>`, and the tag's
+                // own `>` is already gone by the time we get here.
+                let value_end =
+                    raw.bytes().position(|byte| byte.is_ascii_whitespace()).unwrap_or(raw.len());
                 value = Some(&raw[..value_end]);
                 raw = &raw[value_end..];
             }

--- a/crates/ox_content_transform/tests/sanitize_attributes.rs
+++ b/crates/ox_content_transform/tests/sanitize_attributes.rs
@@ -1,0 +1,83 @@
+//! Unquoted attribute values used to end at the first `/`, so the
+//! sanitizer emptied or truncated exactly the values that matter most:
+//! `href=/docs/page` became `href=""`, and `href=https://x/page` became
+//! `href="https:"`. HTML ends an unquoted value at whitespace, and the
+//! trailing `/` of `<img src=a.png/>` belongs to the value.
+
+use ox_content_transform::sanitize::sanitize_html;
+
+fn sanitize(html: &str) -> String {
+    sanitize_html(html, None)
+}
+
+#[test]
+fn unquoted_paths_survive() {
+    assert_eq!(sanitize("<a href=/docs/page>x</a>"), "<a href=\"/docs/page\">x</a>");
+    assert_eq!(sanitize("<img src=/a/b.png>"), "<img src=\"/a/b.png\">");
+    assert_eq!(sanitize("<a href=../up/one>x</a>"), "<a href=\"../up/one\">x</a>");
+    assert_eq!(sanitize("<a href=#frag>x</a>"), "<a href=\"#frag\">x</a>");
+}
+
+#[test]
+fn unquoted_absolute_urls_survive() {
+    assert_eq!(
+        sanitize("<a href=https://example.com/page>x</a>"),
+        "<a href=\"https://example.com/page\">x</a>"
+    );
+    assert_eq!(
+        sanitize("<a href=https://example.com/>x</a>"),
+        "<a href=\"https://example.com/\">x</a>"
+    );
+    assert_eq!(sanitize("<a href=/a/b/c/>x</a>"), "<a href=\"/a/b/c/\">x</a>");
+}
+
+#[test]
+fn several_unquoted_attributes_all_survive() {
+    assert_eq!(
+        sanitize("<a class=lead href=/y title=t>x</a>"),
+        "<a class=\"lead\" href=\"/y\" title=\"t\">x</a>"
+    );
+    assert_eq!(sanitize("<a href=/y disabled>x</a>"), "<a href=\"/y\" disabled>x</a>");
+}
+
+#[test]
+fn a_standalone_trailing_slash_still_closes_the_tag() {
+    assert_eq!(sanitize("<br/>"), "<br />");
+    assert_eq!(sanitize("<br />"), "<br />");
+    assert_eq!(sanitize("<hr/>"), "<hr />");
+    assert_eq!(sanitize("<img src=\"a.png\"/>"), "<img src=\"a.png\" />");
+    assert_eq!(sanitize("<img src='a.png'/>"), "<img src=\"a.png\" />");
+    assert_eq!(sanitize("<img src=a.png />"), "<img src=\"a.png\" />");
+}
+
+#[test]
+fn a_slash_glued_to_an_unquoted_value_belongs_to_the_value() {
+    // What a browser does with the same markup: the value runs to the
+    // whitespace or `>`, so `a.png/` is the source, not a close marker.
+    assert_eq!(sanitize("<img src=a.png/>"), "<img src=\"a.png/\">");
+}
+
+#[test]
+fn unquoted_values_are_still_screened() {
+    assert_eq!(sanitize("<img src=javascript:alert(1)>"), "<img>");
+    assert_eq!(sanitize("<img src=/a onerror=alert(1)>"), "<img src=\"/a\">");
+    assert_eq!(sanitize("<a href=vbscript:x>t</a>"), "<a>t</a>");
+    // A `/` before the colon still reads as a relative path, as it must.
+    assert_eq!(sanitize("<a href=/a:b>t</a>"), "<a href=\"/a:b\">t</a>");
+}
+
+#[test]
+fn quoted_values_are_unchanged_by_the_new_scan() {
+    assert_eq!(sanitize("<a href=\"/docs/page\">x</a>"), "<a href=\"/docs/page\">x</a>");
+    assert_eq!(sanitize("<a href='/single/quoted'>x</a>"), "<a href=\"/single/quoted\">x</a>");
+    assert_eq!(sanitize("<a href=\"javascript:alert(1)\">x</a>"), "<a>x</a>");
+}
+
+#[test]
+fn a_broken_tag_still_collapses_to_something_inert() {
+    // The classic quote-confusion payload: whatever the sanitizer makes of
+    // it, no event handler and no second tag may reach the output.
+    let out = sanitize("<a \"><img src=x onerror=alert(1)>\">");
+    assert!(!out.contains("onerror"), "{out}");
+    assert!(!out.contains("<img"), "{out}");
+}


### PR DESCRIPTION
## Summary

The HTML sanitizer ended an unquoted attribute value at the first `/`, and `ParsedTag::parse` stripped every trailing `/` in a tag as a self-closing marker before attributes were read. Together those emptied or truncated the values that matter most:

| input | before | after |
| ----- | ------ | ----- |
| `<a href=/docs/page>` | `<a href="">` | `<a href="/docs/page">` |
| `<img src=/a/b.png>` | `<img src="">` | `<img src="/a/b.png">` |
| `<a href=https://x/page>` | `<a href="https:">` | `<a href="https://x/page">` |
| `<a href=https://x/>` | `<a href="https:" />` | `<a href="https://x/">` |

Every link and image written with unquoted HTML attributes broke the moment a site turned sanitization on, silently — the tag survives, only the destination is gone.

HTML ends an unquoted value at whitespace or `>`, and the `>` is already consumed by the time attributes are parsed, so the value simply runs to the next whitespace. A trailing `/` now marks a self-closing tag only when it stands alone (`<br/>`) or is separated by whitespace or a quote (`<img src="a" />`, `<img src=a.png />`). Glued to an unquoted value it belongs to that value — `<img src=a.png/>` is `src="a.png/"`, which is what a browser does with the same markup and therefore what the unsanitized page already renders.

## Risk

- Risk level: low
- User or production impact: fixes broken links and images on sanitized sites. The one output change beyond repairs is `<img src=a.png/>`, which now keeps the trailing slash in the value — matching the browser, and matching what the same page renders with sanitization off.
- Rollback plan: revert the commit; the change is confined to `sanitize/parser.rs`.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_transform -p ox_content_ssg -p ox_content_docs` (1098 pass, existing sanitizer snapshots unchanged), `cargo clippy -p ox_content_transform --all-targets -- -D warnings`, `cargo fmt --all --check`, `node scripts/check-panic-constructs.mjs`, `node scripts/check-file-lines.ts`.
- [x] Manual verification completed: 60,000 randomized fragments built from tag, attribute, quote, comment, control-character, and payload pieces were sanitized and checked for emitted `script`/`svg`/`object`/`embed`/`form`/`base`/`meta`/`link` tags, emitted `on*` handlers, and `javascript:`/`vbscript:` in URL attributes — none appeared.
- [x] Edge cases or failure modes considered: several unquoted attributes in one tag, valueless attributes, single- and double-quoted values, `<br/>`, `<hr/>`, `<img src="a"/>`, `<img src=a.png />`, `href=/a:b` (a relative path containing a colon), and the quote-confusion payload `<a "><img src=x onerror=alert(1)>">`.

New `crates/ox_content_transform/tests/sanitize_attributes.rs` covers all of the above; the screening tests pass on `main` too, so they pin the security behaviour across the change rather than only the repair.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed — the reasoning is on the new `closes_tag` helper and at both scan sites.
- [x] Configuration, migration, or environment changes documented, or not needed — none.
- [x] Observability, logging, and alerting impact considered, or not needed — none.
- [x] Security, privacy, and dependency impact considered: URL screening, event-handler removal, and tag allow-listing are untouched and re-verified by fuzzing. No new dependencies.
