### PR TITLE
fix(sanitize): decode attribute values once instead of escaping them twice

### DIFF
--- a/crates/ox_content_transform/src/sanitize.rs
+++ b/crates/ox_content_transform/src/sanitize.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::SanitizeOptions;
 
 pub fn sanitize_html(html: &str, options: Option<&SanitizeOptions>) -> String {
@@ -108,7 +110,12 @@ fn write_sanitized_attr(out: &mut String, attr: &ParsedAttr<'_>, config: &Saniti
     if attr.name.starts_with("on") || !is_attr_name(&attr.name) || !config.allows_attr(&attr.name) {
         return;
     }
-    if let Some(value) = attr.value {
+    // The input is already-escaped HTML, so the value has to be decoded
+    // before anything looks at it: the checks below must see the URL the
+    // browser will see, and escaping an escaped value again would turn a
+    // query string's `&amp;` into a literal `&amp;`.
+    let decoded = attr.value.map(|value| decode_char_refs(value));
+    if let Some(value) = decoded.as_deref() {
         match attr.name.as_str() {
             "href" | "src" | "action" | "poster" if !config.allows_url(value) => return,
             "srcset" if !config.allows_srcset(value) => return,
@@ -117,11 +124,72 @@ fn write_sanitized_attr(out: &mut String, attr: &ParsedAttr<'_>, config: &Saniti
     }
     out.push(' ');
     out.push_str(&attr.name);
-    if let Some(value) = attr.value {
+    if let Some(value) = decoded.as_deref() {
         out.push_str("=\"");
         escape_html_attr(value, out);
         out.push('"');
     }
+}
+
+/// Decodes the character references an escaped attribute value can hold:
+/// the five HTML escapes and both numeric forms.
+///
+/// A reference this does not know stays exactly as written, so it is
+/// re-escaped on the way out and reaches the page inert — the behaviour
+/// every value had before, kept for the names (`&colon;`, `&sol;`, …) that
+/// could otherwise disguise a scheme.
+fn decode_char_refs(value: &str) -> Cow<'_, str> {
+    if !value.contains('&') {
+        return Cow::Borrowed(value);
+    }
+    let mut out = String::with_capacity(value.len());
+    let mut rest = value;
+    while let Some(at) = rest.find('&') {
+        out.push_str(&rest[..at]);
+        let tail = &rest[at..];
+        if let Some((decoded, consumed)) = scan_char_ref(tail) {
+            out.push(decoded);
+            rest = &tail[consumed..];
+        } else {
+            out.push('&');
+            rest = &tail[1..];
+        }
+    }
+    out.push_str(rest);
+    Cow::Owned(out)
+}
+
+/// Scans one character reference at the start of `rest`, which begins with
+/// `&`. Returns the character and the bytes consumed including `&` and `;`.
+fn scan_char_ref(rest: &str) -> Option<(char, usize)> {
+    let bytes = rest.as_bytes();
+    if bytes.get(1) != Some(&b'#') {
+        for (name, ch) in
+            [("amp;", '&'), ("lt;", '<'), ("gt;", '>'), ("quot;", '"'), ("apos;", '\'')]
+        {
+            if rest[1..].starts_with(name) {
+                return Some((ch, 1 + name.len()));
+            }
+        }
+        return None;
+    }
+    let (digits_start, radix) = match bytes.get(2) {
+        Some(b'x' | b'X') => (3, 16),
+        _ => (2, 10),
+    };
+    let mut end = digits_start;
+    // Seven digits cover every code point in either radix; more is invalid.
+    while end < bytes.len().min(digits_start + 8) && bytes[end].is_ascii_hexdigit() {
+        end += 1;
+    }
+    if end == digits_start || bytes.get(end) != Some(&b';') {
+        return None;
+    }
+    let code = u32::from_str_radix(&rest[digits_start..end], radix).ok()?;
+    // U+0000 and anything out of range become the replacement character,
+    // matching how the Markdown parser decodes the same references.
+    let ch = char::from_u32(code).filter(|ch| *ch != '\0').unwrap_or('\u{FFFD}');
+    Some((ch, end + 1))
 }
 
 fn escape_html_text(value: &str, out: &mut String) {
@@ -142,6 +210,13 @@ fn escape_html_attr(value: &str, out: &mut String) {
             '"' => out.push_str("&quot;"),
             '<' => out.push_str("&lt;"),
             '>' => out.push_str("&gt;"),
+            // A line break inside a quoted value is legal but survives
+            // poorly through anything that reads the HTML back a line at a
+            // time, and the values that carry them — code sources, titles —
+            // arrive written this way.
+            '\n' => out.push_str("&#10;"),
+            '\r' => out.push_str("&#13;"),
+            '\t' => out.push_str("&#9;"),
             _ => out.push(ch),
         }
     }

--- a/crates/ox_content_transform/tests/sanitize_entities.rs
+++ b/crates/ox_content_transform/tests/sanitize_entities.rs
@@ -1,0 +1,120 @@
+//! The sanitizer runs over already-escaped HTML, so an attribute value
+//! reaching it is escaped text, not the value itself. It used to escape
+//! that text a second time — turning a query string's `&amp;` into a
+//! literal `&amp;` — and to run its URL screening against the escaped
+//! form, where `&#106;avascript:` reads as a harmless relative path that
+//! the browser then decodes back into a scheme.
+//!
+//! Values are now decoded once, screened, and escaped once on the way out.
+
+use ox_content_transform::sanitize::sanitize_html;
+use ox_content_transform::transformer::MarkdownTransformer;
+use ox_content_transform::{SanitizeOptions, TransformOptions};
+
+fn sanitize(html: &str) -> String {
+    sanitize_html(html, None)
+}
+
+fn transform_sanitized(markdown: &str) -> String {
+    let transformer = MarkdownTransformer::from_options(&TransformOptions {
+        gfm: Some(true),
+        sanitize: Some(SanitizeOptions::default()),
+        ..Default::default()
+    });
+    transformer.transform(markdown).html.trim().to_string()
+}
+
+#[test]
+fn a_query_string_keeps_its_ampersands() {
+    assert_eq!(
+        transform_sanitized("[q](/search?a=1&b=2)"),
+        "<p><a href=\"/search?a=1&amp;b=2\">q</a></p>"
+    );
+    assert_eq!(sanitize("<a href=\"/x?a=1&amp;b=2\">t</a>"), "<a href=\"/x?a=1&amp;b=2\">t</a>");
+}
+
+#[test]
+fn text_attributes_keep_their_escapes() {
+    assert_eq!(
+        transform_sanitized("![alt \"x\" & y](/i.png \"t & u\")"),
+        "<p><img src=\"/i.png\" alt=\"alt &quot;x&quot; &amp; y\" title=\"t &amp; u\"></p>"
+    );
+    assert_eq!(
+        sanitize("<a title=\"&lt;b&gt; &amp;amp; &quot;q&quot;\">t</a>"),
+        "<a title=\"&lt;b&gt; &amp;amp; &quot;q&quot;\">t</a>"
+    );
+}
+
+#[test]
+fn sanitizing_twice_changes_nothing() {
+    // Every escape the sanitizer emits has to survive its own next pass;
+    // otherwise a value drifts a little further from the author's every
+    // time the HTML is handled again.
+    for html in [
+        "<a href=\"/x?a=1&amp;b=2\" title=\"a &amp; b\">t</a>",
+        "<img src=\"/i.png\" alt=\"&quot;q&quot; &amp; &lt;b&gt;\">",
+        "<a href=\"/a&#63;b\">t</a>",
+        "<pre data-ox-code-source=\"line 1&#10;line 2\"><code>x</code></pre>",
+    ] {
+        let once = sanitize(html);
+        assert_eq!(sanitize(&once), once, "not idempotent for {html}");
+    }
+}
+
+#[test]
+fn a_line_break_in_an_attribute_stays_encoded() {
+    assert_eq!(
+        sanitize("<pre data-ox-code-source=\"line 1&#10;line 2\"><code>x</code></pre>"),
+        "<pre data-ox-code-source=\"line 1&#10;line 2\"><code>x</code></pre>"
+    );
+    assert_eq!(sanitize("<a title=\"a\nb\">t</a>"), "<a title=\"a&#10;b\">t</a>");
+}
+
+#[test]
+fn an_encoded_scheme_is_refused_rather_than_escaped() {
+    // A browser decodes these back into `javascript:`, so screening has to
+    // see them decoded. Dropping the attribute is the only safe answer.
+    for html in [
+        "<a href=\"&#106;avascript:alert(1)\">t</a>",
+        "<a href=\"&#74;avaScript:alert(1)\">t</a>",
+        "<a href=\"&#x6a;avascript:alert(1)\">t</a>",
+        "<a href=\"javascript&#58;alert(1)\">t</a>",
+        "<a href=\"&#106;&#97;&#118;&#97;script&#58;alert(1)\">t</a>",
+    ] {
+        assert_eq!(sanitize(html), "<a>t</a>", "for {html}");
+    }
+    assert_eq!(sanitize("<img src=\"&#106;avascript:alert(1)\">"), "<img>");
+}
+
+#[test]
+fn a_reference_the_decoder_does_not_know_stays_inert() {
+    // `&colon;` would decode to `:` in a browser, so it must not reach the
+    // page as written; escaping the `&` keeps it literal text, which is
+    // what it was before decoding existed.
+    assert_eq!(
+        sanitize("<a href=\"javascript&colon;alert(1)\">t</a>"),
+        "<a href=\"javascript&amp;colon;alert(1)\">t</a>"
+    );
+    assert_eq!(
+        sanitize("<img alt=\"&unknown; &notreal\">"),
+        "<img alt=\"&amp;unknown; &amp;notreal\">"
+    );
+}
+
+#[test]
+fn an_encoded_path_decodes_to_the_path_the_author_wrote() {
+    assert_eq!(sanitize("<a href=\"/a&#63;b\">t</a>"), "<a href=\"/a?b\">t</a>");
+    assert_eq!(sanitize("<a href=\"/a&#35;frag\">t</a>"), "<a href=\"/a#frag\">t</a>");
+    // U+0000 is not a character a URL may carry; the parser maps it to the
+    // replacement character and so does this.
+    assert_eq!(sanitize("<a href=\"&#0;/x\">t</a>"), "<a href=\"\u{FFFD}/x\">t</a>");
+}
+
+#[test]
+fn plain_urls_and_schemes_behave_as_before() {
+    assert_eq!(sanitize("<a href=\"https://x/p?a=1\">t</a>"), "<a href=\"https://x/p?a=1\">t</a>");
+    assert_eq!(sanitize("<a href=\"mailto:a@b.c\">t</a>"), "<a href=\"mailto:a@b.c\">t</a>");
+    assert_eq!(sanitize("<a href=\"javascript:alert(1)\">t</a>"), "<a>t</a>");
+    assert_eq!(sanitize("<a href=\"vbscript:x\">t</a>"), "<a>t</a>");
+    assert_eq!(sanitize("<a href=\"data:text/html,x\">t</a>"), "<a>t</a>");
+}

--- a/crates/ox_content_transform/tests/sanitize_invariants.rs
+++ b/crates/ox_content_transform/tests/sanitize_invariants.rs
@@ -1,0 +1,167 @@
+//! Properties the sanitizer must hold for *any* input, checked against
+//! randomized fragments built from the pieces that break HTML parsers:
+//! stray quotes, half-open comments, control characters, encoded schemes,
+//! and tags that never close.
+//!
+//! A hand-written case list only covers the payloads someone thought of.
+//! These four properties are what the sanitizer actually promises.
+
+use ox_content_transform::sanitize::sanitize_html;
+
+/// xorshift64 — deterministic, so a failure reproduces from its seed.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+
+    fn below(&mut self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
+    }
+}
+
+const PIECES: &[&str] = &[
+    "<a",
+    "<img",
+    "<script",
+    "<svg",
+    "<iframe",
+    "<p",
+    "</a>",
+    "</p>",
+    ">",
+    "/>",
+    "/",
+    " ",
+    "href=",
+    "src=",
+    "onerror=",
+    "onclick=",
+    "class=",
+    "srcset=",
+    "title=",
+    "poster=",
+    "=",
+    "\"",
+    "'",
+    "javascript:",
+    "vbscript:",
+    "data:text/html,",
+    "https://x/",
+    "/a/b",
+    "alert(1)",
+    "x",
+    "<!--",
+    "-->",
+    "<!",
+    "?",
+    "&",
+    "&amp;",
+    "&#106;",
+    "&#58;",
+    "&#x3a;",
+    "&colon;",
+    "&lt;",
+    "&#0;",
+    "\n",
+    "\t",
+    "<",
+    "\u{0}",
+    "\u{a0}",
+];
+
+const FORBIDDEN_TAGS: [&str; 9] =
+    ["script", "svg", "object", "embed", "form", "base", "meta", "link", "style"];
+
+const URL_ATTRS: [&str; 4] = ["href", "src", "poster", "action"];
+
+const DANGEROUS_SCHEMES: [&str; 3] = ["javascript:", "vbscript:", "data:"];
+
+/// The `<name ...>` runs the sanitizer emitted, without their delimiters.
+///
+/// Everything the sanitizer refused is escaped text, so a `<` that survives
+/// in the output really does open a tag the browser will act on.
+fn emitted_tags(html: &str) -> Vec<&str> {
+    let bytes = html.as_bytes();
+    let mut tags = Vec::new();
+    let mut cursor = 0;
+    while let Some(relative) = html[cursor..].find('<') {
+        let start = cursor + relative;
+        let Some(end_relative) = html[start..].find('>') else {
+            break;
+        };
+        let end = start + end_relative;
+        if bytes.get(start + 1).is_some_and(|byte| byte.is_ascii_alphabetic() || *byte == b'/') {
+            tags.push(&html[start + 1..end]);
+        }
+        cursor = end + 1;
+    }
+    tags
+}
+
+fn fragment(seed: u64) -> String {
+    let mut rng = Rng(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1);
+    let pieces = 1 + rng.below(14);
+    let mut source = String::new();
+    for _ in 0..pieces {
+        source.push_str(PIECES[rng.below(PIECES.len())]);
+    }
+    source
+}
+
+#[test]
+fn no_fragment_survives_sanitizing_with_teeth() {
+    let mut failures = Vec::new();
+    for seed in 1..40_000u64 {
+        let source = fragment(seed);
+        let once = sanitize_html(&source, None);
+
+        // 1. Sanitizing is idempotent: an escape the sanitizer emits has to
+        //    survive its own next pass, or values drift on every handling.
+        let twice = sanitize_html(&once, None);
+        if once != twice {
+            failures.push(format!(
+                "seed {seed}: not idempotent\n  {source:?}\n  {once:?}\n  {twice:?}"
+            ));
+        }
+
+        for tag in emitted_tags(&once) {
+            let lower = tag.to_ascii_lowercase();
+            let name: String = lower
+                .trim_start_matches('/')
+                .chars()
+                .take_while(char::is_ascii_alphanumeric)
+                .collect();
+
+            // 2. No tag outside the allow list reaches the page.
+            if FORBIDDEN_TAGS.contains(&name.as_str()) {
+                failures.push(format!("seed {seed}: emitted <{name}>\n  {source:?}\n  {once:?}"));
+            }
+
+            // 3. No event handler survives, whatever shape it arrived in.
+            if lower.contains(" on") {
+                failures.push(format!("seed {seed}: event handler\n  {source:?}\n  {tag:?}"));
+            }
+
+            // 4. No navigable attribute carries a scripting scheme.
+            for attr in URL_ATTRS {
+                for scheme in DANGEROUS_SCHEMES {
+                    if lower.contains(&(attr.to_string() + "=\"" + scheme)) {
+                        failures
+                            .push(format!("seed {seed}: {attr}={scheme}\n  {source:?}\n  {tag:?}"));
+                    }
+                }
+            }
+        }
+        if failures.len() > 8 {
+            break;
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n\n"));
+}


### PR DESCRIPTION
## Summary

The sanitizer runs over already-escaped HTML, so an attribute value reaching it is escaped *text*, not the value. It escaped that text a second time.

| markdown | before | after |
| -------- | ------ | ----- |
| `[q](/search?a=1&b=2)` | `href="/search?a=1&amp;amp;b=2"` | `href="/search?a=1&amp;b=2"` |
| `![a "x" & y](/i.png)` | `alt="a &amp;quot;x&amp;quot; &amp;amp; y"` | `alt="a &quot;x&quot; &amp; y"` |

Any query string with more than one parameter pointed at the **wrong URL** on every site with sanitization on, and image alt text showed its own escapes.

The same mistake ran URL screening against the escaped form. `&#106;avascript:alert(1)` has no colon before its first path marker there, so it reads as an ordinary relative path and was **accepted** — it only stayed harmless because the second escaping pass made the whole value inert. Screening that depends on a downstream bug for its safety is not screening.

Values are now decoded once, screened in decoded form, and escaped once on the way out:

- Entity-encoded schemes (`&#106;avascript:`, `javascript&#58;`, `&#x6a;avascript:`, `&#106;&#97;&#118;&#97;script&#58;`) are **refused** rather than defused.
- References the decoder does not know — `&colon;`, `&sol;`, anything else that could disguise a scheme — keep their `&` escaped and reach the page inert, exactly as before.
- Line breaks in an attribute are re-encoded, so values such as `data-ox-code-source="line 1&#10;line 2"` round-trip unchanged.

## Risk

- Risk level: medium — it changes what every sanitized attribute looks like. Every change is a repair or a tightening; both directions are pinned by tests.
- User or production impact: URLs with query strings, and any attribute containing `&`, `<`, `>` or `"`, now render as the author wrote them. Attributes whose decoded value turns out to be a scripting scheme are dropped instead of being emitted in escaped form.
- Rollback plan: revert the commit; the change is confined to `sanitize.rs`.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_transform -p ox_content_ssg -p ox_content_docs` (1099 pass; the existing sanitizer snapshots are unchanged), `cargo clippy -p ox_content_transform --all-targets -- -D warnings`, `cargo fmt --all --check`, `node scripts/check-panic-constructs.mjs`, `node scripts/check-file-lines.ts`.
- [x] Manual verification completed: 80,000 randomized fragments built from stray quotes, half-open comments, control characters, encoded schemes, and never-closing tags — no forbidden tag, no event handler, no scripting scheme in a navigable attribute, and no non-idempotent result.
- [x] Edge cases or failure modes considered: `&#0;` (mapped to U+FFFD like the Markdown parser does), hex and decimal forms, uppercase `&#74;avaScript:`, unknown named references, already-double-escaped values such as `&amp;amp;`, and literal newlines in an attribute.

Two new test files: `sanitize_entities.rs` pins the repairs and the tightening case by case, and `sanitize_invariants.rs` states the four properties as a property test over 40,000 fragments — idempotence, tag allow-listing, handler removal, and scheme screening — so the next payload nobody thought of is covered too.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed — the decoder and its deliberate gap (unknown named references stay escaped) are documented where they live.
- [x] Configuration, migration, or environment changes documented, or not needed — none.
- [x] Observability, logging, and alerting impact considered, or not needed — none.
- [x] Security, privacy, and dependency impact considered: closes a screening bypass that was only inert by accident, and adds a property test that would have caught it. No new dependencies.
