### PR TITLE
perf(lint): stop a long line costing quadratic time

### DIFF
--- a/crates/ox_content_markdown_lint/src/lint/mask.rs
+++ b/crates/ox_content_markdown_lint/src/lint/mask.rs
@@ -37,27 +37,23 @@ pub(super) fn mask_markdown_line(line: &str) -> String {
     if let Some(list_prefix_pattern) = LIST_PREFIX_PATTERN.as_ref()
         && let Some(prefix_match) = list_prefix_pattern.find(line)
     {
-        let (start, end) = byte_range_to_char_range(line, prefix_match.start(), prefix_match.end());
+        let mut cursor = CharIndexCursor::new(line);
+        let start = cursor.char_index(prefix_match.start());
+        let end = cursor.char_index(prefix_match.end());
         blank_range(&mut chars, start, end);
     }
 
-    if let Some(footnote_pattern) = FOOTNOTE_PATTERN.as_ref() {
-        for value in footnote_pattern.find_iter(line) {
-            let (start, end) = byte_range_to_char_range(line, value.start(), value.end());
-            blank_range(&mut chars, start, end);
-        }
-    }
+    // Each scan restarts at the front of the line, so each gets its own
+    // cursor; within a scan the matches arrive in order.
+    for pattern in [FOOTNOTE_PATTERN.as_ref(), URL_PATTERN.as_ref(), HTML_TAG_PATTERN.as_ref()] {
+        let Some(pattern) = pattern else {
+            continue;
+        };
 
-    if let Some(url_pattern) = URL_PATTERN.as_ref() {
-        for value in url_pattern.find_iter(line) {
-            let (start, end) = byte_range_to_char_range(line, value.start(), value.end());
-            blank_range(&mut chars, start, end);
-        }
-    }
-
-    if let Some(html_tag_pattern) = HTML_TAG_PATTERN.as_ref() {
-        for value in html_tag_pattern.find_iter(line) {
-            let (start, end) = byte_range_to_char_range(line, value.start(), value.end());
+        let mut cursor = CharIndexCursor::new(line);
+        for value in pattern.find_iter(line) {
+            let start = cursor.char_index(value.start());
+            let end = cursor.char_index(value.end());
             blank_range(&mut chars, start, end);
         }
     }
@@ -161,8 +157,4 @@ fn blank_range(chars: &mut [char], start: usize, end: usize) {
     for value in chars.iter_mut().take(safe_end).skip(safe_start) {
         *value = ' ';
     }
-}
-
-fn byte_range_to_char_range(text: &str, start: usize, end: usize) -> (usize, usize) {
-    (byte_to_char_index(text, start), byte_to_char_index(text, end))
 }

--- a/crates/ox_content_markdown_lint/src/lint/tokens.rs
+++ b/crates/ox_content_markdown_lint/src/lint/tokens.rs
@@ -13,8 +13,9 @@ pub(super) fn collect_tokens(
     let mut cjk_tokens = Vec::new();
 
     if let Some(cjk_run_pattern) = CJK_RUN_PATTERN.as_ref() {
+        let mut cursor = CharIndexCursor::new(masked_line);
         for value in cjk_run_pattern.find_iter(masked_line) {
-            let start = byte_to_char_index(masked_line, value.start());
+            let start = cursor.char_index(value.start());
             cjk_tokens.extend(collect_cjk_tokens(value.as_str(), start, languages, dictionary));
         }
     }
@@ -65,9 +66,10 @@ fn collect_latin_tokens(
     let mut tokens = Vec::new();
 
     if let Some(latin_word_pattern) = LATIN_WORD_PATTERN.as_ref() {
+        let mut cursor = CharIndexCursor::new(masked_line);
         for value in latin_word_pattern.find_iter(masked_line) {
             let text = value.as_str().to_string();
-            let start = byte_to_char_index(masked_line, value.start());
+            let start = cursor.char_index(value.start());
             let end = start + count_code_points(value.as_str());
             tokens.push(Token { end, language: fallback_language.clone(), start, text });
         }

--- a/crates/ox_content_markdown_lint/src/lint/utils.rs
+++ b/crates/ox_content_markdown_lint/src/lint/utils.rs
@@ -1,7 +1,50 @@
 use super::*;
 
-pub(super) fn byte_to_char_index(text: &str, byte_index: usize) -> usize {
-    text[..byte_index.min(text.len())].chars().count()
+fn clamp_to_char_boundary(text: &str, byte_index: usize) -> usize {
+    let mut index = byte_index.min(text.len());
+    while !text.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+/// Converts byte offsets to character offsets in one forward pass.
+///
+/// Counting from the front of the line for every match of a scan is quadratic
+/// in the line length — a single 1 MiB line took seconds. Regex matches arrive
+/// in order, so a cursor only ever has to count the gap since its last answer.
+pub(super) struct CharIndexCursor<'a> {
+    ascii_only: bool,
+    byte_index: usize,
+    char_index: usize,
+    text: &'a str,
+}
+
+impl<'a> CharIndexCursor<'a> {
+    pub(super) fn new(text: &'a str) -> Self {
+        Self { ascii_only: text.is_ascii(), byte_index: 0, char_index: 0, text }
+    }
+
+    /// Offsets are expected to arrive in non-decreasing order. One that goes
+    /// backwards restarts the count from the front rather than answering with
+    /// a stale character index, so an out-of-order caller stays correct and
+    /// only loses the speedup.
+    pub(super) fn char_index(&mut self, byte_index: usize) -> usize {
+        let byte_index = clamp_to_char_boundary(self.text, byte_index);
+
+        if self.ascii_only {
+            return byte_index;
+        }
+
+        if byte_index < self.byte_index {
+            self.byte_index = 0;
+            self.char_index = 0;
+        }
+
+        self.char_index += self.text[self.byte_index..byte_index].chars().count();
+        self.byte_index = byte_index;
+        self.char_index
+    }
 }
 
 pub(super) fn collect_char_boundaries(text: &str) -> Vec<usize> {
@@ -127,4 +170,66 @@ pub(super) fn levenshtein(left: &str, right: &str) -> usize {
     }
 
     previous_row[right_chars.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cursor_matches_a_full_recount_at_every_boundary() {
+        for text in [
+            "",
+            "plain ascii text",
+            "日本語のテキスト",
+            "mixed 日本語 and ascii ではの",
+            "combining a\u{0301}e\u{0301}o\u{0301} marks",
+            "emoji \u{1F600} and \u{1F1EF}\u{1F1F5} flags",
+        ] {
+            let mut cursor = CharIndexCursor::new(text);
+            for byte_index in 0..=text.len() {
+                if !text.is_char_boundary(byte_index) {
+                    continue;
+                }
+                let expected = text[..byte_index].chars().count();
+                assert_eq!(cursor.char_index(byte_index), expected, "{text:?} at {byte_index}");
+            }
+        }
+    }
+
+    #[test]
+    fn cursor_recovers_when_offsets_go_backwards() {
+        let text = "日本語 mixed テキスト";
+        let mut cursor = CharIndexCursor::new(text);
+
+        let far = text.len();
+        assert_eq!(cursor.char_index(far), text.chars().count());
+        // Walking back has to recount rather than report a stale index.
+        assert_eq!(cursor.char_index(0), 0);
+        assert_eq!(cursor.char_index("日本語".len()), 3);
+    }
+
+    #[test]
+    fn cursor_clamps_past_the_end_and_off_a_boundary() {
+        let text = "日本語";
+        let mut cursor = CharIndexCursor::new(text);
+
+        // Past the end clamps to the end.
+        assert_eq!(cursor.char_index(text.len() + 100), 3);
+
+        // Inside a multi-byte character rounds down to its start.
+        let mut cursor = CharIndexCursor::new(text);
+        assert_eq!(cursor.char_index(4), 1);
+        assert_eq!(cursor.char_index(5), 1);
+        assert_eq!(cursor.char_index(6), 2);
+    }
+
+    #[test]
+    fn cursor_takes_the_ascii_fast_path_without_changing_answers() {
+        let text = "the quick brown fox";
+        let mut cursor = CharIndexCursor::new(text);
+        for byte_index in 0..=text.len() {
+            assert_eq!(cursor.char_index(byte_index), byte_index);
+        }
+    }
 }

--- a/crates/ox_content_markdown_lint/tests/long_line_scaling.rs
+++ b/crates/ox_content_markdown_lint/tests/long_line_scaling.rs
@@ -1,0 +1,134 @@
+//! A single long line used to cost O(n²).
+//!
+//! Every scan in the masker and the tokenizer converted each match's byte
+//! offset to a character offset by counting from the front of the line, so a
+//! line with k matches over n bytes did O(n·k) work. One 1 MiB line took
+//! seconds; four of them took a minute. Markdown that is not hard-wrapped —
+//! generated API docs, a paragraph written as one line, a long table row —
+//! hits this on ordinary content.
+//!
+//! These tests pin the cost back to linear and pin the diagnostic columns
+//! that the conversion feeds, because a cursor that drifts would move every
+//! reported column on a multi-byte line.
+
+use std::time::Instant;
+
+use ox_content_markdown_lint::{MarkdownLintOptions, lint_markdown};
+
+fn options(languages: &[&str]) -> MarkdownLintOptions {
+    MarkdownLintOptions {
+        languages: Some(languages.iter().map(ToString::to_string).collect()),
+        ..Default::default()
+    }
+}
+
+fn one_line(unit: &str, bytes: usize) -> String {
+    let mut out = String::with_capacity(bytes + unit.len());
+    while out.len() < bytes {
+        out.push_str(unit);
+    }
+    out
+}
+
+/// Best of three, so one scheduling stall on a busy runner cannot fail the
+/// build. A complexity regression shows up in every run, not just the slowest.
+fn fastest_lint(source: &str, options: &MarkdownLintOptions) -> f64 {
+    (0..3)
+        .map(|_| {
+            let started = Instant::now();
+            let result = lint_markdown(source, Some(options.clone()));
+            let elapsed = started.elapsed().as_secs_f64();
+            std::hint::black_box(result.diagnostics.len());
+            elapsed
+        })
+        .fold(f64::INFINITY, f64::min)
+}
+
+#[test]
+fn a_long_line_costs_linear_time() {
+    // Both units pack many matches into few bytes and cost little per byte
+    // otherwise, so the quadratic term stands furthest above the noise. Before
+    // the fix these grew x13.3 and x19.1 for 4x the input; after it, x3.9 and
+    // x4.6. The budget sits between, with roughly 2x of room on either side.
+    for (name, unit, languages) in
+        [("short urls", "http://a.b/x ", &["en"][..]), ("footnotes", "[^あ] ", &["en", "ja"][..])]
+    {
+        let options = options(languages);
+        // Warm the lazily-built dictionary before timing anything.
+        let _ = lint_markdown("warm up", Some(options.clone()));
+
+        let small = fastest_lint(&one_line(unit, 256 * 1024), &options);
+        let large = fastest_lint(&one_line(unit, 1024 * 1024), &options);
+
+        // 4x the input. Linear costs about 4x the time; quadratic costs 16x.
+        assert!(
+            large < small * 8.0,
+            "{name}: 1 MiB took {large:.4}s against {small:.4}s for 256 KiB \
+             (x{:.1}); linear is about x4, quadratic about x16",
+            large / small
+        );
+    }
+}
+
+#[test]
+fn columns_stay_character_offsets_on_long_multibyte_lines() {
+    // The cursor replaced a full recount per match. If it drifts, every column
+    // on a multi-byte line moves — and it would only drift once the line is
+    // long enough for the cursor to have advanced, so short cases cannot catch
+    // it on their own.
+    let options = options(&["en"]);
+    let word = "wrrrrong";
+
+    for unit in
+        ["日本語のテキストです。", "café naïve ", "<span>日本語</span> ", "a\u{0301}e\u{0301} "]
+    {
+        for repeats in [1usize, 4, 64, 4096] {
+            let prefix = unit.repeat(repeats);
+            let source = format!("{prefix}{word}");
+            let result = lint_markdown(&source, Some(options.clone()));
+
+            let found = result
+                .diagnostics
+                .iter()
+                .find(|diagnostic| diagnostic.message.contains(word))
+                .unwrap_or_else(|| panic!("no diagnostic for {word:?} after {repeats} x {unit:?}"));
+
+            let expected_column = prefix.chars().count() + 1;
+            assert_eq!(found.column as usize, expected_column, "column after {repeats} x {unit:?}");
+            assert_eq!(
+                found.end_column as usize,
+                expected_column + word.chars().count(),
+                "end column after {repeats} x {unit:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn masking_stays_aligned_on_long_multibyte_lines() {
+    // The same conversion drives `blank_range`, so a drifting cursor blanks
+    // the wrong span: the masked line has to keep the source's length and keep
+    // the visible words visible.
+    let options = options(&["en", "ja"]);
+
+    for unit in [
+        "日本語 [リンク](https://example.com/日本) テキスト ",
+        "見出し <span class=\"あ\">日本語</span> あと ",
+        "1. 項目 [^脚注] おわり ",
+    ] {
+        for repeats in [1usize, 4, 64, 2048] {
+            let source = unit.repeat(repeats);
+            let masked = lint_markdown(&source, Some(options.clone())).masked_document;
+
+            assert_eq!(
+                masked.chars().count(),
+                source.chars().count(),
+                "masked length changed for {repeats} x {unit:?}"
+            );
+            assert!(
+                masked.contains("テキスト") || masked.contains("日本語") || masked.contains("項目"),
+                "masking swallowed the visible text of {repeats} x {unit:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Every scan in the linter's masker and tokenizer turned a match's byte offset into a character offset with

```rust
fn byte_to_char_index(text: &str, byte_index: usize) -> usize {
    text[..byte_index.min(text.len())].chars().count()
}
```

which counts from the front of the line **every time**. It is called once per match of `LIST_PREFIX_PATTERN`, `FOOTNOTE_PATTERN`, `URL_PATTERN`, `HTML_TAG_PATTERN`, `CJK_RUN_PATTERN`, and `LATIN_WORD_PATTERN`. A line with `k` matches over `n` bytes therefore does `O(n·k)` work — and `k` grows with `n`, so it is quadratic in the line length.

Markdown that is not hard-wrapped hits this on ordinary content: generated API docs, a paragraph written as a single line, a long table row, a line carrying a data URI.

**One 1 MiB line took 5.9 seconds.** Growth was a clean **x4.0 per doubling**.

## Fix

Regex matches arrive in order, so a cursor only ever has to count the gap since its last answer. A line that is entirely ASCII needs no count at all — the character index *is* the byte index.

Two robustness improvements come with it, both strictly better than the helper they replace:

- An offset that arrives out of order restarts the count instead of answering from stale state, so an out-of-order caller stays correct and only loses the speedup.
- An offset that lands inside a multi-byte character rounds down to its start. The old helper would have **panicked** (`text[..offset]` on a non-boundary).

## Result

One 1 MiB line, release build:

| content | before | after | |
|---|---|---|---|
| prose | 5.9420s | 0.4476s | **13x** |
| japanese | 1.2282s | 0.0087s | **141x** |
| urls | 2.5745s | 0.0147s | **175x** |

Growth per doubling drops from **x4.0** to **x2.0**.

## Output is unchanged

Linting 12,000 fuzz-corpus documents (the corpus from #1221) plus 32 multi-byte cases produced **byte-identical** output before and after — diagnostics, rule ids, severities, line/column/end-line/end-column, languages, suggestions, messages, the three counts, and the masked document.

## Tests

**Unit** (`src/lint/utils.rs`) — the cursor is checked against a full recount at *every* character boundary of ASCII, Japanese, mixed, combining-mark, and emoji text; plus out-of-order recovery, clamping past the end, clamping off a boundary, and the ASCII fast path.

**Integration** (`tests/long_line_scaling.rs`):

- `a_long_line_costs_linear_time` — 4x the input must not cost 8x the time. Measured against the two shapes where the quadratic term stands furthest above the noise; best-of-three so a scheduling stall on a busy runner cannot fail the build. **On `main` this fails at x15.5**; with the fix it is x3.9.
- `columns_stay_character_offsets_on_long_multibyte_lines` — exact diagnostic columns at 1, 4, 64, and 4096 repeats of Japanese, accented Latin, inline HTML, and combining marks. A cursor that drifts moves every column on a multi-byte line, and it would only drift once the line is long enough to have advanced — short cases cannot catch it alone.
- `masking_stays_aligned_on_long_multibyte_lines` — the same conversion drives `blank_range`, so a drifting cursor blanks the wrong span. Pins that the masked line keeps the source's length and keeps the visible words visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790699086&installation_model_id=422833&pr_number=1225&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1225&signature=d2feda4d1702d17fd4a6303c667e409f42dab538f62b5508b6c83c29b53b5d91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->