### PR TITLE
fix(definition-lists): stop a non-ASCII line after a list aborting

### DIFF
--- a/crates/ox_content_transform/src/features/definition_lists/parse.rs
+++ b/crates/ox_content_transform/src/features/definition_lists/parse.rs
@@ -169,10 +169,14 @@ pub(super) fn raw_html_open(line: &str) -> Option<&'static str> {
 }
 
 fn html_tag_starts(rest: &str, name: &str) -> bool {
-    rest.len() >= name.len()
-        && rest[..name.len()].eq_ignore_ascii_case(name)
-        && rest
-            .as_bytes()
+    // Compare bytes: `rest` is arbitrary line text, so slicing it at the
+    // name's byte length lands inside a character whenever the line opens
+    // with something like `<x\u{3042}`. Every tag name here is ASCII, so a
+    // byte-wise match implies the prefix was ASCII too.
+    let bytes = rest.as_bytes();
+    bytes.len() >= name.len()
+        && bytes[..name.len()].eq_ignore_ascii_case(name.as_bytes())
+        && bytes
             .get(name.len())
             .is_none_or(|byte| *byte == b'>' || *byte == b'/' || byte.is_ascii_whitespace())
 }

--- a/crates/ox_content_transform/tests/definition_list_html.rs
+++ b/crates/ox_content_transform/tests/definition_list_html.rs
@@ -1,0 +1,90 @@
+//! Definition lists let raw `<pre>` / `<code>` / `<script>` / `<style>`
+//! blocks through untouched, which means every line starting with `<` is
+//! tested against those four names.
+//!
+//! That test sliced the line at each name's byte length. A line opening
+//! with `<x` followed by anything non-ASCII — Japanese prose, an emoji, a
+//! byte-order mark — put that boundary inside a character and aborted the
+//! process, because release builds do not unwind.
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use ox_content_transform::transformer::MarkdownTransformer;
+use ox_content_transform::{DefinitionListOptions, TransformOptions};
+
+fn transformer() -> MarkdownTransformer {
+    MarkdownTransformer::from_options(&TransformOptions {
+        gfm: Some(true),
+        definition_lists: Some(DefinitionListOptions { enabled: Some(true) }),
+        ..Default::default()
+    })
+}
+
+fn transform(markdown: &str) -> String {
+    transformer().transform(markdown).html.trim().to_string()
+}
+
+/// A definition list has to be open for the raw-HTML check to run at all.
+fn after_a_definition_list(line: &str) -> String {
+    let mut markdown = String::from("term\n: def\n\n");
+    markdown.push_str(line);
+    markdown.push('\n');
+    markdown
+}
+
+#[test]
+fn a_line_opening_with_non_ascii_does_not_abort() {
+    let transformer = transformer();
+    // One case per byte length the tag-name check slices at: the boundary
+    // has to land inside a character for each of `pre`, `code`, `script`,
+    // and `style`.
+    let lines = [
+        "<x\u{3042}",
+        "<\u{3042}\u{3042}",
+        "<pr\u{3042}",
+        "<cod\u{3042}",
+        "<scrip\u{3042}",
+        "<styl\u{3042}",
+        "</x\u{3042}",
+        "  <x\u{1F600}",
+        "<x\u{FEFF}y",
+        "<x\u{202E}y",
+        "<\u{1F600}",
+        "<x\u{0301}",
+    ];
+    for line in lines {
+        let markdown = after_a_definition_list(line);
+        let outcome = catch_unwind(AssertUnwindSafe(|| transformer.transform(&markdown)));
+        assert!(outcome.is_ok(), "aborted on {line:?}");
+    }
+}
+
+#[test]
+fn non_ascii_after_a_definition_list_still_renders_as_text() {
+    let html = transform(&after_a_definition_list("<x\u{3042}"));
+    assert!(html.contains("<dl class=\"ox-definition-list\">"), "{html}");
+    assert!(html.contains("&lt;x\u{3042}"), "{html}");
+}
+
+#[test]
+fn raw_html_blocks_are_still_recognized() {
+    // The byte-wise comparison must keep matching the four names, their
+    // closing forms, and their case-insensitive spellings.
+    for (line, expected) in [
+        ("<pre>\u{3042}</pre>", "<pre>\u{3042}</pre>"),
+        ("<PRE>x</PRE>", "<PRE>x</PRE>"),
+        ("<script>x</script>", "<script>x</script>"),
+        ("<style>y</style>", "<style>y</style>"),
+        ("<pre/>", "<pre/>"),
+    ] {
+        let html = transform(&after_a_definition_list(line));
+        assert!(html.contains(expected), "{line:?} produced {html}");
+    }
+}
+
+#[test]
+fn a_definition_list_around_raw_html_keeps_both() {
+    let html = transform("term\n: def\n\n<pre>code</pre>\n\nother\n: meaning\n");
+    assert_eq!(html.matches("<dl class=\"ox-definition-list\">").count(), 2, "{html}");
+    assert!(html.contains("<pre>code</pre>"), "{html}");
+}


### PR DESCRIPTION
## Summary

While a definition list is open, every line starting with `<` is tested against `pre`, `code`, `script`, and `style` so raw HTML blocks pass through untouched. That test sliced the line at each name's byte length:

```rust
rest.len() >= name.len() && rest[..name.len()].eq_ignore_ascii_case(name)
```

The length check is on bytes; the slice is on a `&str`. A line opening with `<x` followed by anything non-ASCII puts that boundary inside a character, and slicing there panics — which **aborts** rather than unwinds in a release build:

```
term
: def

<xあ
->  end byte index 3 is not a char boundary; it is inside 'あ' (bytes 1..4)
```

Japanese prose, an emoji, or a byte-order mark on a line after a definition list was enough to take the host process down. Compare bytes instead; every tag name here is ASCII, so a byte-wise match implies the prefix was ASCII too.

Found by fuzzing the transform pipeline with every feature enabled.

## Risk

- Risk level: low
- User or production impact: fixes a process abort on ordinary non-English content. No output changes — the four tag names still match, including their closing and case variants.
- Rollback plan: revert the commit. The change is one function.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_transform -p ox_content_ssg -p ox_content_docs` (1118 pass), `cargo clippy -p ox_content_transform --all-targets -- -D warnings`, `cargo fmt --all --check`, `node scripts/check-panic-constructs.mjs`, `node scripts/check-file-lines.ts`.
- [x] Manual verification completed: the fuzz corpus that found it no longer aborts; the new tests fail on `main` by aborting the test binary, which is the behaviour being fixed.
- [x] Edge cases or failure modes considered: one case per byte length the check slices at, so the boundary lands mid-character for each of `pre` (3), `code` (4), `script` (6) and `style` (5); closing forms (`</x…`); indented lines; a byte-order mark and a bidi override; and a combining mark. Raw `<pre>`, `<PRE>`, `<script>`, `<style>` and `<pre/>` are re-checked to confirm they still pass through.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed — the comparison carries a note on why it is byte-wise.
- [x] Configuration, migration, or environment changes documented, or not needed — none.
- [x] Observability, logging, and alerting impact considered, or not needed — none.
- [x] Security, privacy, and dependency impact considered: removes an abort reachable from ordinary Markdown, the class of defect #774 tracks. No new dependencies.
