### PR TITLE
fix(ci): repair the docs deploy and nightly preview under pnpm 12

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -323,6 +323,16 @@ jobs:
           --package-json-path crates/ox_content_napi/package.json
           --npm-dir binding-packages --no-gh-release --skip-optional-publish
 
+      # pkg-pr-new's `--pnpm` flag shells out to a `pnpm` binary of its own.
+      # setup-vp drives pnpm through corepack, so only `corepack` lands on
+      # PATH and that spawn fails with ENOENT. The shim resolves the version
+      # in `packageManager`, which is the one corepack already fetched.
+      - name: Put pnpm on PATH for pkg-pr-new
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          corepack enable --install-directory "$HOME/.local/bin" pnpm
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Publish to pkg-pr-new
         id: publish-pkg-pr-new
         continue-on-error: ${{ github.event_name == 'pull_request' }}

--- a/scripts/deploy-docs-to-void.mjs
+++ b/scripts/deploy-docs-to-void.mjs
@@ -49,6 +49,13 @@ const run = (command, args, options = {}) => {
   }
 };
 
+// pnpm 12 fails an install whose dependencies carry unapproved build
+// scripts, and `pnpm dlx` runs outside the workspace, so the `allowBuilds`
+// list in pnpm-workspace.yaml never reaches it. The approval is only
+// accepted as a CLI flag — `npm_config_*` is ignored — and `vpx` has no way
+// to pass one through, so the dlx call is spelled out below.
+const voidBuildDependencies = ["better-sqlite3", "esbuild", "workerd"];
+
 const voidArgs = ["void@0.10.8", "deploy"];
 
 if (!hasOption(extraArgs, "--project")) {
@@ -73,4 +80,12 @@ run("vp", ["build"], {
     OX_CONTENT_DOCS_SITE_URL: docsSiteUrl,
   },
 });
-run("vpx", voidArgs);
+run("vp", [
+  "exec",
+  "--",
+  "pnpm",
+  "dlx",
+  "--yes",
+  ...voidBuildDependencies.flatMap((name) => ["--allow-build", name]),
+  ...voidArgs,
+]);


### PR DESCRIPTION
## What is broken

`Deploy docs to Void` and `Nightly release` have failed on **every commit** since [#1207](https://github.com/ubugeeei-prod/ox-content/pull/1207) upgraded pnpm to v12. The last green run of either was `9fa0c1cf`, the commit immediately before it.

Neither failure is in a test job, so the `CI` workflow stayed green and the breakage went unnoticed for ~20 commits.

## 1. `Deploy docs to Void` — `ERR_PNPM_IGNORED_BUILDS`

The site builds fine (`Generated 1283 output files`, `Generated 339 OG images`); it dies on the deploy step:

```
Error: ERR_PNPM_IGNORED_BUILDS
  × adding a new package
  ╰─▶ Ignored build scripts: better-sqlite3@12.11.1, esbuild@0.18.20,
      esbuild@0.25.12, esbuild@0.28.1, esbuild@0.28.2, workerd@1.20260828.1
```

pnpm 12 fails an install whose dependencies carry unapproved build scripts, and `void`'s tree has three of them.

The `allowBuilds` list in `pnpm-workspace.yaml` does not help: `pnpm dlx` installs into a temp project **outside** the workspace, so the workspace config never reaches it. I verified against pnpm 12.1.0 that the approval is accepted **only** as a CLI flag — both `npm_config_allow_build` and `npm_config_dangerously_allow_all_builds` are ignored and still fail:

| attempt | result |
|---|---|
| `pnpm dlx void@0.10.8` | `ERR_PNPM_IGNORED_BUILDS` |
| `npm_config_allow_build=... pnpm dlx void@0.10.8` | `ERR_PNPM_IGNORED_BUILDS` |
| `npm_config_dangerously_allow_all_builds=true pnpm dlx void@0.10.8` | `ERR_PNPM_IGNORED_BUILDS` |
| `pnpm dlx --allow-build better-sqlite3 --allow-build esbuild --allow-build workerd void@0.10.8` | ✅ `0.10.8` |

`vp dlx` / `vpx` has no option to forward that flag (`-p`, `-c`, `-s` only), so the dlx call is spelled out as `vp exec -- pnpm dlx --allow-build ...`. That keeps the toolchain the repo already uses — `vp exec -- pnpm` is how `nightly.yml` invokes pnpm elsewhere — and works both in CI and locally.

The allowed list is exactly the three packages the error names, not a blanket approval.

## 2. `Nightly release` — `spawn pnpm ENOENT`

```
[error] spawn pnpm ENOENT
  at ChildProcess._handle.onexit (node:internal/child_process:286:19)
```

pkg-pr-new's `--pnpm` flag shells out to a `pnpm` binary of its own. setup-vp drives pnpm through corepack — the job log shows `vp: corepack is not available for Node.js 26.8.1; installing it as a managed global package` followed by `Bins: corepack` — so only `corepack` lands on PATH and that spawn fails.

A corepack shim in `$HOME/.local/bin` fixes it. The shim resolves the version in `packageManager` (12.1.0), which is the one corepack has already fetched by that point in the job.

On pull requests this step is `continue-on-error`, so this only ever broke `main` and the scheduled run.

## Verification

Both failures were reproduced locally against pnpm 12.1.0 and both fixes confirmed:

- `vp exec -- pnpm dlx --yes --allow-build better-sqlite3 --allow-build esbuild --allow-build workerd void@0.10.8 --version` → `0.10.8`, with the build scripts actually running on a cold cache.
- `corepack enable --install-directory <dir> pnpm` creates a working `pnpm` shim; with it on PATH, `pnpm --version` → `12.1.0`.

`vp fmt --check` passes on the changed script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the reliability of nightly package publishing by ensuring the required package manager is available during automated releases.
  - Updated documentation deployment tooling to handle approved build dependencies consistently, reducing the risk of failed deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->