### PR TITLE
chore(benchmarks): refresh mizchi markdown 0.8.2 results

### DIFF
--- a/benchmarks/bundle-size/package.json
+++ b/benchmarks/bundle-size/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.4",
-    "@mizchi/markdown": "^0.8.1",
+    "@mizchi/markdown": "^0.8.2",
     "@ox-content/napi": "workspace:*",
     "@tanstack/markdown": "^0.0.13",
     "markdown-it": "^15.0.0",

--- a/benchmarks/commonmark-conformance/package.json
+++ b/benchmarks/commonmark-conformance/package.json
@@ -7,7 +7,7 @@
     "conformance": "node run.mjs --json results.json"
   },
   "dependencies": {
-    "@mizchi/markdown": "^0.8.1",
+    "@mizchi/markdown": "^0.8.2",
     "@ox-content/napi": "workspace:*",
     "@tanstack/markdown": "^0.0.13",
     "markdown-it": "^15.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,8 +183,8 @@ importers:
         specifier: ^7.2.4
         version: 7.2.4(supports-color@10.2.2)
       '@mizchi/markdown':
-        specifier: ^0.8.1
-        version: 0.8.1
+        specifier: ^0.8.2
+        version: 0.8.2
       '@ox-content/napi':
         specifier: workspace:*
         version: link:../../crates/ox_content_napi
@@ -313,8 +313,8 @@ importers:
   benchmarks/commonmark-conformance:
     dependencies:
       '@mizchi/markdown':
-        specifier: ^0.8.1
-        version: 0.8.1
+        specifier: ^0.8.2
+        version: 0.8.2
       '@ox-content/napi':
         specifier: workspace:*
         version: link:../../crates/ox_content_napi
@@ -3787,8 +3787,8 @@ packages:
   '@mermaid-js/parser@1.2.0':
     resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
-  '@mizchi/markdown@0.8.1':
-    resolution: {integrity: sha512-OAym6fErecomnLjNfrfIz/H1mw8d706s+XaXVLgiQqJGUbexbbW+0ohty1baelsVh4Hg739G+qm5Tn86lglDKA==}
+  '@mizchi/markdown@0.8.2':
+    resolution: {integrity: sha512-7lqI6WuKO4RtuQRdt4nVEZPXGHwUwWjO4FPRntcGMdZ7E3tR9WWsQgGEUjQfNnPtPudJgaWzgRWyTwRFwVXUyA==}
     engines: {node: '>=24'}
     peerDependencies:
       '@luna_ui/luna': ^0.23.0
@@ -11012,7 +11012,7 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@mizchi/markdown@0.8.1': {}
+  '@mizchi/markdown@0.8.2': {}
 
   '@napi-rs/canvas-android-arm64@0.1.100':
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,4 +57,4 @@ peerDependencyRules:
     vite: "*"
     vitest: "*"
 minimumReleaseAgeExclude:
-  - "@mizchi/markdown@0.8.1"
+  - "@mizchi/markdown@0.8.2"


### PR DESCRIPTION
## Summary

- update @mizchi/markdown from 0.8.1 to 0.8.2
- refresh the CommonMark and published performance snapshot

## Parse speedup (same-machine A/B)

Median of 7 runs on the same machine and benchmark inputs:

| Input | 0.8.1 | 0.8.2 | Speedup |
| --- | ---: | ---: | ---: |
| large (49,898 bytes) | 92.9 ops/s | 628.4 ops/s | 6.76x |
| huge (1,072,848 bytes) | 2.51 ops/s | 17.77 ops/s | 7.09x |

The published README/SVG snapshot remains gated on the upstream Blacksmith 32 vCPU workflow; fork Actions currently require maintainer approval.

## Validation

- pnpm install --frozen-lockfile
- vp run test:benchmark-scripts (22 tests passed)
- vp fmt --check
- CommonMark conformance: 641/652 (98.3%, unchanged)