### PR TITLE
fix(attrs): stop a second attribute block dropping text and aborting

### DIFF
--- a/crates/ox_content_transform/src/features/attributes.rs
+++ b/crates/ox_content_transform/src/features/attributes.rs
@@ -15,46 +15,57 @@ const HEADER_ANCHOR_OPEN: &str = "<a class=\"header-anchor\"";
 pub(super) fn transform_attribute_syntax(html: &str) -> Option<String> {
     let bytes = html.as_bytes();
     let mut out = String::with_capacity(html.len());
-    let mut cursor = 0usize;
+    // `out` holds exactly `html[..flushed]`, rewritten where an attribute
+    // block applied. `scan` is only where to look for the next `{`.
+    //
+    // These were one variable, and moving it past a block that did not
+    // apply meant the text before that block was never written: a later
+    // rewrite copied from the moved position and everything between was
+    // dropped. It also made an enclosing tag that had already been written
+    // look rewritable, which sliced backwards and aborted the process.
+    let mut flushed = 0usize;
+    let mut scan = 0usize;
     let mut changed = false;
 
-    while cursor < bytes.len() {
-        let Some(relative) = memchr::memchr(b'{', &bytes[cursor..]) else {
+    while scan < bytes.len() {
+        let Some(relative) = memchr::memchr(b'{', &bytes[scan..]) else {
             break;
         };
-        let attr_start = cursor + relative;
+        let attr_start = scan + relative;
         let Some(attr_end) = find_attr_block_end(html, attr_start) else {
-            cursor = attr_start + 1;
+            scan = attr_start + 1;
             continue;
         };
         let attrs = &html[attr_start + 1..attr_end];
         let Some(parsed) = ParsedAttrs::parse(attrs) else {
-            cursor = attr_start + 1;
+            scan = attr_start + 1;
             continue;
         };
 
         if let Some(next) =
-            try_apply_attrs_inside_element(html, &mut out, cursor, attr_start, attr_end, &parsed)
+            try_apply_attrs_inside_element(html, &mut out, flushed, attr_start, attr_end, &parsed)
         {
             changed = true;
-            cursor = next;
+            flushed = next;
+            scan = next;
             continue;
         }
 
-        if try_apply_attrs_to_previous_element(html, &mut out, cursor, attr_start, &parsed)
+        if try_apply_attrs_to_previous_element(html, &mut out, flushed, attr_start, &parsed)
             .is_some()
         {
             changed = true;
-            cursor = attr_end + 1;
+            flushed = attr_end + 1;
+            scan = flushed;
             continue;
         }
-        cursor = attr_start + 1;
+        scan = attr_start + 1;
     }
 
     if !changed {
         return None;
     }
-    out.push_str(&html[cursor..]);
+    out.push_str(&html[flushed..]);
     Some(out)
 }
 
@@ -77,7 +88,11 @@ fn try_apply_attrs_inside_element(
         return None;
     }
     let open_marker = format!("<{tag_name}");
-    let open_start = html[..attr_start].rfind(&open_marker)?;
+    // Only the region after `cursor` is still rewritable: everything before
+    // it has already been written to `out`. Searching the whole prefix found
+    // enclosing tags that were long since emitted — a second `{...}` in one
+    // paragraph re-found that paragraph's own `<p>`.
+    let open_start = cursor + html[cursor..attr_start].rfind(&open_marker)?;
     let open_end = scan_tag_end(html, open_start)?;
     if open_end > attr_start {
         return None;
@@ -129,6 +144,7 @@ fn try_apply_attrs_to_adjacent_inline_child(
 
     if let Some((tag_start, tag_end, _close_end, tag_name)) =
         find_previous_wrapped_element(html, trimmed_end)
+        && tag_start >= cursor
         && tag_start >= container_open_end
         && is_adjacent_inline_attr_target_tag(&tag_name)
     {
@@ -140,6 +156,7 @@ fn try_apply_attrs_to_adjacent_inline_child(
     }
 
     if let Some((tag_start, tag_end, tag_name)) = find_previous_void_element(html, trimmed_end)
+        && tag_start >= cursor
         && tag_start >= container_open_end
         && is_adjacent_inline_attr_target_tag(&tag_name)
     {
@@ -167,8 +184,11 @@ fn try_apply_attrs_to_previous_element(
     }
     let whitespace = &html[trimmed_end..attr_start];
 
+    // As in `try_apply_attrs_inside_element`, an element that starts before
+    // `cursor` has already been written out and can no longer be rewritten.
     if let Some((tag_start, tag_end, close_end, _tag_name)) =
         find_previous_wrapped_element(html, trimmed_end)
+        && tag_start >= cursor
     {
         out.push_str(&html[cursor..tag_start]);
         write_open_tag_attrs(out, &html[tag_start..tag_end], attrs);
@@ -184,7 +204,9 @@ fn try_apply_attrs_to_previous_element(
         return Some(close_end);
     }
 
-    if let Some((tag_start, tag_end, _tag_name)) = find_previous_void_element(html, trimmed_end) {
+    if let Some((tag_start, tag_end, _tag_name)) = find_previous_void_element(html, trimmed_end)
+        && tag_start >= cursor
+    {
         out.push_str(&html[cursor..tag_start]);
         write_open_tag_attrs(out, &html[tag_start..tag_end], attrs);
         out.push_str(&html[tag_end..trimmed_end]);

--- a/crates/ox_content_transform/tests/attribute_blocks.rs
+++ b/crates/ox_content_transform/tests/attribute_blocks.rs
@@ -1,0 +1,153 @@
+//! `{.class}` / `{#id}` blocks rewrite the HTML in one forward pass.
+//!
+//! That pass tracks two things that used to be one variable: how much of
+//! the input has been written out, and where to look for the next block.
+//! Conflating them meant a block the pass declined moved the write mark
+//! forward without writing anything, so a later rewrite copied from the
+//! moved position and silently dropped the text in between — and an
+//! enclosing tag that had already been written still looked rewritable,
+//! which sliced backwards and aborted the process.
+
+use ox_content_transform::transformer::MarkdownTransformer;
+use ox_content_transform::{AttrsOptions, TransformOptions};
+
+fn transform(markdown: &str) -> String {
+    let transformer = MarkdownTransformer::from_options(&TransformOptions {
+        gfm: Some(true),
+        attributes: Some(AttrsOptions { enabled: Some(true) }),
+        ..Default::default()
+    });
+    transformer.transform(markdown).html.trim().to_string()
+}
+
+#[test]
+fn two_declined_and_applied_blocks_in_one_paragraph_keep_every_word() {
+    assert_eq!(
+        transform("aaa *x*{.c} bbb ![i](u){.z} ccc\n"),
+        "<p>aaa <em>x</em>{.c} bbb <img src=\"u\" alt=\"i\" class=\"z\"> ccc</p>"
+    );
+    assert_eq!(
+        transform("lead *x*{.c} tail `code`{.k} end\n"),
+        "<p>lead <em>x</em>{.c} tail <code class=\"k\">code</code> end</p>"
+    );
+}
+
+#[test]
+fn a_declined_block_does_not_stop_the_paragraph_from_being_targeted() {
+    assert_eq!(
+        transform("text *x*{.c} more {.p}\n"),
+        "<p class=\"p\">text <em>x</em>{.c} more</p>"
+    );
+}
+
+#[test]
+fn a_declined_block_mid_line_still_leaves_the_trailing_one_working() {
+    // Emphasis in the middle of a line is not a target, so `{.c}` stays
+    // literal — but `{.d}` sits at the end of the paragraph, which is one,
+    // and the paragraph tag has to still be rewritable at that point.
+    assert_eq!(
+        transform("*x*{.c} and *y*{.d}\n"),
+        "<p class=\"d\"><em>x</em>{.c} and <em>y</em></p>"
+    );
+    assert_eq!(
+        transform("**b**{.x} **c**{.y}\n"),
+        "<p class=\"y\"><strong>b</strong>{.x} <strong>c</strong></p>"
+    );
+}
+
+#[test]
+fn several_applied_blocks_in_one_paragraph_all_take_effect() {
+    assert_eq!(
+        transform("[l](u){.m} [n](o){.p}\n"),
+        "<p><a href=\"u\" class=\"m\">l</a> <a href=\"o\" class=\"p\">n</a></p>"
+    );
+    assert_eq!(
+        transform("![a](b){.i} and ![c](d){.j}\n"),
+        "<p><img src=\"b\" alt=\"a\" class=\"i\"> and <img src=\"d\" alt=\"c\" class=\"j\"></p>"
+    );
+    assert_eq!(
+        transform("`one`{.k} then `two`{.l}\n"),
+        "<p><code class=\"k\">one</code> then <code class=\"l\">two</code></p>"
+    );
+}
+
+#[test]
+fn single_block_behaviour_is_unchanged() {
+    assert_eq!(transform("*x*{.c}\n"), "<p class=\"c\"><em>x</em></p>");
+    assert_eq!(transform("lead *x*{.c}\n"), "<p class=\"c\">lead <em>x</em></p>");
+    assert_eq!(transform("*x*{.c} tail\n"), "<p><em>x</em>{.c} tail</p>");
+    assert_eq!(transform("para one {.p}\n"), "<p class=\"p\">para one</p>");
+    assert_eq!(transform("# One {#a}\n"), "<h1 id=\"a\">One</h1>");
+    assert_eq!(
+        transform("# One {#a}\n\n# Two {#b}\n"),
+        "<h1 id=\"a\">One</h1>\n<h1 id=\"b\">Two</h1>"
+    );
+}
+
+/// xorshift64 — deterministic, so a failure reproduces from its seed.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+
+    fn below(&mut self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
+    }
+}
+
+#[test]
+fn no_arrangement_of_blocks_loses_a_word() {
+    // Every word carries its own marker, so anything the pass drops is
+    // visible. Blocks are mixed across targets it accepts (images, code,
+    // links, the paragraph itself) and ones it declines (emphasis in the
+    // middle of a line), because a decline is what moved the write mark.
+    let targets: [&str; 8] = [
+        "*e{n}*",
+        "**s{n}**",
+        "`c{n}`",
+        "[l{n}](u{n})",
+        "![i{n}](s{n})",
+        "w{n}",
+        "<kbd>k{n}</kbd>",
+        "~~d{n}~~",
+    ];
+    let blocks: [&str; 6] = ["{.c}", "{#i}", "{.a .b}", "{}", "{ }", "{.x #y}"];
+
+    for seed in 1..20_000u64 {
+        let mut rng = Rng(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1);
+        let count = 1 + rng.below(5);
+        let mut markdown = String::new();
+        let mut words = Vec::new();
+        for index in 0..count {
+            let marker = format!("z{seed}x{index}");
+            words.push(marker.clone());
+            markdown.push_str(&marker);
+            markdown.push(' ');
+            markdown
+                .push_str(&targets[rng.below(targets.len())].replace("{n}", &index.to_string()));
+            if rng.below(4) != 0 {
+                markdown.push_str(blocks[rng.below(blocks.len())]);
+            }
+            markdown.push(' ');
+        }
+        let tail = format!("z{seed}tail");
+        words.push(tail.clone());
+        markdown.push_str(&tail);
+        markdown.push('\n');
+
+        let html = transform(&markdown);
+        for word in &words {
+            assert!(
+                html.contains(word.as_str()),
+                "seed {seed} lost {word:?}\n  in:  {markdown:?}\n  out: {html:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The `{.class}` / `{#id}` pass walks the HTML once with a single cursor doing two jobs: marking how much has been written to the output, and marking where to look for the next block. Those are not the same position, and treating them as one broke as soon as a paragraph had two blocks.

**It dropped text.** A block the pass declines moved the cursor past itself without writing anything, so a later block that did apply copied from the moved cursor and everything between was lost:

```
aaa *x*{.c} bbb ![i](u){.z} ccc
->  .c} bbb <img src="u" alt="i" class="z"> ccc</p>
```

**It aborted the process.** The enclosing-tag search still ran over the whole prefix, so it found tags already written out. Slicing from the cursor back to one of those is a reversed range, which panics — and release builds use `panic = "abort"`, so this killed the host:

```
*x*{.c} and *y*{.d}
->  thread panicked: byte range starts at 14 but ends at 0
```

Both are one-line Markdown, with a documented feature turned on.

The fix separates the two marks. The write mark only moves when something is written; the scan mark moves freely. Every rewrite target must sit at or after the write mark, which is exactly the condition for it still being rewritable. The trailing block now also reaches the paragraph it was always meant to reach: `*x*{.c} and *y*{.d}` renders as `<p class="d"><em>x</em>{.c} and <em>y</em></p>`.

Found by fuzzing the transform pipeline with every feature enabled.

## Risk

- Risk level: low
- User or production impact: fixes a process abort and silent content loss. Documents that already rendered are unaffected — every single-block case produces the same HTML as before.
- Rollback plan: revert the commit. The change is confined to `features/attributes.rs`.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_transform -p ox_content_ssg -p ox_content_docs` (1104 pass, existing attribute tests and snapshots unchanged), `cargo clippy -p ox_content_transform --all-targets -- -D warnings`, `cargo fmt --all --check`, `node scripts/check-panic-constructs.mjs`, `node scripts/check-file-lines.ts`.
- [x] Manual verification completed: 20,000 randomized paragraphs mixing targets the pass accepts (images, code spans, links, `<kbd>`, the paragraph itself) with ones it declines (emphasis mid-line), each word carrying a unique marker — every marker survives in the output. The abort no longer reproduces on the fuzz corpus that found it.
- [x] Edge cases or failure modes considered: a declined block followed by an applied one, an applied block followed by a declined one, several applied blocks in a row, empty and whitespace-only blocks, and every single-block form (heading id, paragraph class, image, code, link) pinned unchanged.

`crates/ox_content_transform/tests/attribute_blocks.rs` holds both the case-by-case pins and the no-word-is-lost property test.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed — the two marks and why they must stay separate are documented at the loop.
- [x] Configuration, migration, or environment changes documented, or not needed — none.
- [x] Observability, logging, and alerting impact considered, or not needed — none.
- [x] Security, privacy, and dependency impact considered: removes an abort reachable from ordinary Markdown, which is the class of defect #774 tracks. No new dependencies.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790690156&installation_model_id=422833&pr_number=1219&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1219&signature=4bfe4f5c85fec6092d8022fa6d53bb80acb71320d0ec2d560664c43b07e2246f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Markdown attribute-block processing so skipped blocks no longer remove intervening text.
  - Ensured later attribute blocks continue to apply correctly after an earlier block is declined.
  - Improved handling of adjacent inline elements and repeated attribute blocks.

- **Tests**
  - Added coverage for multiple, skipped, accepted, and randomized attribute-block arrangements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->