### PR TITLE
test(transform): add a bounded fuzz lane for the whole pipeline

### DIFF
--- a/crates/ox_content_transform/tests/pipeline_fuzz.rs
+++ b/crates/ox_content_transform/tests/pipeline_fuzz.rs
@@ -1,0 +1,177 @@
+//! A bounded fuzz lane for the whole transform pipeline.
+//!
+//! [issue #774] asks that malformed Markdown return errors or diagnostics
+//! instead of aborting the host process, and lists "bounded fuzz /
+//! property lanes in CI" as remaining work. Release artifacts build with
+//! `panic = "abort"`, so a slice at a bad index in any feature pass kills
+//! Node — a hand-written case list only ever covers the inputs someone
+//! thought of.
+//!
+//! Two generators run against every feature at once. One assembles token
+//! soup out of the fragments that break scanners: half-open fences and
+//! containers, stray delimiters, multi-byte characters, control
+//! characters, and bidi overrides. The other assembles documents out of
+//! real block templates with real inline content, so the passes are
+//! reached through the shapes they are written for rather than bouncing
+//! off a parse failure at the first line.
+//!
+//! Both are deterministic: a failure prints the seed and the document.
+//!
+//! This lane found two aborts on ordinary input — a second `{.class}`
+//! block in a paragraph, and a line starting with `<` followed by
+//! Japanese after a definition list.
+//!
+//! [issue #774]: https://github.com/ubugeeei-prod/ox-content/issues/774
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use ox_content_transform::transformer::MarkdownTransformer;
+use ox_content_transform::*;
+
+#[path = "pipeline_fuzz/corpus.rs"]
+mod corpus;
+
+use corpus::document;
+
+/// Every feature the transformer can run, so one document exercises all
+/// of the passes rather than the handful a focused test would enable.
+fn all_features() -> TransformOptions {
+    TransformOptions {
+        gfm: Some(true),
+        mdx: Some(true),
+        footnotes: Some(true),
+        task_lists: Some(true),
+        tables: Some(true),
+        strikethrough: Some(true),
+        autolinks: Some(true),
+        frontmatter: Some(true),
+        toc_max_depth: Some(6),
+        convert_md_links: Some(true),
+        base_url: Some("/base/".into()),
+        source_path: Some("docs/page.md".into()),
+        code_annotations: Some(true),
+        code_annotation_meta_key: Some("meta".into()),
+        code_annotation_syntax: Some("shiki".into()),
+        code_annotation_default_line_numbers: Some(true),
+        autolink_urls: Some(true),
+        autolink_patterns: Some(vec!["\\bOX-\\d+".into()]),
+        autolink_target_blank: Some(true),
+        semantic_footnotes: Some(true),
+        heading_permalinks: Some(true),
+        wiki_links: Some(WikiLinkOptions { enabled: Some(true), base_url: Some("/w/".into()) }),
+        emoji_shortcodes: Some(EmojiShortcodeOptions { enabled: Some(true), custom: None }),
+        math: Some(MathOptions { enabled: Some(true) }),
+        attributes: Some(AttrsOptions { enabled: Some(true) }),
+        cjk_emphasis: Some(true),
+        code_imports: None,
+        sanitize: Some(SanitizeOptions::default()),
+        edit_this_page: Some(EditThisPageOptions {
+            enabled: Some(true),
+            repo_url: Some("https://github.com/a/b".into()),
+            branch: Some("main".into()),
+            ..Default::default()
+        }),
+        containers: Some(ContainerOptions { enabled: Some(true), types: None }),
+        // Left off: both read files from disk.
+        includes: None,
+        partials: None,
+        steps: Some(StepsOptions { enabled: Some(true) }),
+        code_groups: Some(CodeGroupOptions { enabled: Some(true) }),
+        badges: Some(BadgeOptions { enabled: Some(true) }),
+        not_by_ai: Some(NotByAiOptions { enabled: Some(true), label: None, href: None }),
+        keyboard_keys: Some(KeyboardKeysOptions {
+            enabled: Some(true),
+            aliases: None,
+            style: None,
+        }),
+        abbreviations: Some(AbbreviationsOptions {
+            enabled: Some(true),
+            terms: None,
+            first_use_only: Some(true),
+        }),
+        definition_lists: Some(DefinitionListOptions { enabled: Some(true) }),
+        magic_links: Some(MagicLinkOptions {
+            enabled: Some(true),
+            aliases: None,
+            favicon: Some(true),
+            favicon_template: None,
+            image_overrides: None,
+        }),
+        images: Some(ImageOptions { enabled: Some(true), lazy: Some(true) }),
+        image_galleries: Some(ImageGalleryOptions {
+            enabled: Some(true),
+            lazy: Some(true),
+            missing_alt: None,
+            empty: None,
+        }),
+        timelines: Some(TimelineOptions {
+            enabled: Some(true),
+            ordered: Some(true),
+            invalid_date: None,
+            unknown_meta: None,
+            empty: None,
+        }),
+        conditional_blocks: Some(ConditionalBlockOptions { enabled: Some(true), values: None }),
+        cards: Some(CardOptions { enabled: Some(true) }),
+        file_tree: Some(FileTreeOptions {
+            enabled: Some(true),
+            default_open: Some(true),
+            icons: Some(true),
+            icon_folder: None,
+            icon_folder_open: None,
+            icon_file: None,
+            icon_files: None,
+        }),
+        data_tables: None,
+    }
+}
+
+#[test]
+fn no_document_aborts_the_pipeline() {
+    let transformer = MarkdownTransformer::from_options(&all_features());
+    let mut failures = Vec::new();
+    for seed in 1..30_000u64 {
+        let source = document(seed);
+        match catch_unwind(AssertUnwindSafe(|| transformer.transform(&source))) {
+            Err(_) => failures.push(format!("seed {seed} panicked on {source:?}")),
+            Ok(result) => {
+                // Debug builds convert an unexpected panic into a
+                // diagnostic; release builds abort outright, so treat one
+                // as the same failure.
+                if result.errors.iter().any(|error| error.to_lowercase().contains("panic")) {
+                    let errors = result.errors;
+                    failures.push(format!("seed {seed} reported {errors:?} on {source:?}"));
+                }
+            }
+        }
+        if failures.len() > 4 {
+            break;
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+#[test]
+fn reusing_a_transformer_gives_the_same_html() {
+    // One transformer serves every page of a build, so anything it carries
+    // from one document to the next shows up as a page that renders
+    // differently depending on what was rendered before it.
+    let shared = MarkdownTransformer::from_options(&all_features());
+    let mut failures = Vec::new();
+    for seed in 1..8_000u64 {
+        let source = document(seed);
+        let fresh = MarkdownTransformer::from_options(&all_features()).transform(&source);
+        let reused = shared.transform(&source);
+        if fresh.html != reused.html {
+            failures.push(format!("seed {seed} differs after earlier documents: {source:?}"));
+        }
+        let again = shared.transform(&source);
+        if again.html != reused.html {
+            failures.push(format!("seed {seed} differs on a second call: {source:?}"));
+        }
+        if failures.len() > 4 {
+            break;
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}

--- a/crates/ox_content_transform/tests/pipeline_fuzz/corpus.rs
+++ b/crates/ox_content_transform/tests/pipeline_fuzz/corpus.rs
@@ -1,0 +1,262 @@
+//! Document generators for the pipeline fuzz lane.
+//!
+//! Kept beside the tests rather than inline so the lane itself stays
+//! readable: this file is corpora and a mixer, nothing else.
+
+/// xorshift64 — deterministic, so a failure reproduces from its seed.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+
+    fn below(&mut self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
+    }
+}
+
+/// Fragments that break scanners: openers with no closer, delimiters with
+/// nothing to pair with, and the characters that make a byte index stop
+/// being a character index.
+const SOUP: &[&str] = &[
+    "---\n",
+    "title: x\n",
+    "a: [1,2\n",
+    "\n",
+    "# ",
+    "## ",
+    "###### ",
+    "\t",
+    "  ",
+    "```",
+    "~~~",
+    "js\n",
+    "x\n",
+    ":::",
+    "tip",
+    "warning",
+    "details",
+    "::: ",
+    ":::steps",
+    ":::code-group",
+    "|",
+    "-",
+    ":",
+    "*",
+    "_",
+    "~",
+    "`",
+    "[",
+    "]",
+    "(",
+    ")",
+    "{",
+    "}",
+    "<",
+    ">",
+    "!",
+    "#",
+    "$",
+    "\\",
+    "&",
+    ";",
+    "\"",
+    "'",
+    "/",
+    "@",
+    "^",
+    "+",
+    "=",
+    "?",
+    "%",
+    "\r",
+    "\u{0}",
+    "\u{a0}",
+    "\u{3042}",
+    "\u{1F600}",
+    "\u{0301}",
+    "http://a.b/c",
+    "https://x.y/z",
+    "mailto:a@b",
+    "[^1]",
+    "[^1]:",
+    "[[wiki]]",
+    ":smile:",
+    "$x$",
+    "$$",
+    "@[a]",
+    "!!!",
+    "<Foo",
+    "</Foo>",
+    "<Foo />",
+    "{expr}",
+    "import x from 'y'",
+    "export const a = 1",
+    "::: v-pre",
+    "<!-- -->",
+    "<!--@include: ../x.md-->",
+    "^[inline note]",
+    "{#id}",
+    "{.cls}",
+    "[[toc]]",
+    "==mark==",
+    "++ins++",
+    "term\n: def",
+    "- [ ] ",
+    "> ",
+    "1. ",
+    "  - ",
+    "<kbd>",
+    "[a](b)",
+    "![a](b)",
+    "```mermaid\n",
+    "```play\n",
+    "<script>",
+    "</script>",
+    "\u{202E}",
+    "\u{FEFF}",
+    "text",
+    "*[abbr]: x",
+    "npm:pkg",
+    "gh:a/b",
+    "@user",
+    "#42",
+    "a.md#f",
+    "<div",
+    "</div>",
+    "<td>",
+    "| --- |",
+    "|:--|--:|",
+    "= ",
+    "== ",
+    "%%",
+    "[!code focus]",
+    "// [!code ++]",
+    "{1,3-5}",
+    "title=\"a\"",
+    "[a]",
+    "[a][b]",
+    "![](",
+    "()",
+    "[]()",
+    "<a href=",
+    "\u{2028}",
+    "\u{2029}",
+];
+
+/// Block templates, each with `{t}` holes filled from [`INLINES`].
+const BLOCKS: &[&str] = &[
+    "# {t}\n\n",
+    "## {t} {#id}\n\n",
+    "{t}\n\n",
+    "- {t}\n- {t}\n\n",
+    "1. {t}\n2. {t}\n\n",
+    "> {t}\n> {t}\n\n",
+    "```ts\n{t}\n```\n\n",
+    "```ts title=\"a.ts\" {1,3-4}\n{t}\n```\n\n",
+    "| {t} | {t} |\n| --- | ---: |\n| {t} | {t} |\n\n",
+    "::: tip {t}\n{t}\n:::\n\n",
+    "::: details\n{t}\n:::\n\n",
+    "::: code-group\n```ts [a]\n{t}\n```\n```js [b]\n{t}\n```\n:::\n\n",
+    "::: steps\n1. {t}\n2. {t}\n:::\n\n",
+    "::: timeline\n- 2020-01-01 {t}\n:::\n\n",
+    "::: file-tree\n- src\n  - {t}\n:::\n\n",
+    "::: cards\n- {t}\n:::\n\n",
+    "::: gallery\n![{t}](a.png)\n:::\n\n",
+    "{t}\n: {t}\n: {t}\n\n",
+    "*[{t}]: {t}\n\n",
+    "[^{t}]: {t}\n\n",
+    "[{t}]: /u \"{t}\"\n\n",
+    "---\ntitle: {t}\n---\n\n",
+    "<div>{t}</div>\n\n",
+    "<Comp prop=\"{t}\">{t}</Comp>\n\n",
+    "{ {t} }\n\n",
+    "import x from '{t}'\n\n",
+    "export const a = {t}\n\n",
+    "$$\n{t}\n$$\n\n",
+    "@[youtube]({t})\n\n",
+    "!!! note\n{t}\n!!!\n\n",
+    "[[toc]]\n\n",
+    "<!-- {t} -->\n\n",
+    "    {t}\n\n",
+    "***\n\n",
+    "{t}\n===\n\n",
+];
+
+const INLINES: &[&str] = &[
+    "text",
+    "*em*",
+    "**strong**",
+    "`code`",
+    "[l](u)",
+    "![i](s)",
+    "~~del~~",
+    "[[wiki]]",
+    ":smile:",
+    "$x^2$",
+    "[^1]",
+    "^[note]",
+    "==mark==",
+    "<kbd>K</kbd>",
+    "{#id}",
+    "{.cls}",
+    "https://a.b/c",
+    "OX-12",
+    "a@b.co",
+    "\u{3042}\u{3044}",
+    "\u{1F600}",
+    "\u{FEFF}",
+    "\u{202E}",
+    "\u{0}",
+    "\u{0301}",
+    "<Comp />",
+    "{expr}",
+    "\\*",
+    "&amp;",
+    "&#65;",
+    "&notreal;",
+    "|",
+    "<",
+    ">",
+    "\"",
+    "'",
+    "npm:react",
+    "gh:a/b",
+    "@user",
+    "#123",
+    "a.md",
+    "./x.md#f",
+    "\t",
+    "  ",
+    "---",
+    "...",
+];
+
+/// Even seeds build token soup, odd seeds build structured documents.
+pub fn document(seed: u64) -> String {
+    let mut rng = Rng(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1);
+    if seed.is_multiple_of(2) {
+        let pieces = 1 + rng.below(26);
+        let mut source = String::new();
+        for _ in 0..pieces {
+            source.push_str(SOUP[rng.below(SOUP.len())]);
+        }
+        return source;
+    }
+    let blocks = 1 + rng.below(6);
+    let mut source = String::new();
+    for _ in 0..blocks {
+        let mut block = BLOCKS[rng.below(BLOCKS.len())].to_string();
+        while let Some(at) = block.find("{t}") {
+            block.replace_range(at..at + 3, INLINES[rng.below(INLINES.len())]);
+        }
+        source.push_str(&block);
+    }
+    source
+}

--- a/docs/content/ja/panic-prevention.md
+++ b/docs/content/ja/panic-prevention.md
@@ -18,6 +18,9 @@ cargo test -p ox_content_ssg --lib paths -- --nocapture
 cargo test -p ox_content_transform --lib hostile_user_content
 cargo test -p ox_content_renderer --lib svelte_public_codegen
 cargo test -p ox_content_napi hostile_markdown
+
+# transform パイプライン全体に対する有界な fuzz レーン
+cargo test -p ox_content_transform --test pipeline_fuzz
 ```
 
 CI は `.github/workflows/ci.yml` の `Panic constructs` ジョブでゲートを実行します。`vp run check:panic-constructs` と `vp run workspace:check` も同じスクリプトです。
@@ -57,7 +60,7 @@ CI は `.github/workflows/ci.yml` の `Panic constructs` ジョブでゲート�
 ## 残作業（後続 PR）
 
 - 残りのワークスペースを終える: `ox_content_docs`、`ox_content_lsp`、`ox_content_i18n`、`ox_content_search`、`ox_content_highlight`、`ox_content_wasm`、Vite バインディング、エディタ crate。
-- CI に有界な fuzz / property レーンを追加する（既存の `fuzz/` ターゲットは nightly が必要で、必須 CI ジョブではありません）。
+- 有界な fuzz レーンを transform パイプライン以外にも広げる。`cargo test -p ox_content_transform --test pipeline_fuzz` は通常のテストジョブで動き、トークンの寄せ集めと実際のブロックテンプレートの 2 通りで文書を生成して全機能を同時に通します（上記の `{.class}` と定義リストの abort はこれで見つかりました）。SSG・docs・エディタ側にはまだ同等のものがなく、`fuzz/` ターゲットは依然として nightly が必要で必須 CI ジョブではありません。
 - 公開成果物の FFI 境界で `panic = "abort"` ではなく unwind を使えるかを決める。
 - 残サイトを証明または書き換えるたびに `config/panic-allowlist.json` を縮める。
 

--- a/docs/content/panic-prevention.md
+++ b/docs/content/panic-prevention.md
@@ -18,6 +18,9 @@ cargo test -p ox_content_ssg --lib paths -- --nocapture
 cargo test -p ox_content_transform --lib hostile_user_content
 cargo test -p ox_content_renderer --lib svelte_public_codegen
 cargo test -p ox_content_napi hostile_markdown
+
+# Bounded fuzz lane over the whole transform pipeline
+cargo test -p ox_content_transform --test pipeline_fuzz
 ```
 
 CI runs the gate as the `Panic constructs` job in `.github/workflows/ci.yml`. `vp run check:panic-constructs` and `vp run workspace:check` run the same script.
@@ -57,7 +60,7 @@ The five focus crates also `deny` `clippy::unwrap_used`, `expect_used`, `panic`,
 ## Remaining work (follow-up PRs)
 
 - Finish the rest of the workspace: `ox_content_docs`, `ox_content_lsp`, `ox_content_i18n`, `ox_content_search`, `ox_content_highlight`, `ox_content_wasm`, Vite bindings, and editor crates.
-- Add bounded fuzz / property lanes in CI (the existing `fuzz/` targets still need nightly and are not a required CI job).
+- Extend the bounded fuzz lanes past the transform pipeline. `cargo test -p ox_content_transform --test pipeline_fuzz` runs in the ordinary test job and generates documents two ways — token soup and real block templates — against every feature at once; it found the `{.class}` and definition-list aborts listed above. The SSG, docs, and editor surfaces have no equivalent yet, and the `fuzz/` targets still need nightly and are not a required CI job.
 - Decide whether published artifacts can use unwind at FFI boundaries instead of `panic = "abort"`.
 - Keep shrinking `config/panic-allowlist.json` as each remaining site is proven or rewritten.
 


### PR DESCRIPTION
## Summary

[#774](https://github.com/ubugeeei-prod/ox-content/issues/774) lists "bounded fuzz / property lanes in CI" as remaining work. The two aborts fixed in #1219 and #1220 are exactly what a hand-written case list misses — a second `{.class}` block in one paragraph, and a line starting with `<` followed by Japanese after a definition list. Both are ordinary Markdown, and release artifacts build with `panic = "abort"`, so either one kills Node.

This adds the lane that found them, as an ordinary `#[test]` — it runs in the existing test job rather than needing the nightly `fuzz/` targets.

Two generators run against every feature at once:

- **Token soup** from the fragments that break scanners: half-open fences and containers, stray delimiters, multi-byte characters, NUL, BOM, bidi overrides, line and paragraph separators.
- **Structured documents** from real block templates (containers, code groups, tables, definition lists, timelines, file trees, MDX, frontmatter) with real inline content, so the passes are reached through the shapes they are written for instead of bouncing off a parse failure on the first line.

Both are deterministic — a failure prints the seed and the document.

A second test pins that a reused transformer renders a document the same way whatever came before it. One transformer serves every page of a build, so carried state would show up as a page that renders differently depending on its neighbours.

## Risk

- Risk level: low — test-only.
- User or production impact: none directly; it makes this class of defect fail in CI instead of in a user's build.
- Rollback plan: delete the test.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_transform --test pipeline_fuzz` (passes, ~4 s in a debug build), plus the full `cargo test -p ox_content_transform`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all --check`, `node scripts/check-panic-constructs.mjs`, `node scripts/check-file-lines.ts`.
- [x] Manual verification completed: reverting either fix makes the lane fail — the definition-list abort reproduces at seed 748 (`"</div>%\u{2028}details\n::: v-pre"`), and the attribute abort at its own seeds. The lane also ran clean at 400,000 documents locally; the committed budget is 30,000 plus 8,000 to keep the job fast.
- [x] Edge cases or failure modes considered: debug builds turn an unexpected panic into an `errors` entry rather than unwinding out, so the lane treats a diagnostic containing "panic" as the same failure. File-reading features (`includes`, `partials`, `code_imports`, `data_tables`) are left off so the lane stays hermetic.

`docs/content/panic-prevention.md` and its Japanese translation record the command and narrow the remaining-work item to the surfaces still uncovered — SSG, docs, and the editor crates.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated: the panic-prevention page in both languages.
- [x] Configuration, migration, or environment changes documented, or not needed — none; it rides the existing test job.
- [x] Observability, logging, and alerting impact considered, or not needed — none.
- [x] Security, privacy, and dependency impact considered: this is the regression net for a denial-of-service class. No new dependencies.
