### PR TITLE
perf(parser): stop a run of unclosed brackets costing quadratic time

### DIFF
--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -225,6 +225,17 @@ pub struct Parser<'a> {
     /// long as the cache exists.
     link_probe_cache: std::cell::RefCell<rustc_hash::FxHashMap<(usize, usize), bool>>,
 
+    /// Memoized position of the final `]` in a content slice, keyed the same
+    /// way as `link_probe_cache`.
+    ///
+    /// A `[` can only open something when a `]` follows it, and
+    /// `scan_balanced` answers that by walking to the end of the content.
+    /// A run of brackets with no closer therefore paid one full walk per
+    /// bracket: 64 KiB of `[ ` took 1.0 s, growing x16 for every x4 of
+    /// input. The position of the last `]` settles it for every bracket in
+    /// the slice at once, so the run costs one scan in total.
+    last_close_bracket: std::cell::RefCell<rustc_hash::FxHashMap<(usize, usize), Option<usize>>>,
+
     /// The last `[scanned_from, blank_line)` window found while bounding a
     /// link reference definition, so a run of them costs one scan in total.
     ///
@@ -258,6 +269,7 @@ impl<'a> Parser<'a> {
             footnote_labels: None,
             lazy_lines: None,
             link_probe_cache: std::cell::RefCell::default(),
+            last_close_bracket: std::cell::RefCell::default(),
             definition_region: None,
         };
         // A single fused pre-pass collects both the reference definitions
@@ -296,6 +308,7 @@ impl<'a> Parser<'a> {
             // line, and every block quote and list item builds one of these.
             lazy_lines: (!lazy_lines.is_empty()).then(|| std::rc::Rc::new(lazy_lines)),
             link_probe_cache: std::cell::RefCell::default(),
+            last_close_bracket: std::cell::RefCell::default(),
             definition_region: None,
         }
     }

--- a/crates/ox_content_parser/src/parser/inline_helpers.rs
+++ b/crates/ox_content_parser/src/parser/inline_helpers.rs
@@ -24,6 +24,16 @@ impl<'a> Parser<'a> {
         }
 
         let image_start = *pos;
+
+        // Nothing can close this bracket, so skip the balanced scan that
+        // would walk to the end of the content to reach the same verdict.
+        // Same fallback as below, reached without the walk.
+        if !self.has_close_bracket_from(content, *pos + 2) {
+            Self::push_text(children, "![", offset + image_start, offset + image_start + 2);
+            *pos = image_start + 2;
+            return Ok(());
+        }
+
         *pos += 2;
         let alt_start = *pos;
         *pos = Self::scan_balanced(content, *pos, b'[', b']');
@@ -47,7 +57,9 @@ impl<'a> Parser<'a> {
             }
 
             let mut well_formed_reference = false;
