### PR TITLE
perf(ssg): resolve the pager by walking the sidebar, not copying it

### DIFF
--- a/crates/ox_content_ssg/src/html/pagination.rs
+++ b/crates/ox_content_ssg/src/html/pagination.rs
@@ -14,12 +14,6 @@ pub(super) struct PagerView {
     pub next: Option<PagerLinkView>,
 }
 
-struct NavPage {
-    title: String,
-    path: String,
-    href: String,
-}
-
 /// Resolves previous/next links from sidebar order and frontmatter overrides.
 pub(super) fn resolve_pager(
     page: &PageData,
@@ -30,13 +24,9 @@ pub(super) fn resolve_pager(
         return None;
     }
 
-    let pages = flatten_nav_pages(nav_groups);
-    let index = pages.iter().position(|item| page_matches(&page.path, item));
-    let auto_prev = index.and_then(|i| i.checked_sub(1)).and_then(|i| pages.get(i));
-    let auto_next = index.and_then(|i| pages.get(i + 1));
-
-    let prev = resolve_side(page.prev.as_ref(), auto_prev);
-    let next = resolve_side(page.next.as_ref(), auto_next);
+    let neighbours = find_neighbours(nav_groups, &page.path);
+    let prev = resolve_side(page.prev.as_ref(), neighbours.prev);
+    let next = resolve_side(page.next.as_ref(), neighbours.next);
 
     if prev.is_none() && next.is_none() {
         return None;
@@ -45,28 +35,62 @@ pub(super) fn resolve_pager(
     Some(PagerView { prev, next })
 }
 
-fn flatten_nav_pages(nav_groups: &[NavGroup]) -> Vec<NavPage> {
-    let mut pages = Vec::new();
-    for group in nav_groups {
-        flatten_nav_items(&group.items, &mut pages);
-    }
-    pages
+/// The sidebar entries on either side of the current page.
+#[derive(Default)]
+struct Neighbours<'a> {
+    prev: Option<&'a NavItem>,
+    next: Option<&'a NavItem>,
+    /// Set once the current page's own entry has been passed.
+    matched: bool,
+    /// Set once `next` is known, so the walk stops early.
+    done: bool,
 }
 
-fn flatten_nav_items(items: &[NavItem], pages: &mut Vec<NavPage>) {
+/// Walks the sidebar in the order it renders and returns the steppable
+/// entries either side of `page_path`.
+///
+/// This used to flatten the whole sidebar into an owned `Vec` first, which
+/// cloned three `String`s per entry — on every page. A site pays that for
+/// each page it builds, so it was quadratic in sidebar size with an
+/// allocator-bound constant. Nothing here needs ownership, and the walk
+/// stops one entry past the match.
+fn find_neighbours<'a>(nav_groups: &'a [NavGroup], page_path: &str) -> Neighbours<'a> {
+    let mut state = Neighbours::default();
+    for group in nav_groups {
+        visit_nav_items(&group.items, page_path, &mut state);
+        if state.done {
+            break;
+        }
+    }
+    if !state.matched {
+        // The page is not in the sidebar, so neither side is meaningful.
+        return Neighbours::default();
+    }
+    state
+}
+
+fn visit_nav_items<'a>(items: &'a [NavItem], page_path: &str, state: &mut Neighbours<'a>) {
     for item in items {
         if is_in_site_href(&item.href) {
-            pages.push(NavPage {
-                title: item.title.clone(),
-                path: item.path.clone(),
-                href: item.href.clone(),
-            });
+            if state.matched {
+                state.next = Some(item);
+                state.done = true;
+                return;
+            }
+            if page_matches(page_path, item) {
+                state.matched = true;
+            } else {
+                state.prev = Some(item);
+            }
         }
-        flatten_nav_items(&item.children, pages);
+        visit_nav_items(&item.children, page_path, state);
+        if state.done {
+            return;
+        }
     }
 }
 
