### PR TITLE
perf(renderer): find a free footnote slug without scanning every footnote

### DIFF
--- a/crates/ox_content_renderer/src/html/renderer.rs
+++ b/crates/ox_content_renderer/src/html/renderer.rs
@@ -50,6 +50,12 @@ pub struct HtmlRenderer {
     footnote_index: FxHashMap<CompactString, u32>,
     /// Document-order footnote list used when `semantic_footnotes` is on.
     footnote_records: Vec<footnotes::FootnoteRecord>,
+    /// Slugs already handed to a footnote, mapped to the next `-N` suffix
+    /// to try for that slug as a base. Presence means "taken", so one
+    /// lookup answers both questions the uniquifier asks. This replaces a
+    /// scan of `footnote_records` per footnote, which made a document of
+    /// many footnotes quadratic. Cleared per render like the heading map.
+    footnote_slug_counts: FxHashMap<CompactString, usize>,
     toc_entries: Vec<InlineTocEntry>,
     /// Whether the document being rendered contains at least one
     /// `[[toc]]` directive paragraph. Cached at `render()` entry so each
@@ -117,6 +123,7 @@ impl HtmlRenderer {
             footnote_ref_counts: FxHashMap::default(),
             footnote_index: FxHashMap::default(),
             footnote_records: Vec::new(),
+            footnote_slug_counts: FxHashMap::default(),
             toc_entries: Vec::new(),
             document_has_toc_marker: false,
             // Pre-size the heading scratch buffers: a typical heading text

--- a/crates/ox_content_renderer/src/html/renderer/footnotes.rs
+++ b/crates/ox_content_renderer/src/html/renderer/footnotes.rs
@@ -19,6 +19,9 @@ use super::super::escape::write_escaped_into;
 use super::super::heading::slugify_heading_into;
 use super::HtmlRenderer;
 
+/// First `-N` tried when a slug repeats, matching the ids the scan produced.
+const FIRST_SUFFIX: usize = 2;
+
 #[derive(Clone)]
 pub(super) struct FootnoteRecord {
     pub(super) slug: CompactString,
@@ -80,6 +83,7 @@ impl HtmlRenderer {
         self.footnote_ref_counts.clear();
         self.footnote_index.clear();
         self.footnote_records.clear();
+        self.footnote_slug_counts.clear();
     }
 
     fn render_legacy_footnote_reference(&mut self, identifier: &str) {
@@ -204,20 +208,37 @@ impl HtmlRenderer {
         write_escaped_into(&mut self.output, &self.footnote_records[index].slug);
     }
 
+    /// Turns the slug in `heading_slug_scratch` into one no footnote holds,
+    /// appending `-2`, `-3`, ... as the old scan did.
+    ///
+    /// The map answers "is this slug taken" in one lookup, and remembers
+    /// per base slug which suffix the last collision reached — so a run of
+    /// identical slugs walks forward instead of restarting at `-2` and
+    /// re-testing every earlier one.
     fn uniquify_footnote_slug(&mut self) {
-        if !self.footnote_records.iter().any(|record| record.slug == self.heading_slug_scratch) {
-            return;
-        }
         let base_len = self.heading_slug_scratch.len();
-        let mut suffix = 2usize;
+        let Some(&start) = self.footnote_slug_counts.get(self.heading_slug_scratch.as_str()) else {
+            self.claim_footnote_slug();
+            return;
+        };
+        // Only allocated when a slug actually repeats, which is rare.
+        let base = CompactString::from(&self.heading_slug_scratch[..base_len]);
+        let mut suffix = start;
         loop {
             self.heading_slug_scratch.truncate(base_len);
             let _ = write!(self.heading_slug_scratch, "-{suffix}");
-            if !self.footnote_records.iter().any(|record| record.slug == self.heading_slug_scratch)
-            {
+            suffix += 1;
+            if !self.footnote_slug_counts.contains_key(self.heading_slug_scratch.as_str()) {
+                self.claim_footnote_slug();
+                self.footnote_slug_counts.insert(base, suffix);
                 return;
             }
-            suffix += 1;
         }
+    }
+
+    /// Records the scratch slug as taken, starting its own suffix run at 2.
+    fn claim_footnote_slug(&mut self) {
+        self.footnote_slug_counts
+            .insert(CompactString::from(self.heading_slug_scratch.as_str()), FIRST_SUFFIX);
     }
 }

--- a/crates/ox_content_renderer/src/html/renderer/incremental.rs
+++ b/crates/ox_content_renderer/src/html/renderer/incremental.rs
@@ -26,6 +26,7 @@ impl HtmlRenderer {
         let footnote_ref_counts = self.footnote_ref_counts.clone();
         let footnote_index = self.footnote_index.clone();
         let footnote_records = self.footnote_records.clone();
+        let footnote_slug_counts = self.footnote_slug_counts.clone();
         let html = self.render_fragment_with_scan(document, document_scan);
         if let Some(heading_id_counts) = heading_id_counts {
             self.heading_id_counts = heading_id_counts;
@@ -33,6 +34,7 @@ impl HtmlRenderer {
         self.footnote_ref_counts = footnote_ref_counts;
         self.footnote_index = footnote_index;
         self.footnote_records = footnote_records;
+        self.footnote_slug_counts = footnote_slug_counts;
         html
     }
 

--- a/crates/ox_content_renderer/tests/edge_footnote_slugs.rs
+++ b/crates/ox_content_renderer/tests/edge_footnote_slugs.rs
@@ -1,0 +1,148 @@
+//! Footnote slug uniquification.
+//!
+//! Two footnotes whose identifiers slugify the same have to end up with
+//! different ids, or the page carries duplicate anchors. Finding a free
+//! slug used to scan every footnote already emitted, which made a page of
+//! many footnotes quadratic; the ids it produced are what these tests pin.
+
+#[path = "support/edge.rs"]
+mod edge_support;
+
+use std::time::{Duration, Instant};
+
+use edge_support::render;
+use ox_content_allocator::Allocator;
+use ox_content_parser::{Parser, ParserOptions};
+use ox_content_renderer::{HtmlRenderer, HtmlRendererOptions};
+
+fn semantic(source: &str) -> String {
+    render(
+        source,
+        ParserOptions::gfm(),
+        HtmlRendererOptions { semantic_footnotes: true, ..HtmlRendererOptions::default() },
+    )
+}
+
+/// The `fn-…` ids in document order.
+fn footnote_ids(html: &str) -> Vec<String> {
+    html.match_indices("id=\"fn-")
+        .map(|(at, _)| {
+            let rest = &html[at + 7..];
+            rest[..rest.find('"').unwrap_or(0)].to_string()
+        })
+        .collect()
+}
+
+fn definitions(identifiers: &[&str]) -> String {
+    let mut source = String::new();
+    for identifier in identifiers {
+        source.push_str("[^");
+        source.push_str(identifier);
+        source.push_str("]: body\n\n");
+    }
+    source
+}
+
+#[test]
+fn colliding_slugs_are_numbered_in_document_order() {
+    assert_eq!(footnote_ids(&semantic(&definitions(&["x!", "x?", "x."]))), ["x", "x-2", "x-3"]);
+    assert_eq!(
+        footnote_ids(&semantic(&definitions(&["p.q", "p!q", "p?q"]))),
+        ["p-q", "p-q-2", "p-q-3"]
+    );
+}
+
+#[test]
+fn a_slug_that_is_already_a_suffixed_form_is_not_taken_twice() {
+    // `x-2` arrives on its own, so the collision after it has to skip past
+    // the id that footnote already holds.
+    assert_eq!(footnote_ids(&semantic(&definitions(&["x!", "x-2", "x?"]))), ["x", "x-2", "x-3"]);
+    assert_eq!(footnote_ids(&semantic(&definitions(&["x-2", "x!", "x?"]))), ["x-2", "x", "x-3"]);
+    // And a suffixed form that collides in turn gets suffixed itself.
+    assert_eq!(
+        footnote_ids(&semantic(&definitions(&["x!", "x?", "x-2", "x."]))),
+        ["x", "x-2", "x-2-2", "x-3"]
+    );
+}
+
+#[test]
+fn identifiers_without_a_usable_slug_fall_back_to_their_position() {
+    assert_eq!(
+        footnote_ids(&semantic(&definitions(&["!", "?", "@"]))),
+        ["footnote-1", "footnote-2", "footnote-3"]
+    );
+}
+
+#[test]
+fn distinct_identifiers_keep_their_own_slugs() {
+    let ids = footnote_ids(&semantic(&definitions(&["alpha", "beta", "gamma"])));
+    assert_eq!(ids, ["alpha", "beta", "gamma"]);
+}
+
+#[test]
+fn slugs_do_not_carry_over_between_renders() {
+    let options =
+        HtmlRendererOptions { semantic_footnotes: true, ..HtmlRendererOptions::default() };
+    let mut renderer = HtmlRenderer::with_options(options);
+    let source = definitions(&["x!", "x?"]);
+    let allocator = Allocator::new();
+    let document = Parser::with_options(&allocator, &source, ParserOptions::gfm())
+        .parse()
+        .expect("source should parse");
+
+    let first = renderer.render(&document);
+    let second = renderer.render(&document);
+    assert_eq!(footnote_ids(&first), ["x", "x-2"]);
+    assert_eq!(footnote_ids(&second), ["x", "x-2"], "a second render must start clean");
+}
+
+#[test]
+fn a_provisional_fragment_does_not_claim_slugs() {
+    // `render_provisional_fragment` is meant to be replaceable, so nothing
+    // it renders may push the real render's ids along.
+    let options =
+        HtmlRendererOptions { semantic_footnotes: true, ..HtmlRendererOptions::default() };
+    let mut renderer = HtmlRenderer::with_options(options);
+    let source = definitions(&["x!", "x?"]);
+    let allocator = Allocator::new();
+    let document = Parser::with_options(&allocator, &source, ParserOptions::gfm())
+        .parse()
+        .expect("source should parse");
+
+    let provisional = renderer.render_provisional_fragment(&document);
+    let final_html = renderer.render_provisional_fragment(&document);
+    assert_eq!(footnote_ids(&provisional), footnote_ids(&final_html));
+}
+
+#[test]
+fn many_footnotes_cost_linear_time() {
+    // Four times the footnotes used to cost sixteen times the work, because
+    // each one scanned every footnote before it.
+    let build = |count: usize| {
+        let mut source = String::new();
+        for index in 0..count {
+            source.push_str("[^n");
+            source.push_str(&index.to_string());
+            source.push_str("]: body\n\n");
+        }
+        source
+    };
+    let measure = |source: &str| {
+        let allocator = Allocator::new();
+        let document = Parser::with_options(&allocator, source, ParserOptions::gfm())
+            .parse()
+            .expect("source should parse");
+        let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
+            semantic_footnotes: true,
+            ..HtmlRendererOptions::default()
+        });
+        let start = Instant::now();
+        let html = renderer.render(&document);
+        assert!(!html.is_empty());
+        start.elapsed()
+    };
+
+    let small = measure(&build(2_000)).max(Duration::from_micros(1));
+    let large = measure(&build(8_000));
+    assert!(large < small * 8, "8,000 footnotes took {large:?} against {small:?} for 2,000");
+}


### PR DESCRIPTION
## Summary

`uniquify_footnote_slug` walked `footnote_records` to ask whether a slug was taken — once per footnote, and once more for every `-N` it tried. A page of footnotes was therefore quadratic.

| footnotes | before | after |
| --------- | -----: | ----: |
| 1,000     | 1.9 ms | 1.2 ms |
| 2,000     | 4.1 ms | 1.0 ms |
| 4,000     | 17.1 ms | 1.8 ms |
| 16,000    | — | 9.2 ms |

At 4,000 footnotes that scan was 17 ms of the 19 ms the whole transform spent; the same page with `semantic_footnotes` off took 1 ms.

Headings already solve this with `heading_id_counts`, a hash map of ids. Footnotes now use the same shape, and the map doubles as the suffix bookkeeping: a slug's entry holds the next `-N` to try for it, so a run of identical slugs walks forward instead of restarting at `-2` and re-testing every earlier one.

## Risk

- Risk level: low
- User or production impact: render time only. The ids are unchanged, including the order in which colliding slugs claim their suffixes.
- Rollback plan: revert the commit. It adds one renderer field and rewrites one function.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_renderer -p ox_content_transform -p ox_content_parser` (1089 pass, including the CommonMark 0.31.2 and GFM spec suites), `cargo clippy -p ox_content_renderer --all-targets -- -D warnings`, `cargo fmt --all --check`, `node scripts/check-panic-constructs.mjs`, `node scripts/check-file-lines.ts`.
- [x] Manual verification completed: 30,000 randomized documents whose footnote identifiers collide heavily in slug space (`a b` / `a-b` / `a_b` / `x!` / `x?` / `x-2` / `section` / non-alphanumeric / CJK, with and without references) render **byte-identically** before and after.
- [x] Edge cases or failure modes considered: a slug that is itself an already-suffixed form (`x`, `x-2` arriving on its own, then another `x`), a suffixed form that collides in turn (`x-2-2`), identifiers with no usable slug falling back to `footnote-N`, state not carrying between renders, and `render_provisional_fragment` — which snapshots footnote state precisely so a throwaway render cannot push the real one's ids along, and now snapshots the new map too.

New `crates/ox_content_renderer/tests/edge_footnote_slugs.rs` covers each of those plus a growth assertion: 4x the footnotes must cost less than 8x the time.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed — the field and the function carry the reasoning.
- [x] Configuration, migration, or environment changes documented, or not needed — none.
- [x] Observability, logging, and alerting impact considered, or not needed — none.
- [x] Security, privacy, and dependency impact considered, or not needed. No new dependencies.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790688743&installation_model_id=422833&pr_number=1216&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1216&signature=2fc8721cfd28ed8f7c4d55c99e27c698fa44c273486a60b3d3c0106702858a77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->