### PR TITLE
perf(ssg): resolve git lastmod in one walk instead of one per page

### DIFF
--- a/crates/ox_content_napi/src/ssg_bindings/git.rs
+++ b/crates/ox_content_napi/src/ssg_bindings/git.rs
@@ -1,32 +1,130 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::{Mutex, OnceLock, PoisonError};
+use std::sync::{Arc, Mutex, OnceLock, PoisonError};
 
 use napi_derive::napi;
 
 use crate::JsGitContributor;
 
 type ContributorCache = Mutex<HashMap<(String, String), Vec<JsGitContributor>>>;
+type LastmodCache = Mutex<HashMap<(String, String), Arc<HashMap<String, f64>>>>;
+type HeadCache = Mutex<HashMap<String, (std::time::Instant, Option<String>)>>;
+
+/// How long a HEAD reading is reused before git is asked again.
+const HEAD_FRESHNESS: std::time::Duration = std::time::Duration::from_secs(1);
+
+fn head_cache() -> &'static HeadCache {
+    static CACHE: OnceLock<HeadCache> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// HEAD for `root`, re-read at most once a second.
+///
+/// `git rev-parse HEAD` is a process spawn, and it keys every cache lookup
+/// here — so without this the caches still paid one spawn per file, which is
+/// most of what they exist to avoid. A build finishes well inside the window;
+/// a dev server picks up a new commit within a second of it landing.
+fn cached_git_head(root: &std::path::Path) -> Option<String> {
+    let key = root.to_string_lossy().into_owned();
+    let now = std::time::Instant::now();
+
+    if let Some((read_at, head)) =
+        head_cache().lock().unwrap_or_else(PoisonError::into_inner).get(&key)
+        && now.duration_since(*read_at) < HEAD_FRESHNESS
+    {
+        return head.clone();
+    }
+
+    let head = git_head(root);
+    head_cache().lock().unwrap_or_else(PoisonError::into_inner).insert(key, (now, head.clone()));
+    head
+}
+
+fn lastmod_cache() -> &'static LastmodCache {
+    static CACHE: OnceLock<LastmodCache> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Last commit time, in seconds, for every file under `root` that git knows.
+///
+/// This used to be one `git log -1 -- <path>` per file. A page git has never
+/// seen is the expensive case, not the cheap one: git cannot answer "never"
+/// without walking the whole history, so every new page cost a full walk plus
+/// a process spawn. A 400-page site spent 20 s in the sitemap step against
+/// 0.6 s for the rest of the build. One walk for the whole subtree costs about
+/// half a second here and does not grow with the page count.
+///
+/// `-z` with a NUL-prefixed timestamp makes the stream unambiguous for any
+/// path bytes: an empty field means the next field is a timestamp, and
+/// everything else is a path belonging to the timestamp before it.
+fn build_lastmod_map(root: &std::path::Path) -> HashMap<String, f64> {
+    let mut map = HashMap::new();
+
+    let Ok(output) = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["log", "-z", "--format=%x00%ct", "--name-only", "--relative", "--", "."])
+        .output()
+    else {
+        return map;
+    };
+    if !output.status.success() {
+        return map;
+    }
+
+    let mut seconds: Option<f64> = None;
+    let mut next_is_timestamp = false;
+    for field in output.stdout.split(|byte| *byte == 0) {
+        if field.is_empty() {
+            next_is_timestamp = true;
+            continue;
+        }
+        if next_is_timestamp {
+            next_is_timestamp = false;
+            seconds = std::str::from_utf8(field).ok().and_then(|value| value.trim().parse().ok());
+            continue;
+        }
+        let Some(seconds) = seconds else {
+            continue;
+        };
+        // The first path of a commit carries the newline that ended the
+        // format line.
+        let path = field.strip_prefix(b"\n").unwrap_or(field);
+        let Ok(path) = std::str::from_utf8(path) else {
+            continue;
+        };
+        if path.is_empty() {
+            continue;
+        }
+        // git walks newest first, so the first time a path appears is its
+        // last commit.
+        map.entry(path.to_string()).or_insert(seconds);
+    }
+
+    map
+}
+
+fn lastmod_map(root: &std::path::Path) -> Option<Arc<HashMap<String, f64>>> {
+    // HEAD keys the cache the way it keys the contributor cache: a build never
+    // moves it, and a dev server that outlives a commit picks up the new one.
+    let head = cached_git_head(root)?;
+    let key = (root.to_string_lossy().into_owned(), head);
+
+    if let Some(hit) = lastmod_cache().lock().unwrap_or_else(PoisonError::into_inner).get(&key) {
+        return Some(Arc::clone(hit));
+    }
+
+    let map = Arc::new(build_lastmod_map(root));
+    lastmod_cache().lock().unwrap_or_else(PoisonError::into_inner).insert(key, Arc::clone(&map));
+    Some(map)
+}
 
 /// Returns the last git commit timestamp for a file in milliseconds.
 #[napi]
 pub fn get_git_last_updated(file_path: String, root: Option<String>) -> Option<f64> {
-    let root = root.map(PathBuf::from)?;
-    let file = PathBuf::from(&file_path);
-    let pathspec = file.strip_prefix(&root).ok().and_then(|p| p.to_str()).unwrap_or(&file_path);
-    let output = std::process::Command::new("git")
-        .arg("-C")
-        .arg(root)
-        .args(["log", "-1", "--format=%ct", "--"])
-        .arg(pathspec)
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let seconds = String::from_utf8(output.stdout).ok()?.trim().parse::<f64>().ok()?;
+    let root = root.filter(|root| !root.is_empty()).map(PathBuf::from)?;
+    let pathspec = git_pathspec(&file_path, &root);
+    let seconds = *lastmod_map(&root)?.get(pathspec)?;
     Some(seconds * 1_000.0)
 }
 