-            if bytes.get(close + 1) == Some(&b'[') {
+            if bytes.get(close + 1) == Some(&b'[')
+                && self.has_close_bracket_from(content, close + 2)
+            {
                 let label_start = close + 2;
                 let label_end = Self::scan_balanced(content, label_start, b'[', b']');
                 if label_end < content.len() && bytes[label_end] == b']' {
@@ -145,6 +157,27 @@ impl<'a> Parser<'a> {
     /// backslash escapes, code spans (an unmatched opener stays literal),
     /// autolinks, and inline raw HTML. This is what makes
     /// `[not a `link](/foo`)` a code span instead of a link.
+    /// Reports whether a `]` exists at or after `from` in `content`.
+    ///
+    /// `scan_balanced` finds that out by walking to the end of the content,
+    /// which is one full walk per bracket and quadratic over a run of them.
+    /// The answer is the same for every bracket in a slice, so the position
+    /// of the final `]` is computed once and reused.
+    pub(super) fn has_close_bracket_from(&self, content: &'a str, from: usize) -> bool {
+        let key = (content.as_ptr() as usize, content.len());
+
+        let cached = self.last_close_bracket.borrow().get(&key).copied();
+        let last = if let Some(last) = cached {
+            last
+        } else {
+            let last = memchr::memrchr(b']', content.as_bytes());
+            self.last_close_bracket.borrow_mut().insert(key, last);
+            last
+        };
+
+        last.is_some_and(|last| last >= from)
+    }
+
     pub(super) fn scan_balanced(content: &str, mut cursor: usize, open: u8, close: u8) -> usize {
         let bytes = content.as_bytes();
         let mut depth = 1;

--- a/crates/ox_content_parser/src/parser/inline_link.rs
+++ b/crates/ox_content_parser/src/parser/inline_link.rs
@@ -34,6 +34,16 @@ impl<'a> Parser<'a> {
             return Ok(());
         }
 
+        // Every accepting branch below needs a `]`, and `scan_balanced`
+        // only reports that there is none after walking to the end of the
+        // content — once per bracket, which is quadratic over a run of
+        // them. Settle it for the whole slice first.
+        if !self.has_close_bracket_from(content, *pos + 1) {
+            Self::push_text(children, "[", offset + link_start, offset + link_start + 1);
+            *pos = link_start + 1;
+            return Ok(());
+        }
+
         *pos += 1;
         let text_start = *pos;
         *pos = Self::scan_balanced(content, *pos, b'[', b']');
@@ -75,7 +85,10 @@ impl<'a> Parser<'a> {
 
             // Full [text][label] and collapsed [text][] reference forms.
             let mut well_formed_reference = false;
-            if !inner_has_link && bytes.get(close + 1) == Some(&b'[') {
+            if !inner_has_link
+                && bytes.get(close + 1) == Some(&b'[')
+                && self.has_close_bracket_from(content, close + 2)
+            {
                 let label_start = close + 2;
                 let label_end = Self::scan_balanced(content, label_start, b'[', b']');
                 if label_end < content.len() && bytes[label_end] == b']' {

--- a/crates/ox_content_parser/tests/unclosed_brackets.rs
+++ b/crates/ox_content_parser/tests/unclosed_brackets.rs
@@ -1,0 +1,152 @@
+//! A `[` can only open a link when a `]` follows it, but `scan_balanced`
+//! answered that by walking to the end of the content — once for every
+//! bracket. A run of brackets with no closer therefore cost O(n²): 64 KiB
+//! of `[ ` took 1.0 s and grew x16 for every x4 of input, and `[[ ` took
+//! 2.0 s. That is ordinary text — a shell snippet outside a fence, a log
+//! paste, BibTeX, a glob pattern — not a crafted document.
+//!
+//! These tests pin the cost back to linear and pin the parse that the
+//! early exit now short-circuits, down to the text nodes and their spans:
+//! the bracket has to stay literal in exactly the shape the slow path
+//! produced.
+
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use ox_content_allocator::Allocator;
+use ox_content_parser::{Parser, ParserOptions};
+use ox_content_renderer::HtmlRenderer;
+
+#[path = "support/pretty.rs"]
+mod pretty;
+
+/// Generous enough that a slow shared runner never trips it, and far below
+/// what the quadratic path needed for these sizes.
+const BUDGET: Duration = Duration::from_secs(30);
+
+fn render(source: &str) -> String {
+    let allocator = Allocator::new();
+    let document = Parser::with_options(&allocator, source, ParserOptions::gfm())
+        .parse()
+        .expect("source should parse");
+    HtmlRenderer::new().render(&document).trim().to_string()
+}
+
+fn tree(source: &str) -> String {
+    let allocator = Allocator::new();
+    let document = Parser::with_options(&allocator, source, ParserOptions::gfm())
+        .parse()
+        .expect("source should parse");
+    let mut out = String::new();
+    pretty::format_document(&document, source, &mut out);
+    out
+}
+
+fn repeat_to(unit: &str, bytes: usize) -> String {
+    let mut out = String::with_capacity(bytes + unit.len());
+    while out.len() < bytes {
+        out.push_str(unit);
+    }
+    out
+}
+
+/// Parses on a worker thread so a regression fails the suite in bounded
+/// time instead of hanging it. Best of two, so one scheduling stall on a
+/// busy runner cannot fail the build.
+fn parse_within_budget(source: &str) -> Duration {
+    let mut best = BUDGET;
+    for _ in 0..2 {
+        let owned = source.to_string();
+        let (sender, receiver) = mpsc::channel();
+        thread::spawn(move || {
+            let started = Instant::now();
+            let allocator = Allocator::new();
+            let parsed =
+                Parser::with_options(&allocator, &owned, ParserOptions::gfm()).parse().is_ok();
+            let _ = sender.send((parsed, started.elapsed()));
+        });
+        let (parsed, elapsed) = receiver
+            .recv_timeout(BUDGET)
+            .expect("a run of unclosed brackets should parse in bounded time");
+        assert!(parsed, "a run of unclosed brackets should parse to a document");
+        best = best.min(elapsed);
+    }
+    best
+}
+
+#[test]
+fn a_run_of_unclosed_brackets_costs_linear_time() {
+    // Each shape reaches the guard through a different branch: a bare
+    // opener, an image opener, a nested opener, a footnote-looking opener,
+    // and an opener with text after it.
+    for unit in ["[ ", "[", "![ ", "[[ ", "[^ ", "[a "] {
+        let small = parse_within_budget(&repeat_to(unit, 32 * 1024));
+        let large = parse_within_budget(&repeat_to(unit, 128 * 1024));
+
+        let ratio = large.as_secs_f64() / small.as_secs_f64().max(1e-9);
+        // 4x the input. Linear costs about 4x the time; quadratic costs
+        // 16x, which is what every one of these measured before the fix.
+        assert!(
+            ratio < 8.0,
+            "{unit:?}: 128 KiB took {large:?} against {small:?} for 32 KiB (x{ratio:.1}); \
+             linear is about x4, quadratic about x16"
+        );
+    }
+}
+
+#[test]
+fn an_unclosed_bracket_stays_literal() {
+    // The early exit replaces a scan that ended in the literal-bracket
+    // fallback, so every one of these has to render exactly as it did.
+    for (source, expected) in [
+        ("[", "<p>[</p>"),
+        ("a [ b", "<p>a [ b</p>"),
+        ("[ [ [", "<p>[ [ [</p>"),
+        ("![", "<p>![</p>"),
+        ("a ![ b", "<p>a ![ b</p>"),
+        ("[^x", "<p>[^x</p>"),
+        ("[a](b", "<p>[a](b</p>"),
+        ("[a][b", "<p>[a][b</p>"),
+        ("\\[ a", "<p>[ a</p>"),
+        ("prefix [ suffix ] tail", "<p>prefix [ suffix ] tail</p>"),
+    ] {
+        assert_eq!(render(source), expected, "for {source:?}");
+    }
+}
+
+#[test]
+fn a_bracket_that_does_close_still_links() {
+    // The guard must not swallow the cases that do have a closer, in any
+    // of the four accepting forms.
+    for (source, expected) in [
+        ("[a]", "<p>[a]</p>"),
+        ("[a](/u)", r#"<p><a href="/u">a</a></p>"#),
+        ("[a][b]\n\n[b]: /u", r#"<p><a href="/u">a</a></p>"#),
+        ("[a]\n\n[a]: /u", r#"<p><a href="/u">a</a></p>"#),
+        ("[a][]\n\n[a]: /u", r#"<p><a href="/u">a</a></p>"#),
+        ("![a](b.png)", r#"<p><img src="b.png" alt="a"></p>"#),
+        ("![a][b]\n\n[b]: /u.png", r#"<p><img src="/u.png" alt="a"></p>"#),
+        ("[`]`", "<p>[<code>]</code></p>"),
+    ] {
+        assert_eq!(render(source), expected, "for {source:?}");
+    }
+}
+
+#[test]
+fn the_literal_fallback_keeps_its_node_shape() {
+    // HTML alone would not catch a changed split: `![` has to stay one
+    // two-byte text node, not a `!` node followed by a `[` node, or spans
+    // reported to editors and diagnostics would shift.
+    assert_eq!(
+        tree("a ![ b"),
+        "Document [0..6]\n  Paragraph [0..6]\n    Text \"a \" [0..2]\n    \
+         Text \"![\" [2..4]\n    Text \" b\" [4..6]\n"
+    );
+    assert_eq!(
+        tree("[ [ ["),
+        "Document [0..5]\n  Paragraph [0..5]\n    Text \"[\" [0..1]\n    \
+         Text \" \" [1..2]\n    Text \"[\" [2..3]\n    Text \" \" [3..4]\n    \
+         Text \"[\" [4..5]\n"
+    );
+}


### PR DESCRIPTION
## Problem

A `[` can only open a link when a `]` follows it. `parse_link` and `parse_image` answered that question with `scan_balanced`, which **walks to the end of the content** before reporting that it found nothing:

```rust
*pos += 1;
let text_start = *pos;
*pos = Self::scan_balanced(content, *pos, b'[', b']');   // O(n), every time

if *pos < content.len() && bytes[*pos] == b']' { ... }
// falls through: the bracket is literal, *pos = link_start + 1
```

Every bracket in a run pays one full walk, so a run of `n` brackets costs **O(n²)**.

This is not a crafted document. A shell snippet outside a fence, a log paste, BibTeX, a glob pattern — any text with many unmatched `[` reaches it. **It reproduces with every transform feature turned off**, so it is the plain CommonMark path, not a feature pass.

| input | 8 KiB | 32 KiB | 64 KiB | growth |
|---|---|---|---|---|
| `[ ` | 0.0215s | 0.2527s | 0.9956s | x11.8 |
| `[` | 0.0206s | 0.3389s | 1.3328s | x16.4 |
| `[[ ` | 0.0235s | 0.3869s | 1.9736s | x16.5 |
| `![ ` | 0.0092s | 0.1472s | 0.6916s | x16.1 |

In a debug build, 128 KiB of `[ ` takes **22 seconds**.

## Fix

The position of the final `]` settles the question for every bracket in a slice at once. Find it once with `memrchr`, memoize it keyed by slice address and length — the same shape as the existing `link_probe_cache` and `definition_region` memos — and let a bracket past it take the literal fallback directly.

The guard sits at four call sites: the opener scan in `parse_link` and `parse_image`, and the `[text][label` label scan in both.

## Result

One 64 KiB line, release:

| input | before | after | |
|---|---|---|---|
| `[` | 1.3328s | 0.00071s | **1877x** |
| `[ x ` | 1.4970s | 0.00023s | **6509x** |
| `[[ ` | 1.9736s | 0.00053s | **3723x** |
| `[ ` | 0.9956s | 0.00044s | **2263x** |
| `![ ` | 0.6916s | 0.00053s | **1305x** |

Growth per 4x of input drops from **x16** to **x4**.

## Output is unchanged

- 30,000 fuzz-corpus documents (the corpus from #1221) plus 700 bracket-shape cases render **byte-identical HTML** through the full transform pipeline with every feature on, before and after.
- The CommonMark conformance suite and the whole parser and renderer suites pass unchanged.

## Tests

`crates/ox_content_parser/tests/unclosed_brackets.rs`:

- `a_run_of_unclosed_brackets_costs_linear_time` — six shapes, each reaching the guard through a different branch (bare opener, image opener, nested opener, footnote-looking opener, opener with text). 4x the input must not cost 8x the time; each runs on a worker thread under a 30s budget so a regression fails in bounded time instead of hanging the suite. **On `main` this fails at x20.6** with the 128 KiB case taking 22s.
- `an_unclosed_bracket_stays_literal` — the early exit replaces a scan that ended in the literal fallback, so each of these has to render exactly as before.
- `a_bracket_that_does_close_still_links` — the guard must not swallow the cases that do close, in all four accepting forms (inline, full reference, collapsed, shortcut) plus images and a code span holding the `]`.
- `the_literal_fallback_keeps_its_node_shape` — HTML alone would not catch a changed split. `![` has to stay **one** two-byte text node, not `!` followed by `[`, or the spans reported to editors and diagnostics would shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790700276&installation_model_id=422833&pr_number=1227&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1227&signature=d00908de09245b8dfef25c12cf13b7d757dbc3c452f9f70f224bcfe09c505653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->