### PR TITLE
fix(lint): stop an unpaired `][` hanging the linter forever

### DIFF
--- a/crates/ox_content_markdown_lint/src/lint/mask.rs
+++ b/crates/ox_content_markdown_lint/src/lint/mask.rs
@@ -124,14 +124,17 @@ fn mask_link_targets(line_chars: &[char], chars: &mut [char]) {
         }
 
         if line_chars[index + 1] == '[' {
-            let mut cursor = index + 2;
-            while cursor < line_chars.len() {
-                if line_chars[cursor] == ']' {
-                    blank_range(chars, index, cursor + 1);
-                    index = cursor + 1;
-                    break;
+            // `index` has to move whether or not the reference label
+            // closes. It used to move only on the `]`, so a `][` with no
+            // later `]` — `text ][ text`, or any line where the brackets do
+            // not pair up — spun here forever.
+            match line_chars[index + 2..].iter().position(|value| *value == ']') {
+                Some(offset) => {
+                    let close = index + 2 + offset;
+                    blank_range(chars, index, close + 1);
+                    index = close + 1;
                 }
-                cursor += 1;
+                None => index += 1,
             }
         } else {
             index += 1;

--- a/crates/ox_content_markdown_lint/tests/link_mask.rs
+++ b/crates/ox_content_markdown_lint/tests/link_mask.rs
@@ -1,0 +1,151 @@
+//! `mask_link_targets` used to advance its cursor only when a reference label
+//! closed, so any line holding a `][` without a later `]` spun forever. These
+//! tests pin both halves of the contract: the masker always terminates, and it
+//! still blanks exactly the link targets it is supposed to blank.
+
+use std::sync::mpsc::{RecvTimeoutError, channel};
+use std::thread;
+use std::time::Duration;
+
+use ox_content_markdown_lint::{MarkdownLintOptions, lint_markdown, lint_markdown_documents};
+
+/// Runs `work` on a helper thread so a hang fails the test instead of wedging
+/// the whole suite. A regression here is an infinite loop, not a slow path, so
+/// the budget is deliberately generous.
+fn within_timeout<T: Send + 'static>(
+    label: &str,
+    seconds: u64,
+    work: impl FnOnce() -> T + Send + 'static,
+) -> T {
+    let (sender, receiver) = channel();
+    thread::spawn(move || {
+        let _ = sender.send(work());
+    });
+
+    match receiver.recv_timeout(Duration::from_secs(seconds)) {
+        Ok(value) => value,
+        Err(RecvTimeoutError::Timeout) => panic!("{label} did not finish within {seconds}s"),
+        Err(RecvTimeoutError::Disconnected) => panic!("{label} panicked"),
+    }
+}
+
+fn mask_of(source: &str) -> String {
+    lint_markdown(source, None).masked_document
+}
+
+/// `visible` kept, then `blanks` spaces, then `tail` kept.
+fn expected(visible: &str, blanks: usize, tail: &str) -> String {
+    let mut out = String::from(visible);
+    out.extend(std::iter::repeat_n(' ', blanks));
+    out.push_str(tail);
+    out
+}
+
+#[test]
+fn unpaired_reference_bracket_terminates() {
+    let masked = within_timeout("lone `][`", 30, || mask_of("text ][ text"));
+
+    // Nothing here is a link, so only the bracket characters themselves are
+    // blanked (every masked line loses its `[]()` markers). Both words survive.
+    assert_eq!(masked, "text    text");
+}
+
+#[test]
+fn repeated_unpaired_reference_brackets_terminate() {
+    let masked =
+        within_timeout("repeated `][`", 30, || mask_of("prose ][ more ][ and ][ still going"));
+
+    // The first `][` finds its closing `]` in the *second* `][`, so the span
+    // between them is treated as a reference label and blanked; the third `][`
+    // never closes. What matters is that the scan terminates and the text past
+    // the last unpaired bracket still reaches the rules.
+    assert_eq!(masked, "prose            and    still going");
+}
+
+#[test]
+fn unpaired_reference_bracket_inside_a_large_document_terminates() {
+    // Guards against the fix being linear-per-line but quadratic overall: 20k
+    // lines each carrying the pathological shape.
+    let source = (0..20_000).map(|_| "a ][ b\n").collect::<String>();
+    let line_count = source.lines().count();
+
+    let masked = within_timeout("20k pathological lines", 60, move || mask_of(&source));
+
+    assert_eq!(masked.lines().count(), line_count);
+    assert!(masked.lines().all(|line| line == "a    b"));
+}
+
+#[test]
+fn reference_labels_are_still_blanked() {
+    // The label must be blanked so the spellchecker never sees it, and the
+    // blanking must be length-preserving so diagnostic columns stay accurate.
+    assert_eq!(mask_of("[shown][hidden]"), expected(" shown", 9, ""));
+    assert_eq!(mask_of("see [shown][hidden] here"), expected("see  shown", 9, " here"));
+    assert!(!mask_of("[shown][hidden]").contains("hidden"));
+}
+
+#[test]
+fn inline_link_targets_are_still_blanked() {
+    assert_eq!(mask_of("[shown](/hidden)"), expected(" shown", 10, ""));
+    assert_eq!(mask_of("[shown](/a(nested)b) tail"), expected(" shown", 14, " tail"));
+    assert!(!mask_of("[shown](/hidden)").contains("hidden"));
+}
+
+#[test]
+fn text_after_an_unpaired_bracket_is_still_linted() {
+    // The old loop never reached anything past the `][`. Text that follows it
+    // has to keep flowing through the rules.
+    let result = within_timeout("lint after `][`", 30, || {
+        lint_markdown("Sentence ][ with with a repeated word.", None)
+    });
+
+    let rules: Vec<_> = result.diagnostics.iter().map(|d| d.rule_id.as_str()).collect();
+    assert!(
+        rules.contains(&"repeated-word"),
+        "expected a repeated-word diagnostic after the `][`, got {rules:?}"
+    );
+}
+
+#[test]
+fn every_short_bracket_soup_terminates() {
+    // Exhaustive over the characters that drive the masker's state machine.
+    // Every string up to length 6 must terminate and must preserve length.
+    const ALPHABET: [char; 5] = ['[', ']', '(', ')', 'a'];
+    const MAX_LEN: u32 = 6;
+
+    let mut sources = Vec::new();
+    for len in 1..=MAX_LEN {
+        for index in 0..ALPHABET.len().pow(len) {
+            let mut rest = index;
+            let mut source = String::with_capacity(len as usize);
+            for _ in 0..len {
+                source.push(ALPHABET[rest % ALPHABET.len()]);
+                rest /= ALPHABET.len();
+            }
+            sources.push(source);
+        }
+    }
+
+    let expected = sources.clone();
+    let results = within_timeout("exhaustive bracket soup", 180, move || {
+        lint_markdown_documents(&sources, Some(MarkdownLintOptions::default()))
+    });
+
+    assert_eq!(results.len(), expected.len());
+    for (result, source) in results.iter().zip(&expected) {
+        assert_eq!(
+            result.masked_document.chars().count(),
+            source.chars().count(),
+            "masking changed the length of {source:?}"
+        );
+    }
+}
+
+#[test]
+fn multibyte_text_around_an_unpaired_bracket_terminates() {
+    // The masker works in `char`s; a regression that reintroduced byte
+    // indexing would panic rather than hang, so cover that too.
+    let masked = within_timeout("multibyte `][`", 30, || mask_of("日本語 ][ の文章です"));
+
+    assert_eq!(masked, "日本語    の文章です");
+}


### PR DESCRIPTION
## Problem

`mask_link_targets` blanks link targets before the text rules run. On a `][` it scanned forward for the closing `]` and advanced `index` **only when it found one**:

```rust
let mut cursor = index + 2;
while cursor < line_chars.len() {
    if line_chars[cursor] == ']' {
        blank_range(chars, index, cursor + 1);
        index = cursor + 1;
        break;
    }
    cursor += 1;
}
```

If no `]` follows, the inner loop runs to the end of the line, falls out, and leaves `index` untouched — so the outer `while index + 1 < line_chars.len()` re-enters the same branch at the same index forever.

**Minimal repro is two characters.** `text ][ text` is enough:

```rust
lint_markdown("text ][ text", None); // never returns
```

That is ordinary prose, not a malformed edge case, and `lintMarkdown` is exposed through NAPI — an editor integration linting a line like this wedges the process.

## Fix

Advance past the `]` when the reference label does not close. Everything else is unchanged: a label that *does* close is still blanked exactly as before.

## Tests

`crates/ox_content_markdown_lint/tests/link_mask.rs`, 8 tests:

- **Termination** — lone `][`, repeated `][`, a 20k-line document of them (catches a fix that is linear per line but quadratic overall), and a multibyte line (a regression to byte indexing would panic instead of hang). Each runs on a watchdog thread, so a regression **fails the test** rather than hanging CI.
- **Exhaustive** — every string up to length 6 over `[`, `]`, `(`, `)`, `a` (19,530 documents) goes through the linter; all must terminate and preserve length.
- **Correctness, not just termination** — reference labels and inline link targets are still blanked (and the hidden text provably absent from the masked document), and text *after* an unpaired `][` still reaches the rules (the old loop never got there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a problem that could cause Markdown linting to become unresponsive when link reference brackets were incomplete.
  * Improved handling of malformed and repeated brackets while preserving correct masking of link targets.
  * Ensured linting continues correctly for text following incomplete link syntax, including multibyte text.

* **Tests**
  * Added comprehensive coverage for malformed brackets, large documents, inline links, reference labels, and edge-case Markdown strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->