### PR TITLE
chore(benchmarks): update mizchi markdown to 0.8.3

### DIFF
--- a/benchmarks/bundle-size/package.json
+++ b/benchmarks/bundle-size/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.4",
-    "@mizchi/markdown": "^0.8.2",
+    "@mizchi/markdown": "^0.8.3",
     "@ox-content/napi": "workspace:*",
     "@tanstack/markdown": "^0.0.13",
     "markdown-it": "^15.0.0",

--- a/benchmarks/commonmark-conformance/package.json
+++ b/benchmarks/commonmark-conformance/package.json
@@ -7,7 +7,7 @@
     "conformance": "node run.mjs --json results.json"
   },
   "dependencies": {
-    "@mizchi/markdown": "^0.8.2",
+    "@mizchi/markdown": "^0.8.3",
     "@ox-content/napi": "workspace:*",
     "@tanstack/markdown": "^0.0.13",
     "markdown-it": "^15.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,8 +183,8 @@ importers:
         specifier: ^7.2.4
         version: 7.2.4(supports-color@10.2.2)
       '@mizchi/markdown':
-        specifier: ^0.8.2
-        version: 0.8.2
+        specifier: ^0.8.3
+        version: 0.8.3
       '@ox-content/napi':
         specifier: workspace:*
         version: link:../../crates/ox_content_napi
@@ -313,8 +313,8 @@ importers:
   benchmarks/commonmark-conformance:
     dependencies:
       '@mizchi/markdown':
-        specifier: ^0.8.2
-        version: 0.8.2
+        specifier: ^0.8.3
+        version: 0.8.3
       '@ox-content/napi':
         specifier: workspace:*
         version: link:../../crates/ox_content_napi
@@ -3787,8 +3787,8 @@ packages:
   '@mermaid-js/parser@1.2.0':
     resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
-  '@mizchi/markdown@0.8.2':
-    resolution: {integrity: sha512-7lqI6WuKO4RtuQRdt4nVEZPXGHwUwWjO4FPRntcGMdZ7E3tR9WWsQgGEUjQfNnPtPudJgaWzgRWyTwRFwVXUyA==}
+  '@mizchi/markdown@0.8.3':
+    resolution: {integrity: sha512-Cerz620N/RixkM0Io2mxsp5118HGj4MnIe6z5CxFSyDXtevUvFtp+v7pGNcN+s1fnES5qEc73gSCIiTcKgmmCQ==}
     engines: {node: '>=24'}
     peerDependencies:
       '@luna_ui/luna': ^0.23.0
@@ -11012,7 +11012,7 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@mizchi/markdown@0.8.2': {}
+  '@mizchi/markdown@0.8.3': {}
 
   '@napi-rs/canvas-android-arm64@0.1.100':
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,4 +57,4 @@ peerDependencyRules:
     vite: "*"
     vitest: "*"
 minimumReleaseAgeExclude:
-  - "@mizchi/markdown@0.8.2"
+  - "@mizchi/markdown@0.8.3"


### PR DESCRIPTION
## Summary
- update benchmark workspaces to @mizchi/markdown 0.8.3
- align the lockfile and minimum-release-age exception with the new package version
- refresh benchmark docs from the GitHub Actions benchmark artifact

## Verification
- npm view @mizchi/markdown version => 0.8.3
- vp install --frozen-lockfile --prefer-offline
- node benchmarks/commonmark-conformance/run.mjs --json benchmarks/commonmark-conformance/results.json
- Benchmark docs: https://github.com/ubugeeei-prod/ox-content/actions/runs/33320622850

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated benchmark packages to use `@mizchi/markdown` version 0.8.3.
  - Updated workspace package release-age configuration to recognize the newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->