-fn page_matches(page_path: &str, item: &NavPage) -> bool {
+fn page_matches(page_path: &str, item: &NavItem) -> bool {
     let current = normalize_path(page_path);
     current == normalize_path(&item.path) || current == normalize_path(&item.href)
 }
@@ -86,16 +110,24 @@ fn is_in_site_href(href: &str) -> bool {
     if trimmed.is_empty() || trimmed.starts_with('#') {
         return false;
     }
-    let lower = trimmed.to_ascii_lowercase();
-    if lower.starts_with("http://") || lower.starts_with("https://") {
+    if starts_with_ignore_case(trimmed, "http://") || starts_with_ignore_case(trimmed, "https://") {
         return false;
     }
     is_safe_href(trimmed)
 }
 
+/// Case-insensitive prefix test that does not build a lowercased copy.
+///
+/// This runs once per sidebar entry per page, so the copy it replaces was
+/// an allocation per entry per page across the whole site.
+fn starts_with_ignore_case(value: &str, prefix: &str) -> bool {
+    value.len() >= prefix.len()
+        && value.as_bytes()[..prefix.len()].eq_ignore_ascii_case(prefix.as_bytes())
+}
+
 fn resolve_side(
     override_link: Option<&PagerOverride>,
-    auto: Option<&NavPage>,
+    auto: Option<&NavItem>,
 ) -> Option<PagerLinkView> {
     match override_link {
         Some(over) if over.hidden => None,
@@ -119,8 +151,8 @@ fn resolve_side(
     }
 }
 
-fn nav_page_to_link(page: &NavPage) -> PagerLinkView {
-    PagerLinkView { title: page.title.clone(), href: page.href.clone() }
+fn nav_page_to_link(item: &NavItem) -> PagerLinkView {
+    PagerLinkView { title: item.title.clone(), href: item.href.clone() }
 }
 
 fn is_safe_href(href: &str) -> bool {
@@ -128,16 +160,17 @@ fn is_safe_href(href: &str) -> bool {
     if trimmed.is_empty() || trimmed.starts_with("//") {
         return false;
     }
-    let lower = trimmed.to_ascii_lowercase();
-    if lower.starts_with("javascript:")
-        || lower.starts_with("data:")
-        || lower.starts_with("vbscript:")
+    if starts_with_ignore_case(trimmed, "javascript:")
+        || starts_with_ignore_case(trimmed, "data:")
+        || starts_with_ignore_case(trimmed, "vbscript:")
     {
         return false;
     }
     if let Some(scheme_end) = trimmed.find(':') {
-        let scheme = &lower[..scheme_end];
-        return matches!(scheme, "http" | "https" | "mailto");
+        let scheme = &trimmed[..scheme_end];
+        return scheme.eq_ignore_ascii_case("http")
+            || scheme.eq_ignore_ascii_case("https")
+            || scheme.eq_ignore_ascii_case("mailto");
     }
     true
 }

--- a/crates/ox_content_ssg/src/html/pagination/tests.rs
+++ b/crates/ox_content_ssg/src/html/pagination/tests.rs
@@ -1,4 +1,5 @@
 mod flatten;
+mod walk;
 
 use super::super::{
     EntryPageConfig, HeadValidation, NavGroup, NavItem, PageChromeFlags, PageData, PagerOverride,

--- a/crates/ox_content_ssg/src/html/pagination/tests/walk.rs
+++ b/crates/ox_content_ssg/src/html/pagination/tests/walk.rs
@@ -1,0 +1,157 @@
+//! Where the sidebar walk starts and stops.
+//!
+//! Resolving the pager used to flatten the whole sidebar into an owned
+//! `Vec` and search it. It now walks the tree in place and stops one entry
+//! past the current page, so the cases that matter are the boundaries: the
+//! first entry, the last one, a match buried in a nested subtree whose
+//! successor lives in a later group, and a page the sidebar does not list
+//! at all — where a walk that forgot to check for a match would hand back
+//! whatever entry it happened to stop on.
+
+use std::time::{Duration, Instant};
+
+use super::super::super::{NavGroup, generate_html};
+use super::{config, guide, nav_item, nav_item_with_children, page, pager_html};
+
+fn three_pages() -> Vec<NavGroup> {
+    guide(vec![
+        nav_item("One", "one", "/docs/one/index.html"),
+        nav_item("Two", "two", "/docs/two/index.html"),
+        nav_item("Three", "three", "/docs/three/index.html"),
+    ])
+}
+
+#[test]
+fn the_first_entry_has_no_previous() {
+    let html = generate_html(&page("one"), &three_pages(), &config(true));
+    let pager = pager_html(&html).expect("the first page still has a next link");
+
+    assert!(!pager.contains(r#"rel="prev""#), "{pager}");
+    assert!(pager.contains(r#"href="/docs/two/index.html""#), "{pager}");
+}
+
+#[test]
+fn the_last_entry_has_no_next() {
+    let html = generate_html(&page("three"), &three_pages(), &config(true));
+    let pager = pager_html(&html).expect("the last page still has a previous link");
+
+    assert!(!pager.contains(r#"rel="next""#), "{pager}");
+    assert!(pager.contains(r#"href="/docs/two/index.html""#), "{pager}");
+}
+
+#[test]
+fn a_page_the_sidebar_does_not_list_gets_no_pager() {
+    let html = generate_html(&page("orphan"), &three_pages(), &config(true));
+
+    assert!(pager_html(&html).is_none(), "an unlisted page must not borrow a neighbour: {html}");
+}
+
+#[test]
+fn the_successor_may_live_in_a_later_group() {
+    let nav = vec![
+        guide(vec![nav_item_with_children(
+            "Parent",
+            "parent",
+            "/docs/parent/index.html",
+            vec![nav_item("Last child", "parent/z", "/docs/parent/z/index.html")],
+        )])
+        .remove(0),
+        NavGroup {
+            title: "Reference".to_string(),
+            items: vec![nav_item("API", "api", "/docs/api/index.html")],
+            collapsed: None,
+            sticky_collapsed: None,
+        },
+    ];
+
+    let html = generate_html(&page("parent/z"), &nav, &config(true));
+    let pager = pager_html(&html).expect("the last child of a group has a next in the next group");
+
+    assert!(pager.contains(r#"href="/docs/api/index.html""#), "{pager}");
+    assert!(pager.contains("API"), "{pager}");
+    assert!(pager.contains(r#"href="/docs/parent/index.html""#), "{pager}");
+}
+
+#[test]
+fn the_match_stops_the_walk_before_a_later_group() {
+    // Two entries after the match: only the first may be picked up.
+    let nav = vec![
+        guide(vec![
+            nav_item("One", "one", "/docs/one/index.html"),
+            nav_item("Two", "two", "/docs/two/index.html"),
+        ])
+        .remove(0),
+        NavGroup {
+            title: "Reference".to_string(),
+            items: vec![
+                nav_item("API", "api", "/docs/api/index.html"),
+                nav_item("CLI", "cli", "/docs/cli/index.html"),
+            ],
+            collapsed: None,
+            sticky_collapsed: None,
+        },
+    ];
+
+    let html = generate_html(&page("two"), &nav, &config(true));
+    let pager = pager_html(&html).expect("a pager is expected");
+
+    assert!(pager.contains(r#"href="/docs/api/index.html""#), "{pager}");
+    assert!(!pager.contains(r#"href="/docs/cli/index.html""#), "{pager}");
+}
+
+#[test]
+fn scheme_checks_stay_case_insensitive() {
+    // The lowercased copies these used to build were an allocation per
+    // entry per page; the comparisons must still ignore case.
+    let nav = guide(vec![
+        nav_item("Upper external", "ext", "HTTPS://EXAMPLE.COM/x"),
+        nav_item("Here", "here", "/docs/here/index.html"),
+        nav_item("Script", "script", "JavaScript:alert(1)"),
+        nav_item("After", "after", "/docs/after/index.html"),
+    ]);
+
+    let html = generate_html(&page("here"), &nav, &config(true));
+    let pager = pager_html(&html).expect("a pager is expected");
+
+    assert!(!pager.contains("EXAMPLE.COM"), "an external link is not steppable: {pager}");
+    assert!(!pager.to_ascii_lowercase().contains("javascript:"), "{pager}");
+    assert!(pager.contains(r#"href="/docs/after/index.html""#), "{pager}");
+    assert!(!pager.contains(r#"rel="prev""#), "{pager}");
+}
+
+#[test]
+fn resolving_the_pager_costs_the_same_per_page_as_the_sidebar_grows() {
+    // Flattening cloned three strings per entry on every page, so a site
+    // paid it once per page — quadratic in sidebar size. Four times the
+    // entries may cost more per page, but not sixteen times.
+    let measure = |entries: usize| {
+        let items = (0..entries)
+            .map(|index| {
+                let path = format!("p{index}");
+                let href = format!("/docs/p{index}/index.html");
+                nav_item("T", &path, &href)
+            })
+            .collect();
+        let nav = guide(items);
+        let target = page(&format!("p{}", entries / 2));
+        let enabled = config(true);
+        let disabled = config(false);
+        let start = Instant::now();
+        for _ in 0..20 {
+            let _ = generate_html(&target, &nav, &enabled);
+        }
+        let with = start.elapsed();
+        let start = Instant::now();
+        for _ in 0..20 {
+            let _ = generate_html(&target, &nav, &disabled);
+        }
+        with.saturating_sub(start.elapsed())
+    };
+
+    let small = measure(500).max(Duration::from_micros(1));
+    let large = measure(2_000);
+    assert!(
+        large < small * 16,
+        "the pager cost {large:?} at 2,000 entries against {small:?} at 500"
+    );
+}


### PR DESCRIPTION
## Summary

`resolve_pager` flattened the entire sidebar into an owned `Vec`, cloning three `String`s per entry, then searched it for the current page. A site does that **once per page**, so it was quadratic in sidebar size with an allocator-bound constant. `is_in_site_href` and `is_safe_href` each built a lowercased copy of the href on top of that — two more allocations per entry per page.

Nothing there needs ownership. The walk now goes through the tree in place, keeps the last steppable entry, and stops one entry past the match; only the two entries that end up in the pager are cloned. Scheme checks use `eq_ignore_ascii_case`.

Building every page of a site whose sidebar lists them all:

| pages / sidebar entries | pager off | pager on (before) | pager on (after) |
| ----------------------- | --------: | ----------------: | ---------------: |
| 500   | 0.11 s | 0.13 s | 0.09 s |
| 1,000 | 0.31 s | 0.50 s | 0.33 s |
| 2,000 | 1.20 s | 1.82 s | 1.24 s |

The pager's share of a page render falls from ~50% to ~3% at 2,000 entries, and grows with the sidebar rather than with the sidebar squared.

## Risk

- Risk level: low
- User or production impact: build time only; the emitted pager is identical.
- Rollback plan: revert the commit. The change is confined to `html/pagination.rs`.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_ssg -p ox_content_docs` (537 pass), `cargo clippy -p ox_content_ssg --all-targets -- -D warnings`, `cargo fmt --all --check`, `node scripts/check-panic-constructs.mjs`, `node scripts/check-file-lines.ts`.
- [x] Manual verification completed: 12,000 randomized sidebars — nested children up to three deep, multiple groups, and hrefs that are empty, whitespace, fragment-only, external `http(s)`, `mailto`, `javascript:`, `data:`, `vbscript:`, protocol-relative, and mixed-case variants of each, with `prev`/`next` frontmatter overrides (hidden, text-only, custom href) on both sides — produce **byte-identical** pager HTML. 7,409 of them emit a pager.
- [x] Edge cases or failure modes considered: the first and last entries, a match buried in a nested subtree whose successor lives in a later group, only the immediate successor being taken, and — the real hazard of a stop-early walk — a page the sidebar does not list, where a walk that forgot to check for a match would hand back whatever entry it stopped on.

New `src/html/pagination/tests/walk.rs` covers those boundaries plus a growth assertion on the pager's isolated cost. The existing `flatten.rs` tests, which pin which entries are steppable at all, pass unchanged.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed — the walk and the case-insensitive helper carry the reasoning.
- [x] Configuration, migration, or environment changes documented, or not needed — none.
- [x] Observability, logging, and alerting impact considered, or not needed — none.
- [x] Security, privacy, and dependency impact considered: the `javascript:` / `data:` / `vbscript:` and external-link screening is unchanged and re-verified case-insensitively by the differential run. No new dependencies.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790689218&installation_model_id=422833&pr_number=1217&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1217&signature=a15300d1d2168f564ce6de9176f536abd93506e19b8cce521274f1214d02c491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved sidebar pagination efficiency, especially for large navigation structures.
* **Bug Fixes**
  * Improved previous and next page resolution across nested sidebar groups.
  * Added case-insensitive handling for supported links.
  * Improved pagination behavior for boundary pages and pages not listed in the sidebar.
* **Tests**
  * Added coverage for navigation traversal, edge cases, link handling, and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->