@@ -100,7 +198,7 @@ pub fn get_git_contributors(file_path: String, root: Option<String>) -> Vec<JsGi
         return Vec::new();
     };
     let spec = git_pathspec(&file_path, &root).to_string();
-    let head = git_head(&root);
+    let head = cached_git_head(&root);
     if let Some(head) = head.as_ref() {
         let cache = contributors_cache().lock().unwrap_or_else(PoisonError::into_inner);
         if let Some(hit) = cache.get(&(spec.clone(), head.clone())) {

--- a/crates/ox_content_napi/src/tests.rs
+++ b/crates/ox_content_napi/src/tests.rs
@@ -53,6 +53,7 @@ mod docs_nav_output;
 mod entry_points;
 mod frontmatter;
 mod git_contributors;
+mod git_lastmod;
 mod mdx_bindings;
 mod render_scratch;
 mod runtime_features;

--- a/crates/ox_content_napi/src/tests/git_lastmod.rs
+++ b/crates/ox_content_napi/src/tests/git_lastmod.rs
@@ -1,0 +1,180 @@
+use super::*;
+
+/// Runs `git` in `root`, failing the test if it does not succeed. Output is
+/// captured rather than inherited so a passing run leaves the log clean.
+fn git(root: &std::path::Path, args: &[&str], timestamp: &str) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["-c", "commit.gpgsign=false", "-c", "user.name=Test"])
+        .args(["-c", "user.email=test@example.com"])
+        .args(args)
+        .env("GIT_AUTHOR_DATE", timestamp)
+        .env("GIT_COMMITTER_DATE", timestamp)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "git {args:?} failed: {output:?}");
+}
+
+/// A repository whose files are committed at known, distinct times.
+fn repository(name: &str) -> std::path::PathBuf {
+    let root = std::env::temp_dir().join(format!("ox-content-{name}-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("docs/guide")).unwrap();
+    git(&root, &["init"], "@1000000000");
+
+    fs::write(root.join("docs/first.md"), "# First\n").unwrap();
+    fs::write(root.join("docs/guide/nested.md"), "# Nested\n").unwrap();
+    git(&root, &["add", "."], "@1000000000");
+    git(&root, &["commit", "-m", "first"], "@1000000000");
+
+    // A second commit touches only one of them, so "newest wins" is testable
+    // and the two files must not report the same time.
+    fs::write(root.join("docs/first.md"), "# First, edited\n").unwrap();
+    fs::write(root.join("docs/second.md"), "# Second\n").unwrap();
+    git(&root, &["add", "."], "@2000000000");
+    git(&root, &["commit", "-m", "second"], "@2000000000");
+
+    root
+}
+
+fn last_updated(file: &std::path::Path, root: &std::path::Path) -> Option<f64> {
+    get_git_last_updated(
+        file.to_string_lossy().into_owned(),
+        Some(root.to_string_lossy().into_owned()),
+    )
+}
+
+/// What a per-file `git log -1` would have answered, which is what this
+/// lookup did before it was batched into one walk.
+fn per_file_log(root: &std::path::Path, relative: &str) -> Option<f64> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["log", "-1", "--format=%ct", "--", relative])
+        .output()
+        .unwrap();
+    let text = String::from_utf8(output.stdout).unwrap();
+    let trimmed = text.trim();
+    if trimmed.is_empty() { None } else { Some(trimmed.parse::<f64>().unwrap() * 1000.0) }
+}
+
+#[test]
+fn lastmod_matches_a_per_file_log() {
+    // The batched walk has to answer exactly what the per-file command did,
+    // for every file, including the one git has never seen.
+    let root = repository("lastmod-diff");
+    fs::write(root.join("docs/untracked.md"), "# Untracked\n").unwrap();
+
+    for relative in ["docs/first.md", "docs/second.md", "docs/guide/nested.md", "docs/untracked.md"]
+    {
+        assert_eq!(
+            last_updated(&root.join(relative), &root),
+            per_file_log(&root, relative),
+            "for {relative}"
+        );
+    }
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn lastmod_takes_the_newest_commit() {
+    let root = repository("lastmod-newest");
+
+    assert_eq!(last_updated(&root.join("docs/first.md"), &root), Some(2_000_000_000_000.0));
+    assert_eq!(last_updated(&root.join("docs/guide/nested.md"), &root), Some(1_000_000_000_000.0));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn lastmod_is_none_for_a_file_git_has_never_seen() {
+    // This is the expensive case the batching exists for: answering "never"
+    // used to mean walking the whole history, once per page.
+    let root = repository("lastmod-untracked");
+    fs::write(root.join("docs/untracked.md"), "# Untracked\n").unwrap();
+
+    assert_eq!(last_updated(&root.join("docs/untracked.md"), &root), None);
+    assert_eq!(last_updated(&root.join("docs/missing.md"), &root), None);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn lastmod_resolves_when_the_root_is_a_subdirectory() {
+    // The walk reports paths relative to the directory it runs in, and the
+    // lookup key is relative to `root`. When `root` is not the repository top
+    // level those two only agree because the walk asks for relative paths.
+    let root = repository("lastmod-subdir");
+    let docs = root.join("docs");
+
+    assert_eq!(last_updated(&docs.join("first.md"), &docs), Some(2_000_000_000_000.0));
+    assert_eq!(last_updated(&docs.join("guide/nested.md"), &docs), Some(1_000_000_000_000.0));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn lastmod_handles_paths_that_need_quoting() {
+    // Non-ASCII and spaces are why the walk is NUL-framed rather than
+    // line-framed: git quotes such paths in line-oriented output.
+    let root = repository("lastmod-quoting");
+    fs::write(root.join("docs/日本語 ページ.md"), "# Page\n").unwrap();
+    git(&root, &["add", "."], "@3000000000");
+    git(&root, &["commit", "-m", "unicode"], "@3000000000");
+
+    assert_eq!(last_updated(&root.join("docs/日本語 ページ.md"), &root), Some(3_000_000_000_000.0));
+    // The other files keep their own times.
+    assert_eq!(last_updated(&root.join("docs/guide/nested.md"), &root), Some(1_000_000_000_000.0));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn lastmod_without_a_repository_is_none() {
+    let root =
+        std::env::temp_dir().join(format!("ox-content-lastmod-nogit-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("page.md"), "# Page\n").unwrap();
+
+    assert_eq!(last_updated(&root.join("page.md"), &root), None);
+    assert_eq!(
+        get_git_last_updated(root.join("page.md").to_string_lossy().into_owned(), None),
+        None
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn looking_up_every_page_costs_one_walk() {
+    // The lookup used to run `git log` per file, so a build paid one process
+    // spawn and one history walk per page. Now the first lookup builds the
+    // whole map and the rest read it, which makes 500 pages cheaper than the
+    // one page that filled the cache — a ratio no per-file implementation can
+    // reach, and one that does not depend on how fast the machine is.
+    let root = repository("lastmod-batched");
+    for index in 0..500 {
+        fs::write(root.join(format!("docs/page-{index}.md")), "# Page\n").unwrap();
+    }
+
+    let started = std::time::Instant::now();
+    last_updated(&root.join("docs/first.md"), &root);
+    let first = started.elapsed();
+
+    let started = std::time::Instant::now();
+    for index in 0..500 {
+        last_updated(&root.join(format!("docs/page-{index}.md")), &root);
+    }
+    let rest = started.elapsed();
+
+    assert!(
+        rest < first,
+        "500 lookups took {rest:?} against {first:?} for the one that built the map; \
+         a per-file lookup would take about 500 times as long"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}


### PR DESCRIPTION
## Problem

`getGitLastUpdated` ran a separate git process for every page:

```rust
std::process::Command::new("git")
    .args(["log", "-1", "--format=%ct", "--"])
    .arg(pathspec)
```

The expensive case is the ordinary one. A page git has never seen — a page someone just added — cannot be answered without walking the **entire history**, and that walk happens once per page, after a process spawn.

`siteMaps` is what asks for lastmod, so enabling it made the sitemap step cost more than the whole rest of the build. Measured on a synthetic site, with the sitemap step isolated by building with and without it:

| pages | rest of build | sitemap step |
|---|---|---|
| 100 | 456 ms | 3,654 ms |
| 200 | 499 ms | 8,518 ms |
| 400 | 632 ms | 21,035 ms |
| 800 | 1,269 ms | **29,868 ms** |

At 800 pages the sitemap step was **40x the build it belonged to**. A 5,000-page project would spend minutes there.

## Fix

One walk for the whole subtree:

```
git log -z --format=%x00%ct --name-only --relative -- .
```

git walks newest-first, so the first time a path appears is its last commit. Two details are load-bearing:

- **NUL framing.** git quotes paths in line-oriented output, so a line-based parse breaks on non-ASCII and spaces. With `-z` and a NUL-prefixed timestamp the stream is unambiguous for any path bytes: an empty field means the next field is a timestamp, everything else is a path.
- **`--relative`.** The lookup key is relative to the project root, which need not be the repository top level. Without it a project rooted at `docs/` gets `docs/content/x.md` from the walk and looks up `content/x.md`.

The map is memoized per `(root, HEAD)`, like the existing contributor cache. **HEAD itself is now memoized too**, for one second — reading it is also a process spawn and it keys every cache lookup, so without that the caches still paid one spawn per file. That was worth 2x on its own: batching the log alone took 400 pages from 21.0s to 8.9s; caching HEAD took it to 0.06s.

## Result

Same machine, same corpus, alternating runs:

| pages | before | after | |
|---|---|---|---|
| 100 | 3,654 ms | 42 ms | **87x** |
| 200 | 8,518 ms | 37 ms | **230x** |
| 400 | 21,035 ms | 56 ms | **376x** |
| 800 | 29,868 ms | 53 ms | **564x** |

The cost no longer grows with the page count at all — it is one walk either way.

## Behaviour is unchanged

- The six behavioural tests in this PR pass against **both** implementations.
- On this repository's 215 real docs pages, the batched lookup returns timestamps identical to the per-file command, with no case where one found a commit and the other did not.

## Tests

`crates/ox_content_napi/src/tests/git_lastmod.rs`:

- `lastmod_matches_a_per_file_log` — the differential, in CI: every file, including one git has never seen, must match what `git log -1 -- <path>` answers.
- `lastmod_takes_the_newest_commit`, `lastmod_is_none_for_a_file_git_has_never_seen`, `lastmod_without_a_repository_is_none` — the three answers the lookup can give.
- `lastmod_resolves_when_the_root_is_a_subdirectory` — covers `--relative`; the existing test only used a root that was the repository top level.
- `lastmod_handles_paths_that_need_quoting` — non-ASCII and spaces, which is why the walk is NUL-framed.
- `looking_up_every_page_costs_one_walk` — 500 lookups must together cost less than the single lookup that built the map. No per-file implementation can reach that ratio, and it does not depend on machine speed. **On `main` this fails**: 500 lookups take 10.3s against 26ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790703196&installation_model_id=422833&pr_number=1231&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1231&signature=d665244a499a9d3c8ee48bff99e7ea042d88d106c5dac78e789707c58a31fc2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->