### PR TITLE
perf(incremental): resume the stable-prefix scan instead of rescanning

### DIFF
--- a/crates/ox_content_incremental/src/boundary.rs
+++ b/crates/ox_content_incremental/src/boundary.rs
@@ -7,47 +7,83 @@ use memchr::memchr;
 /// unstable tail while still letting the UI render that tail provisionally.
 #[must_use]
 pub fn stable_prefix_len(source: &str) -> usize {
-    let bytes = source.as_bytes();
-    let mut pos = 0usize;
-    let mut blank_boundary = 0usize;
-    let mut stable_boundary = 0usize;
-    let mut fence: Option<(u8, usize)> = None;
+    BoundaryScan::default().advance(source)
+}
 
-    while pos < bytes.len() {
-        let line_start = pos;
-        let line_end =
-            memchr(b'\n', &bytes[line_start..]).map_or(bytes.len(), |off| line_start + off);
-        let next_line = if line_end < bytes.len() { line_end + 1 } else { line_end };
-        let line = strip_cr(&source[line_start..line_end]);
+/// Resumable form of the [`stable_prefix_len`] scan.
+///
+/// A streaming caller asks for the stable prefix after every chunk, and the
+/// answer depends on state that only accumulates: how far the scan got, the
+/// fence it is inside, and where the last run of blank lines ended. Keeping
+/// that state turns a whole-buffer rescan per chunk into one pass over the
+/// stream. It matters most exactly where nothing commits — a long fenced
+/// code block arriving in chunks — which is where the rescan was quadratic.
+#[derive(Debug, Clone, Default)]
+pub struct BoundaryScan {
+    /// Bytes of the buffer already consumed as complete lines.
+    pos: usize,
+    fence: Option<(u8, usize)>,
+    /// Offset just past the most recent run of blank lines, or `0`.
+    blank_boundary: usize,
+    /// Highest offset proven safe to commit.
+    stable_boundary: usize,
+}
 
-        if let Some((fence_byte, fence_len)) = fence {
-            if is_closing_fence(line, fence_byte, fence_len) {
-                fence = None;
-            }
-            pos = next_line;
-            continue;
+impl BoundaryScan {
+    /// Consumes whatever `source` has gained since the last call and returns
+    /// the stable prefix length. `source` must be the same buffer, extended
+    /// at the end (and rebased through [`Self::commit`] when it is drained).
+    pub fn advance(&mut self, source: &str) -> usize {
+        let bytes = source.as_bytes();
+        while self.pos < bytes.len() {
+            let Some(offset) = memchr(b'\n', &bytes[self.pos..]) else {
+                break;
+            };
+            let line_end = self.pos + offset;
+            let line = strip_cr(&source[self.pos..line_end]);
+            self.step(line, line_end + 1);
+            self.pos = line_end + 1;
         }
 
-        if let Some(opening) = opening_fence(line) {
-            fence = Some(opening);
-            pos = next_line;
-            continue;
+        // The buffer may end mid-line. Such a line can still prove a
+        // boundary — an unindented character after a blank line does that
+        // on its own — but it may grow into something else on the next
+        // chunk, so score it without keeping the state it implies.
+        if self.pos < bytes.len() {
+            let mut tentative = self.clone();
+            tentative.step(strip_cr(&source[self.pos..]), bytes.len());
+            return tentative.stable_boundary;
         }
-
-        if line.trim().is_empty() {
-            blank_boundary = next_line;
-            pos = next_line;
-            continue;
-        }
-
-        if blank_boundary != 0 && indentation_columns(line) == 0 {
-            stable_boundary = blank_boundary;
-        }
-        blank_boundary = 0;
-        pos = next_line;
+        self.stable_boundary
     }
 
-    stable_boundary
+    /// Rebases the scan after `len` bytes have been drained from the front.
+    pub fn commit(&mut self, len: usize) {
+        self.pos = self.pos.saturating_sub(len);
+        self.blank_boundary = self.blank_boundary.saturating_sub(len);
+        self.stable_boundary = self.stable_boundary.saturating_sub(len);
+    }
+
+    fn step(&mut self, line: &str, next_line: usize) {
+        if let Some((fence_byte, fence_len)) = self.fence {
+            if is_closing_fence(line, fence_byte, fence_len) {
+                self.fence = None;
+            }
+            return;
+        }
+        if let Some(opening) = opening_fence(line) {
+            self.fence = Some(opening);
+            return;
+        }
+        if line.trim().is_empty() {
+            self.blank_boundary = next_line;
+            return;
+        }
+        if self.blank_boundary != 0 && indentation_columns(line) == 0 {
+            self.stable_boundary = self.blank_boundary;
+        }
+        self.blank_boundary = 0;
+    }
 }
 
 pub fn opening_fence(line: &str) -> Option<(u8, usize)> {

--- a/crates/ox_content_incremental/src/parser.rs
+++ b/crates/ox_content_incremental/src/parser.rs
@@ -4,7 +4,7 @@ use ox_content_allocator::Allocator;
 use ox_content_ast::Document;
 use ox_content_parser::{ParseResult, Parser, ParserOptions};
 
-use crate::boundary::stable_prefix_len;
+use crate::boundary::BoundaryScan;
 use crate::provisional::complete_provisional_markdown;
 use crate::result::IncrementalParseResult;
 
@@ -21,6 +21,9 @@ pub struct IncrementalParser {
     committed_bytes: usize,
     total_bytes: usize,
     is_final: bool,
+    /// Boundary scan carried across appends so each chunk is examined once
+    /// rather than the whole pending buffer being rescanned per chunk.
+    scan: BoundaryScan,
 }
 
 impl IncrementalParser {
@@ -33,6 +36,7 @@ impl IncrementalParser {
             committed_bytes: 0,
             total_bytes: 0,
             is_final: false,
+            scan: BoundaryScan::default(),
         }
     }
 
@@ -60,8 +64,8 @@ impl IncrementalParser {
         self.total_bytes = self.total_bytes.saturating_add(chunk.len());
         self.is_final = is_final;
 
-        let commit_len =
-            if is_final { self.pending.len() } else { stable_prefix_len(&self.pending) };
+        let stable_len = self.scan.advance(&self.pending);
+        let commit_len = if is_final { self.pending.len() } else { stable_len };
 
         if commit_len == 0 {
             return Ok(IncrementalParseResult::empty(
@@ -84,6 +88,7 @@ impl IncrementalParser {
         };
 
         self.pending.drain(..commit_len);
+        self.scan.commit(commit_len);
         self.committed_bytes = self.committed_bytes.saturating_add(commit_len);
 
         Ok(IncrementalParseResult {
@@ -136,6 +141,7 @@ impl IncrementalParser {
     /// Clears all stream state.
     pub fn reset(&mut self) {
         self.pending.clear();
+        self.scan = BoundaryScan::default();
         self.committed_bytes = 0;
         self.total_bytes = 0;
         self.is_final = false;

--- a/crates/ox_content_incremental/tests/streaming_boundary.rs
+++ b/crates/ox_content_incremental/tests/streaming_boundary.rs
@@ -1,0 +1,180 @@
+//! Streaming has to answer "what is safe to commit" after every chunk.
+//!
+//! That answer used to be recomputed from the whole pending buffer each
+//! time, which is quadratic exactly where nothing commits — a long fenced
+//! code block arriving in pieces, which is what streamed output usually
+//! looks like. The scan now resumes where it left off, so these tests
+//! check that resuming lands on the same commits a rescan would, and that
+//! the cost stops squaring.
+
+use std::time::{Duration, Instant};
+
+use ox_content_incremental::{IncrementalParser, stable_prefix_len};
+use ox_content_parser::ParserOptions;
+
+/// xorshift64 — deterministic, so a failure reproduces from its seed.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+
+    fn below(&mut self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
+    }
+}
+
+/// Lines chosen for the states the scan carries: fences that open, close,
+/// nest by length, or never close; blank lines of every whitespace shape;
+/// indented continuations; CRLF; and fragments with no line ending at all.
+const LINES: &[&str] = &[
+    "text\n",
+    "\n",
+    "  \n",
+    "\t\n",
+    "```\n",
+    "```rust\n",
+    "~~~\n",
+    "~~~~\n",
+    "``` \n",
+    "  ```\n",
+    "    indented\n",
+    "  two space\n",
+    "- item\n",
+    "  - nested\n",
+    "> quote\n",
+    "# heading\n",
+    "|a|b|\n",
+    "\r\n",
+    "text\r\n",
+    "```\r\n",
+    "partial",
+    "a",
+    "   ",
+    "1. one\n",
+    "\u{3042}\n",
+    "    ```\n",
+    "`````\n",
+];
+
+fn split(source: &str, size: usize) -> Vec<String> {
+    let mut chunks = Vec::new();
+    let mut at = 0;
+    while at < source.len() {
+        let mut end = (at + size).min(source.len());
+        while !source.is_char_boundary(end) {
+            end += 1;
+        }
+        chunks.push(source[at..end].to_string());
+        at = end;
+    }
+    chunks
+}
+
+/// What the old append loop did: rescan the whole pending buffer per chunk.
+fn rescan_commits(chunks: &[String]) -> Vec<String> {
+    let mut pending = String::new();
+    let mut commits = Vec::new();
+    for chunk in chunks {
+        pending.push_str(chunk);
+        let stable = stable_prefix_len(&pending);
+        if stable > 0 {
+            commits.push(pending[..stable].to_string());
+            pending.drain(..stable);
+        }
+    }
+    if !pending.is_empty() {
+        commits.push(pending);
+    }
+    commits
+}
+
+fn streamed_commits(chunks: &[String]) -> Vec<String> {
+    let mut parser = IncrementalParser::new(ParserOptions::gfm());
+    let mut commits = Vec::new();
+    for chunk in chunks {
+        let outcome = parser
+            .append(chunk, false, |markdown, _, _| markdown.to_string())
+            .expect("chunk should parse");
+        if let Some(committed) = outcome.committed {
+            commits.push(committed);
+        }
+    }
+    let outcome = parser.finish(|markdown, _, _| markdown.to_string()).expect("tail should parse");
+    if let Some(committed) = outcome.committed {
+        commits.push(committed);
+    }
+    commits
+}
+
+#[test]
+fn resuming_the_scan_commits_what_a_rescan_would() {
+    for seed in 1..40_000u64 {
+        let mut rng = Rng(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1);
+        let mut document = String::new();
+        for _ in 0..1 + rng.below(14) {
+            document.push_str(LINES[rng.below(LINES.len())]);
+        }
+        let size = 1 + rng.below(9);
+        let chunks = split(&document, size);
+        assert_eq!(
+            streamed_commits(&chunks),
+            rescan_commits(&chunks),
+            "seed {seed}, chunk size {size}, document {document:?}"
+        );
+    }
+}
+
+#[test]
+fn a_chunk_boundary_inside_a_fence_marker_still_opens_the_fence() {
+    // The trailing partial line is scored but not committed to, so "``"
+    // becoming "```" on the next chunk has to open a fence.
+    let chunks = ["a\n\n``".to_string(), "`\n".to_string(), "b\n\nc\n".to_string()];
+    assert_eq!(streamed_commits(&chunks), rescan_commits(&chunks));
+    assert_eq!(streamed_commits(&chunks)[0], "a\n\n");
+}
+
+#[test]
+fn blank_lines_inside_a_streamed_fence_never_commit() {
+    let mut document = String::from("```\n");
+    for index in 0..200 {
+        document.push_str("line ");
+        document.push_str(&index.to_string());
+        document.push_str("\n\n");
+    }
+    let commits = streamed_commits(&split(&document, 7));
+    assert_eq!(commits.len(), 1, "an unclosed fence commits only at finish: {commits:?}");
+    assert_eq!(commits[0], document);
+}
+
+#[test]
+fn streaming_a_long_fenced_block_costs_linear_time() {
+    // Nothing commits until the fence closes, so the pending buffer grows
+    // for the whole stream — the shape the rescan turned quadratic.
+    let build = |kilobytes: usize| {
+        let mut document = String::from("```rust\n");
+        while document.len() < kilobytes * 1024 {
+            document.push_str("let value = compute(input);\n");
+        }
+        document.push_str("```\n");
+        document
+    };
+    let measure = |document: &str| {
+        let chunks = split(document, 1024);
+        let start = Instant::now();
+        let commits = streamed_commits(&chunks);
+        let elapsed = start.elapsed();
+        assert_eq!(commits.len(), 1);
+        elapsed
+    };
+
+    let small = measure(&build(128)).max(Duration::from_micros(1));
+    let large = measure(&build(512));
+    assert!(large < small * 16, "512 KB took {large:?} against {small:?} for 128 KB");
+}


### PR DESCRIPTION
## Summary

`IncrementalParser::append` asked `stable_prefix_len` for the commit point after every chunk, and that scan starts from the beginning of the pending buffer.

While something commits, the buffer drains and the cost stays flat. While nothing commits it does not — the same bytes are rescanned for every chunk. Streaming one long fenced code block, which is what streamed output usually looks like, was therefore quadratic:

| streamed in 1 KB chunks | before | after |
| ----------------------- | -----: | ----: |
| 128 KB code block | 4.9 ms | 1.0 ms |
| 256 KB code block | 20.8 ms | 1.0 ms |
| 512 KB code block | 84.5 ms | 3.1 ms |
| 1 MB code block | ~340 ms | 11.4 ms |

Prose with blank lines was always linear and stays so.

The scan's entire state is three offsets and the fence it is inside, and all of it only moves forward, so it now lives on the parser and resumes where the last chunk stopped. One subtlety is kept explicit: a buffer may end mid-line, and such a line can still prove a boundary (an unindented character after a blank line does that on its own) while later growing into something else — `` `` `` becoming ``` ``` ```. That line is scored but the state it implies is not kept, so the next chunk re-reads it.

## Risk

- Risk level: medium — it replaces a stateless recomputation with carried state, and the carried state has to be rebased whenever the buffer is drained.
- User or production impact: streaming only. Where each chunk commits, the commit points are identical; where nothing commits, the wait is the same and only the cost changes.
- Rollback plan: revert the commit. `stable_prefix_len` keeps its signature and behaviour and is now a one-shot use of the same scan.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_incremental -p ox_content_napi` (all pass), `cargo clippy -p ox_content_incremental --all-targets -- -D warnings`, `cargo fmt --all --check`, `node scripts/check-panic-constructs.mjs`, `node scripts/check-file-lines.ts`.
- [x] Manual verification completed: **40,000 randomized streams** compared against the previous behaviour — the exact sequence of committed fragments matches a whole-buffer rescan in every case. Documents are built from lines chosen for the states the scan carries: fences that open, close, nest by length, or never close; blank lines made of spaces, tabs, and CRLF; indented continuations; and fragments with no line ending. Chunk sizes run from 1 to 9 bytes so boundaries land inside markers, inside CRLF pairs, and inside multi-byte characters.
- [x] Edge cases or failure modes considered: a chunk boundary splitting a fence marker, blank lines inside an unclosed fence never committing, the tail committing only at `finish`, and `reset` clearing the carried state.

`crates/ox_content_incremental/tests/streaming_boundary.rs` holds the differential, the two boundary cases spelled out by hand, and a growth assertion: 4x the code block must cost less than 16x the time.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed — `BoundaryScan` documents why the state is carried and what the mid-line rule is.
- [x] Configuration, migration, or environment changes documented, or not needed — none.
- [x] Observability, logging, and alerting impact considered, or not needed — none.
- [x] Security, privacy, and dependency impact considered: removes a super-linear path reachable from ordinary streamed content. No new dependencies.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790689592&installation_model_id=422833&pr_number=1218&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1218&signature=3a732857a20075fd1c25ee124ddc530fd6477b53b05a1d0a6eb382295d5af04a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->