### PR TITLE
chore(benchmarks): cover mizchi markdown runtimes

### DIFF
--- a/.github/scripts/run-pr-benchmark.mjs
+++ b/.github/scripts/run-pr-benchmark.mjs
@@ -17,6 +17,8 @@ if (options.skipRuntime && options.skipBundle) {
 const sourceRoot = resolve(options.source ?? requiredEnv("GITHUB_WORKSPACE"));
 
 for (const file of [
+  "benchmarks/mizchi-markdown-native.mjs",
+  "benchmarks/mizchi-markdown-native-template.mjs",
   "benchmarks/bundle-size/parse-benchmark.mjs",
   "benchmarks/bundle-size/parse-benchmark-bun.mjs",
   "benchmarks/bundle-size/measure.mjs",

--- a/.github/workflows/benchmark-docs.yml
+++ b/.github/workflows/benchmark-docs.yml
@@ -55,6 +55,13 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
+      # The docs refresh includes @mizchi/markdown's native MoonBit runtime in
+      # both the speed tables and the CommonMark coverage table.
+      - name: Setup MoonBit
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+
       - name: Mount sticky cache
         uses: ./.github/actions/mount-sticky-cache
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -80,6 +80,15 @@ jobs:
         # is no project lockfile to install it from.
         run: npm install --global bun@1.3.14 # zizmor: ignore[adhoc-packages]
 
+      # @mizchi/markdown ships a native MoonBit build in its source repository.
+      # The runtime benchmark builds the matching gitHead for the package
+      # version under test, so install the MoonBit CLI when runtime rows run.
+      - name: Setup MoonBit
+        if: steps.scope.outputs.runtime == 'true'
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+
       - name: Setup Rust
         if: steps.scope.outputs.runtime == 'true' || steps.scope.outputs.bundle == 'true'
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Run the benchmark with:
 node benchmarks/bundle-size/parse-benchmark.mjs
 ```
 
-The script compares against `@tanstack/markdown`, `markdown-it-ts`, `satteri`, `@mizchi/markdown`, `md4w (md4c)`, and `md4x (napi)` by default, and includes `Bun.markdown.html` automatically when `bun` is installed.
+The script compares against `@tanstack/markdown`, `markdown-it-ts`, `satteri`, `@mizchi/markdown` (JS, Wasm, and native), `md4w (md4c)`, and `md4x` (NAPI and Wasm) by default, and includes `Bun.markdown.html` automatically when `bun` is installed.
 
 ## CommonMark Conformance
 
@@ -322,7 +322,7 @@ Ox Content targets full CommonMark conformance. The engine is checked against th
 - **GFM profile: 649 / 652 examples.** The three differences are spec examples 608, 611, and 612, where the GFM autolink extension deliberately linkifies bare URLs and emails that plain CommonMark leaves as text. They are listed in `crates/ox_content_renderer/tests/spec_fixtures/commonmark-known-failures.txt`.
 - **GFM extensions: every example** in the GitHub Flavored Markdown 0.29-gfm spec sections for tables, task lists, strikethrough, autolinks, and disallowed raw HTML, driven by `spec_gfm.rs`.
 
-Where the two Ox Content rows in the tables differ: `ox-content (native)` is the core profile and scores 100%, while `@ox-content/napi` scores 99.5% because its defaults enable the bare-URL autolinking builtin, which linkifies examples 602, 608, and 611. Pass `autolinkUrls: false` to turn it off.
+Where the two Ox Content rows in the tables differ: `ox-content (native)` is the core profile and scores 100%, while `@ox-content/napi` scores 99.5% because its defaults enable the bare-URL autolinking builtin, which linkifies examples 602, 608, and 611. Pass `autolinkUrls: false` to turn it off. The `@mizchi/markdown` JS, Wasm, and native rows likewise disable their default autolink and tagfilter extensions for the CommonMark column; the speed rows keep runtime defaults.
 
 Extensions beyond CommonMark — GFM tables, task lists, strikethrough, footnotes, and the built-in embeds — are opt-out rather than opt-in, so a document that uses none of them renders exactly as the specification requires. [Markdown Baseline](https://ubugeeei-prod.github.io/ox-content/built-in/markdown/) lists each toggle.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -34,10 +34,11 @@ Two decisions make the comparison fair, and both are load-bearing:
 - **Configuration.** Each engine runs in the most spec-faithful mode it exposes,
   not in its benchmark defaults: `markdown-it` and `markdown-it-ts` use their
   `commonmark` presets, `micromark` and `remark-html` are told to pass raw HTML
-  through, and `md4w` runs with `parseFlags: 0`. Otherwise the column would
-  measure a default preset rather than the engine. Engines with no such mode
-  (`marked`, `md4x`, `@tanstack/markdown`, `@mizchi/markdown`) are scored as
-  they ship, which each entry notes.
+  through, `md4w` runs with `parseFlags: 0`, and the `@mizchi/markdown` JS,
+  Wasm, and native rows disable their default autolink and tagfilter
+  extensions. Otherwise the column would measure a default preset rather than
+  the engine. Engines with no such mode (`marked`, `md4x`,
+  `@tanstack/markdown`) are scored as they ship, which each entry notes.
 - **Comparison.** Both sides pass through `normalize_html`, the normalizer the
   in-repo conformance suite uses, reached through the native binary's
   `--normalize` filter so JS and native engines are judged identically. A
@@ -50,7 +51,8 @@ Two decisions make the comparison fair, and both are load-bearing:
   it is not tuned to one engine.
 
 The sweep needs `cargo` because the normalizer lives in the native binary; `bun`
-is optional and adds the `Bun.markdown.html` row.
+is optional and adds the `Bun.markdown.html` row, while `git` and `moon` add the
+`@mizchi/markdown (native)` row.
 
 Regenerate with:
 
@@ -92,6 +94,11 @@ pulldown-cmark's `push_html` stands in for the render side of that stack.
 The runner mirrors the JS harness protocol byte-for-byte (same sample
 document, sizes, warmup, iteration counts, and `--runs` median selection),
 which its unit tests pin against `parse-benchmark-bun.mjs`.
+
+The `@mizchi/markdown (native)` row is built separately from the installed
+package version's upstream gitHead with `moon build --target native`. It runs
+the same in-process parse and parse+render workloads as the JS package rows,
+skipping itself when `git` or `moon` is unavailable.
 
 ## OSS Markdown corpus (real-world inputs)
 

--- a/benchmarks/bundle-size/parse-benchmark.mjs
+++ b/benchmarks/bundle-size/parse-benchmark.mjs
@@ -10,6 +10,8 @@ import { performance } from "node:perf_hooks";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { loadMizchiMarkdownNativeBenchmarks } from "../mizchi-markdown-native.mjs";
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BUN_BENCHMARK_SCRIPT = join(__dirname, "parse-benchmark-bun.mjs");
 // Resolved relative to this script (not process.cwd()) so the CI flow that
@@ -75,15 +77,19 @@ Here's a [link](https://example.com) and an image: ![alt](image.png)
 Final paragraph with \`inline code\` and more text.
 `;
 
-// Repeat the sample to create larger documents
-const sizes = {
-  small: sampleMarkdown,
-  medium: Array(10).fill(sampleMarkdown).join("\n\n"),
-  large: Array(100).fill(sampleMarkdown).join("\n\n"),
+const SIZE_SPECS = [
+  { name: "small", repeats: 1, iterations: 100 },
+  { name: "medium", repeats: 10, iterations: 50 },
+  { name: "large", repeats: 100, iterations: 20 },
   // ~1 MB document: stresses parsers at a scale typical of a large
   // single-file handbook chapter or a concatenated docs bundle.
-  huge: Array(2150).fill(sampleMarkdown).join("\n\n"),
-};
+  { name: "huge", repeats: 2150, iterations: 5 },
+];
+
+// Repeat the sample to create larger documents.
+const sizes = Object.fromEntries(
+  SIZE_SPECS.map(({ name, repeats }) => [name, Array(repeats).fill(sampleMarkdown).join("\n\n")]),
+);
 
 /**
  * Benchmark a sync function
@@ -502,15 +508,23 @@ async function runBenchmarks() {
     console.log("@ox-content/wasm pkg not built (vp run build:wasm), skipping\n");
   }
 
-  // @mizchi/markdown (markdown.mbt) is a MoonBit-authored Markdown compiler
-  // shipped as a pure-JS build. Loaded defensively like satteri so an older
-  // checkout without the dependency skips it rather than crashing.
-  let mizchi = null;
+  // @mizchi/markdown (markdown.mbt) ships separate JS, Wasm, and native
+  // runtimes. Load each defensively so copied base benchmarks still run if a
+  // checkout predates one of the package exports or the native toolchain.
+  let mizchiJs = null;
   try {
-    mizchi = await import("@mizchi/markdown");
-    console.log("Using @mizchi/markdown\n");
+    mizchiJs = await import("@mizchi/markdown");
+    console.log("Using @mizchi/markdown (js)\n");
   } catch {
-    console.log("@mizchi/markdown not available, skipping mizchi comparisons\n");
+    console.log("@mizchi/markdown not available, skipping mizchi JS comparisons\n");
+  }
+
+  let mizchiWasm = null;
+  try {
+    mizchiWasm = await import("@mizchi/markdown/wasm");
+    console.log("Using @mizchi/markdown (wasm)\n");
+  } catch {
+    console.log("@mizchi/markdown/wasm not available, skipping mizchi Wasm comparisons\n");
   }
 
   // TanStack Markdown exposes separate parser and HTML renderer entry points.
@@ -576,6 +590,17 @@ async function runBenchmarks() {
     console.log("native competitors not available, skipping\n");
   }
 
+  const mizchiNative = loadMizchiMarkdownNativeBenchmarks({
+    sampleMarkdown,
+    sizeSpecs: SIZE_SPECS,
+    runs: options.runs,
+  });
+  if (mizchiNative) {
+    console.log("Using @mizchi/markdown (native)\n");
+  } else {
+    console.log("@mizchi/markdown native benchmark not available, skipping\n");
+  }
+
   const md = new MarkdownIt();
   const mdTs = MarkdownItTs ? MarkdownItTs() : null;
   const remarkParseProcessor = unified().use(remarkParse);
@@ -613,10 +638,17 @@ async function runBenchmarks() {
     });
   }
 
-  if (mizchi) {
+  if (mizchiJs) {
     parsers.push({
-      name: "@mizchi/markdown",
-      fn: (input) => mizchi.parse(input),
+      name: "@mizchi/markdown (js)",
+      fn: (input) => mizchiJs.parse(input),
+    });
+  }
+
+  if (mizchiWasm) {
+    parsers.push({
+      name: "@mizchi/markdown (wasm)",
+      fn: (input) => mizchiWasm.parse(input),
     });
   }
 
@@ -674,10 +706,17 @@ async function runBenchmarks() {
     });
   }
 
-  if (mizchi) {
+  if (mizchiJs) {
     renderers.push({
-      name: "@mizchi/markdown",
-      fn: (input) => mizchi.toHtml(input),
+      name: "@mizchi/markdown (js)",
+      fn: (input) => mizchiJs.toHtml(input),
+    });
+  }
+
+  if (mizchiWasm) {
+    renderers.push({
+      name: "@mizchi/markdown (wasm)",
+      fn: (input) => mizchiWasm.toHtml(input),
     });
   }
 
@@ -712,12 +751,11 @@ async function runBenchmarks() {
     });
   }
 
-  for (const [sizeName, content] of Object.entries(sizes)) {
+  for (const { name: sizeName, iterations } of SIZE_SPECS) {
+    const content = sizes[sizeName];
     const sizeKB = (content.length / 1024).toFixed(1);
     console.log(`\n## ${sizeName.toUpperCase()} (${sizeKB} KB)`);
 
-    const iterations =
-      sizeName === "huge" ? 5 : sizeName === "large" ? 20 : sizeName === "medium" ? 50 : 100;
     const suites = {};
 
     // Parse only benchmark
@@ -733,6 +771,10 @@ async function runBenchmarks() {
     const nativeParseRows = nativeCompetitors?.parse?.[sizeName];
     if (Array.isArray(nativeParseRows)) {
       parseResults.push(...nativeParseRows);
+    }
+    const mizchiNativeParseRows = mizchiNative?.parse?.[sizeName];
+    if (Array.isArray(mizchiNativeParseRows)) {
+      parseResults.push(...mizchiNativeParseRows);
     }
     parseResults.sort((a, b) => (b.opsPerSec || 0) - (a.opsPerSec || 0));
     suites.parseOnly = parseResults;
@@ -754,6 +796,10 @@ async function runBenchmarks() {
     const nativeRenderRows = nativeCompetitors?.render?.[sizeName];
     if (Array.isArray(nativeRenderRows)) {
       renderResults.push(...nativeRenderRows);
+    }
+    const mizchiNativeRenderRows = mizchiNative?.render?.[sizeName];
+    if (Array.isArray(mizchiNativeRenderRows)) {
+      renderResults.push(...mizchiNativeRenderRows);
     }
     renderResults.sort((a, b) => (b.opsPerSec || 0) - (a.opsPerSec || 0));
     suites.parseAndRender = renderResults;

--- a/benchmarks/commonmark-conformance/engines.mjs
+++ b/benchmarks/commonmark-conformance/engines.mjs
@@ -24,6 +24,8 @@ async function optional(name, load) {
   }
 }
 
+const MIZCHI_COMMONMARK_OPTIONS = { autolink: false, tagfilter: false };
+
 /** @returns {Promise<Array<[string, (markdown: string) => string]>>} */
 export async function collectJsRenderers() {
   const renderers = [];
@@ -127,9 +129,24 @@ export async function collectJsRenderers() {
   const satteri = await optional("satteri", () => import("satteri"));
   if (satteri) renderers.push(["satteri", (input) => satteri.markdownToHtml(input).html]);
 
-  // @mizchi/markdown exposes no CommonMark mode; scored as it ships.
+  // @mizchi/markdown exposes CommonMark switches to disable its default
+  // autolink and tagfilter extensions. Score both package runtimes with the
+  // same strict options.
   const mizchi = await optional("@mizchi/markdown", () => import("@mizchi/markdown"));
-  if (mizchi) renderers.push(["@mizchi/markdown", (input) => mizchi.toHtml(input)]);
+  if (mizchi) {
+    renderers.push([
+      "@mizchi/markdown (js)",
+      (input) => mizchi.toHtml(input, MIZCHI_COMMONMARK_OPTIONS),
+    ]);
+  }
+
+  const mizchiWasm = await optional("@mizchi/markdown/wasm", () => import("@mizchi/markdown/wasm"));
+  if (mizchiWasm) {
+    renderers.push([
+      "@mizchi/markdown (wasm)",
+      (input) => mizchiWasm.toHtml(input, MIZCHI_COMMONMARK_OPTIONS),
+    ]);
+  }
 
   // @tanstack/markdown exposes no CommonMark mode; scored as it ships.
   const tanstack = await optional("@tanstack/markdown", async () => {

--- a/benchmarks/commonmark-conformance/results.json
+++ b/benchmarks/commonmark-conformance/results.json
@@ -6,6 +6,18 @@
   },
   "comparison": "normalized",
   "engines": {
+    "@mizchi/markdown (js)": {
+      "passed": 652,
+      "total": 652
+    },
+    "@mizchi/markdown (native)": {
+      "passed": 652,
+      "total": 652
+    },
+    "@mizchi/markdown (wasm)": {
+      "passed": 652,
+      "total": 652
+    },
     "@ox-content/wasm": {
       "passed": 652,
       "total": 652
@@ -56,10 +68,6 @@
     },
     "satteri": {
       "passed": 645,
-      "total": 652
-    },
-    "@mizchi/markdown": {
-      "passed": 641,
       "total": 652
     },
     "marked": {

--- a/benchmarks/commonmark-conformance/run.mjs
+++ b/benchmarks/commonmark-conformance/run.mjs
@@ -27,6 +27,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { loadMizchiMarkdownNativeConformanceRenderings } from "../mizchi-markdown-native.mjs";
 import { collectJsRenderers } from "./engines.mjs";
 import { parseSpec } from "./spec-txt.mjs";
 
@@ -219,6 +220,11 @@ async function main() {
     name,
     renderAll(render, examples),
   ]);
+
+  const mizchiNative = loadMizchiMarkdownNativeConformanceRenderings(examples);
+  if (mizchiNative) {
+    rendered.push([mizchiNative.name, mizchiNative.rendered]);
+  }
 
   const bun = loadBunRenderings();
   if (bun) {

--- a/benchmarks/mizchi-markdown-native-template.mjs
+++ b/benchmarks/mizchi-markdown-native-template.mjs
@@ -1,0 +1,158 @@
+export function renderNativeCommandSource({ nativeLabel, sampleMarkdown, sizeSpecs }) {
+  const runSizeCalls = sizeSpecs
+    .map(
+      ({ name, repeats, iterations }) =>
+        `  run_size(${moonbitString(name)}, ${repeats}, ${iterations}, runs)`,
+    )
+    .join("\n");
+
+  return `let sample_markdown : String = ${moonbitString(sampleMarkdown)}
+
+priv enum Mode {
+  Parse
+  Render
+}
+
+priv struct Measurement {
+  ops_per_sec : Double
+  avg_ms : Double
+  throughput_mbs : Double
+}
+
+fn sample_document(repeats : Int) -> String {
+  let builder = StringBuilder::new()
+  for index in 0..<repeats {
+    if index > 0 {
+      builder.write_string("\\n\\n")
+    }
+    builder.write_string(sample_markdown)
+  }
+  builder.to_string()
+}
+
+fn parse_runs(args : Array[String]) -> Result[Int, String] {
+  if args.length() != 3 || args[1] != "--runs" {
+    return Err("usage: ox-content-competitor --runs <n>")
+  }
+
+  let runs = @string.parse_int(args[2]) catch {
+    _ => return Err("runs must be a positive integer")
+  }
+  guard runs > 0 else {
+    return Err("runs must be a positive integer")
+  }
+  Ok(runs)
+}
+
+fn run_workload(mode : Mode, input : String) -> Int {
+  match mode {
+    Parse => @markdown.parse(input).document.children.length()
+    Render => @markdown.md_to_html(input).length()
+  }
+}
+
+fn measure_once(mode : Mode, input : String, iterations : Int) -> Measurement {
+  let mut checksum = 0
+  for _ in 0..<5 {
+    checksum += run_workload(mode, input)
+  }
+
+  let start = @bench.monotonic_clock_start()
+  for _ in 0..<iterations {
+    checksum += run_workload(mode, input)
+  }
+  let elapsed_us = @bench.monotonic_clock_end(start)
+  let avg_ms = elapsed_us / iterations.to_double() / 1000.0
+  let ops_per_sec = 1000.0 / avg_ms
+  let throughput_mbs = input.length().to_double() / 1024.0 / 1024.0 * ops_per_sec
+
+  if checksum == -1 {
+    abort("unreachable")
+  }
+
+  {
+    ops_per_sec,
+    avg_ms,
+    throughput_mbs,
+  }
+}
+
+fn emit_samples(
+  suite : String,
+  size_name : String,
+  input : String,
+  iterations : Int,
+  mode : Mode,
+  runs : Int
+) -> Unit {
+  for _ in 0..<runs {
+    let sample = measure_once(mode, input, iterations)
+    println(
+      suite +
+      "\\t" +
+      ${moonbitString(nativeLabel)} +
+      "\\t" +
+      size_name +
+      "\\t" +
+      sample.ops_per_sec.to_string() +
+      "\\t" +
+      sample.avg_ms.to_string() +
+      "\\t" +
+      sample.throughput_mbs.to_string(),
+    )
+  }
+}
+
+fn run_size(size_name : String, repeats : Int, iterations : Int, runs : Int) -> Unit {
+  let input = sample_document(repeats)
+  emit_samples("parse", size_name, input, iterations, Mode::Parse, runs)
+  emit_samples("render", size_name, input, iterations, Mode::Render, runs)
+}
+
+fn run_benchmarks(args : Array[String]) -> Unit {
+  let runs = match parse_runs(args) {
+    Ok(value) => value
+    Err(message) => abort(message)
+  }
+${runSizeCalls}
+}
+
+async fn write_error(message : String, exit_code : Int) -> Unit {
+  @stdio.stderr.write(message + "\\n") catch {
+    _ => ()
+  }
+  @sys.exit(exit_code)
+}
+
+async fn render_stdin() -> Unit {
+  let source = @stdio.stdin.read_all().text() catch {
+    error => {
+      write_error("failed to read stdin: \\{error}", 2)
+      return
+    }
+  }
+
+  @stdio.stdout.write(@markdown.md_to_html(source, autolink=false, tagfilter=false)) catch {
+    error => write_error("failed to write stdout: \\{error}", 2)
+  }
+}
+
+async fn main {
+  let args = @env.args()
+  if args.length() == 2 && args[1] == "--render-stdin" {
+    render_stdin()
+    return
+  }
+  run_benchmarks(args)
+}
+`;
+}
+
+function moonbitString(value) {
+  return `"${value
+    .replaceAll("\\", "\\\\")
+    .replaceAll('"', '\\"')
+    .replaceAll("\r", "\\r")
+    .replaceAll("\n", "\\n")
+    .replaceAll("\t", "\\t")}"`;
+}

--- a/benchmarks/mizchi-markdown-native.mjs
+++ b/benchmarks/mizchi-markdown-native.mjs
@@ -1,0 +1,312 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { renderNativeCommandSource } from "./mizchi-markdown-native-template.mjs";
+
+const PACKAGE_NAME = "@mizchi/markdown";
+const REPOSITORY_URL = "https://github.com/mizchi/markdown.mbt.git";
+const NATIVE_LABEL = "@mizchi/markdown (native)";
+const COMMAND_PATH = "src/cmd/ox-content-competitor";
+const COMMAND_DIR = join("src", "cmd", "ox-content-competitor");
+const BINARY_PATH = join(
+  "_build",
+  "native",
+  "release",
+  "build",
+  "cmd",
+  "ox-content-competitor",
+  "ox-content-competitor.exe",
+);
+
+const KNOWN_GIT_HEADS = new Map([
+  ["0.8.2", "159b5a38b500f066d78de6a5be61d32379abf0f9"],
+  ["0.8.3", "b574e7f07c0d47e1c0aeff7dd344891511cfd631"],
+]);
+
+export function loadMizchiMarkdownNativeBenchmarks({ sampleMarkdown, sizeSpecs, runs }) {
+  const command = prepareNativeCommand({ sampleMarkdown, sizeSpecs });
+  if (!command) return null;
+
+  const result = spawnSync(command.binaryPath, ["--runs", String(runs)], {
+    cwd: command.checkoutDir,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: 10 * 60 * 1000,
+  });
+
+  if (result.error || result.status !== 0) {
+    warnNativeUnavailable("run native benchmark", result);
+    return null;
+  }
+
+  return parseBenchmarkOutput(result.stdout);
+}
+
+export function loadMizchiMarkdownNativeConformanceRenderings(examples) {
+  const command = prepareNativeCommand({ sampleMarkdown: "", sizeSpecs: [] });
+  if (!command) return null;
+
+  const rendered = [];
+  let failureWarned = false;
+  for (const [index, example] of examples.entries()) {
+    const result = spawnSync(command.binaryPath, ["--render-stdin"], {
+      cwd: command.checkoutDir,
+      input: example.markdown,
+      encoding: "utf8",
+      maxBuffer: 4 * 1024 * 1024,
+      timeout: 30 * 1000,
+    });
+
+    if (result.error || result.status !== 0) {
+      if (!failureWarned) {
+        warnNativeUnavailable(`render CommonMark example ${index + 1}`, result);
+        failureWarned = true;
+      }
+      rendered.push("");
+      continue;
+    }
+
+    rendered.push(result.stdout);
+  }
+
+  return { name: NATIVE_LABEL, rendered };
+}
+
+function prepareNativeCommand({ sampleMarkdown, sizeSpecs }) {
+  const metadata = loadInstalledPackageMetadata();
+  if (!metadata) {
+    console.warn(`Skipping ${NATIVE_LABEL}: ${PACKAGE_NAME} is not installed.`);
+    return null;
+  }
+
+  const gitHead = resolvePackageGitHead(metadata);
+  if (!gitHead) {
+    console.warn(
+      `Skipping ${NATIVE_LABEL}: could not resolve ${PACKAGE_NAME}@${metadata.version} git head.`,
+    );
+    return null;
+  }
+
+  if (!hasCommand("git")) {
+    console.warn(`Skipping ${NATIVE_LABEL}: git is not available.`);
+    return null;
+  }
+
+  if (!hasCommand("moon")) {
+    console.warn(`Skipping ${NATIVE_LABEL}: moon is not available.`);
+    return null;
+  }
+
+  const checkoutDir = ensureCheckout(gitHead);
+  if (!checkoutDir) return null;
+
+  writeNativeCommand(checkoutDir, sampleMarkdown, sizeSpecs);
+
+  const build = spawnSync("moon", ["build", "--target", "native", "--release", COMMAND_PATH], {
+    cwd: checkoutDir,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: 5 * 60 * 1000,
+  });
+
+  if (build.error || build.status !== 0) {
+    warnNativeUnavailable("build native benchmark command", build);
+    return null;
+  }
+
+  return {
+    checkoutDir,
+    binaryPath: join(checkoutDir, BINARY_PATH),
+  };
+}
+
+function loadInstalledPackageMetadata() {
+  const packageJsonPath = resolveInstalledPackageJson();
+  if (!packageJsonPath) return null;
+  return JSON.parse(readFileSync(packageJsonPath, "utf8"));
+}
+
+function resolveInstalledPackageJson() {
+  const fromDirs = [
+    join(process.cwd(), "benchmarks", "bundle-size"),
+    join(process.cwd(), "benchmarks", "commonmark-conformance"),
+    process.cwd(),
+  ];
+
+  for (const fromDir of fromDirs) {
+    const packageJsonPath = findNodeModulesPackageJson(fromDir);
+    if (packageJsonPath) return packageJsonPath;
+  }
+
+  return null;
+}
+
+function findNodeModulesPackageJson(startDir) {
+  let currentDir = startDir;
+  while (true) {
+    const packageJsonPath = join(currentDir, "node_modules", "@mizchi", "markdown", "package.json");
+    if (existsSync(packageJsonPath)) return packageJsonPath;
+
+    const parentDir = dirname(currentDir);
+    if (parentDir === currentDir) return null;
+    currentDir = parentDir;
+  }
+}
+
+function resolvePackageGitHead(metadata) {
+  if (KNOWN_GIT_HEADS.has(metadata.version)) {
+    return KNOWN_GIT_HEADS.get(metadata.version);
+  }
+
+  const result = spawnSync(
+    "npm",
+    ["view", `${PACKAGE_NAME}@${metadata.version}`, "gitHead", "--json"],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      timeout: 30 * 1000,
+    },
+  );
+
+  if (result.error || result.status !== 0) return null;
+
+  try {
+    const gitHead = JSON.parse(result.stdout);
+    return typeof gitHead === "string" && gitHead.length > 0 ? gitHead : null;
+  } catch {
+    return result.stdout.trim() || null;
+  }
+}
+
+function hasCommand(command) {
+  const result = spawnSync(command, ["--version"], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+    timeout: 30 * 1000,
+  });
+  return !result.error && result.status === 0;
+}
+
+function ensureCheckout(gitHead) {
+  const cacheRoot =
+    process.env.OX_CONTENT_MIZCHI_MARKDOWN_NATIVE_CACHE_DIR ??
+    join(tmpdir(), "ox-content-mizchi-markdown-native");
+  const checkoutDir = join(cacheRoot, gitHead);
+
+  if (existsSync(checkoutDir) && !existsSync(join(checkoutDir, ".git"))) {
+    rmSync(checkoutDir, { force: true, recursive: true });
+  }
+
+  mkdirSync(cacheRoot, { recursive: true });
+
+  if (!existsSync(checkoutDir)) {
+    const clone = spawnSync("git", ["clone", "--filter=blob:none", REPOSITORY_URL, checkoutDir], {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      timeout: 5 * 60 * 1000,
+    });
+
+    if (clone.error || clone.status !== 0) {
+      warnNativeUnavailable("clone native source", clone);
+      return null;
+    }
+  }
+
+  const checkout = spawnSync("git", ["checkout", "--detach", gitHead], {
+    cwd: checkoutDir,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: 2 * 60 * 1000,
+  });
+
+  if (checkout.error || checkout.status !== 0) {
+    warnNativeUnavailable("checkout native source", checkout);
+    return null;
+  }
+
+  return checkoutDir;
+}
+
+function writeNativeCommand(checkoutDir, sampleMarkdown, sizeSpecs) {
+  const outputDir = join(checkoutDir, COMMAND_DIR);
+  mkdirSync(outputDir, { recursive: true });
+  writeFileSync(
+    join(outputDir, "moon.pkg"),
+    `supported_targets = "native"
+
+import {
+  "mizchi/markdown",
+  "moonbitlang/async",
+  "moonbitlang/async/io",
+  "moonbitlang/async/stdio",
+  "moonbitlang/core/bench",
+  "moonbitlang/core/env",
+  "moonbitlang/core/string",
+  "moonbitlang/x/sys",
+}
+
+pkgtype(kind: "executable")
+`,
+  );
+  writeFileSync(
+    join(outputDir, "main.mbt"),
+    renderNativeCommandSource({
+      nativeLabel: NATIVE_LABEL,
+      sampleMarkdown,
+      sizeSpecs,
+    }),
+  );
+}
+
+function parseBenchmarkOutput(output) {
+  const grouped = {
+    parse: Object.create(null),
+    render: Object.create(null),
+  };
+
+  for (const line of output.trim().split(/\r?\n/)) {
+    if (!line) continue;
+    const [suite, name, size, opsPerSec, avgMs, throughputMBs] = line.split("\t");
+    if (!grouped[suite] || !name || !size) continue;
+    grouped[suite][size] ??= Object.create(null);
+    grouped[suite][size][name] ??= [];
+    grouped[suite][size][name].push({
+      opsPerSec: Number.parseFloat(opsPerSec),
+      avgMs: Number.parseFloat(avgMs),
+      throughputMBs: Number.parseFloat(throughputMBs),
+    });
+  }
+
+  return {
+    parse: summarizeGroupedSamples(grouped.parse),
+    render: summarizeGroupedSamples(grouped.render),
+  };
+}
+
+function summarizeGroupedSamples(grouped) {
+  const bySize = Object.create(null);
+  for (const [size, rowsByName] of Object.entries(grouped)) {
+    bySize[size] = Object.entries(rowsByName).map(([name, samples]) => {
+      const sortedSamples = [...samples].sort((a, b) => a.opsPerSec - b.opsPerSec);
+      const median = sortedSamples[Math.floor(sortedSamples.length / 2)];
+      return {
+        name,
+        opsPerSec: median.opsPerSec,
+        avgMs: median.avgMs,
+        throughputMBs: median.throughputMBs,
+        samples,
+      };
+    });
+  }
+  return bySize;
+}
+
+function warnNativeUnavailable(action, result) {
+  const error = result?.error ? `${result.error.name}: ${result.error.message}` : null;
+  const stderr = typeof result?.stderr === "string" ? result.stderr.trim() : "";
+  const stdout = typeof result?.stdout === "string" ? result.stdout.trim() : "";
+  const details = [error, stderr, stdout].filter(Boolean).join("\n");
+  console.warn(`Skipping ${NATIVE_LABEL}: failed to ${action}.${details ? `\n${details}` : ""}`);
+}

--- a/benchmarks/mizchi-markdown-native.mjs
+++ b/benchmarks/mizchi-markdown-native.mjs
@@ -104,6 +104,18 @@ function prepareNativeCommand({ sampleMarkdown, sizeSpecs }) {
 
   writeNativeCommand(checkoutDir, sampleMarkdown, sizeSpecs);
 
+  const update = spawnSync("moon", ["update"], {
+    cwd: checkoutDir,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: 5 * 60 * 1000,
+  });
+
+  if (update.error || update.status !== 0) {
+    warnNativeUnavailable("resolve native source dependencies", update);
+    return null;
+  }
+
   const build = spawnSync("moon", ["build", "--target", "native", "--release", COMMAND_PATH], {
     cwd: checkoutDir,
     encoding: "utf8",

--- a/docs/content/performance.md
+++ b/docs/content/performance.md
@@ -155,11 +155,10 @@ the engine — is what separates the top two rows there. The JavaScript-facing
 `@ox-content/napi` row is 4.0–5.1x faster than the two TypeScript renderers on
 parse-only and 7.1–12.1x faster on parse+render. At ~1 MB those N-API leads grow
 to 7.7–8.7x and 11.4–12.0x respectively, while the native pipeline sustains
-267–370 MB/s. At that size the incremental CST parser (`@mizchi/markdown`, tuned
-for real-time editing rather than bulk parsing) falls to ~2 ops/sec on parse-only
-while recovering to ~23 ops/sec on parse+render, whereas the `unified`/`remark`
-pipeline stays at ~1 op/sec in both tables and `micromark` measures ~1 op/sec on
-parse+render.
+267–370 MB/s. The `@mizchi/markdown` rows are split by JS, Wasm, and native
+runtime so package-boundary and native-build costs stay visible, while the
+`unified`/`remark` pipeline stays at ~1 op/sec in both ~1 MB tables and
+`micromark` measures ~1 op/sec on parse+render.
 
 The runtime sweep covers more than the tables above. The harness also runs small
 and medium Markdown inputs, an async parse+render target for the N-API package
@@ -210,8 +209,10 @@ Two choices make that comparison fair, and both matter when reading the numbers:
   `commonmark` presets, `micromark` and `remark-html` are told to pass raw HTML
   through instead of escaping it, and `md4w` runs with `parseFlags: 0`. Judging
   an engine by a default preset that enables GFM extensions would measure the
-  preset rather than the engine. Engines that expose no such mode — `marked`,
-  `md4x`, `@tanstack/markdown`, `@mizchi/markdown` — are scored as they ship.
+  preset rather than the engine. The `@mizchi/markdown` JS, Wasm, and native
+  rows disable their default autolink and tagfilter extensions for this column.
+  Engines that expose no such mode — `marked`, `md4x`, `@tanstack/markdown` —
+  are scored as they ship.
 - **Both sides pass through the conformance suite's HTML normalizer**, so
   differences that do not change how a document renders (entity spelling,
   attribute order, `<br />` vs `<br>`, whitespace between block tags) are not


### PR DESCRIPTION
## Summary
- split @mizchi/markdown benchmark rows into JS, Wasm, and native runtime variants
- build the native MoonBit command from the installed package gitHead
- add MoonBit setup to benchmark workflows and refresh CommonMark coverage

## Verification
- vp fmt --check
- git diff --check origin/main
- node scripts/check-file-lines.ts --base origin/main
- node benchmarks/commonmark-conformance/run.mjs --json benchmarks/commonmark-conformance/results.json
- node benchmarks/bundle-size/parse-benchmark.mjs --runs 1 --json /tmp/ox-content-parse-mizchi-smoke.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790700269&installation_model_id=422833&pr_number=1226&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1226&signature=729c10b7c51d7d611ef8daf2c23d1c499b4b65ff5750380ad21ccd927471c20c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JavaScript, Wasm, and native runtime comparisons for `@mizchi/markdown` in performance benchmarks.
  * Added native runtime coverage to CommonMark conformance testing, with all 652 examples passing.
  * Added benchmark results for additional `md4x` variants.

* **Documentation**
  * Updated benchmark, README, and performance documentation to explain runtime-specific results and strict CommonMark settings.
  * Documented native benchmark requirements and graceful handling when optional tooling is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->