### PR TITLE
perf(og-image): render across browsers instead of pages in one browser

### DIFF
--- a/npm/vite-plugin-ox-content/src/og-image-pool.test.ts
+++ b/npm/vite-plugin-ox-content/src/og-image-pool.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vite-plus/test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { generateOgImages, mapWithSessions, openBrowser, resolveOgImageOptions } from "./og-image";
+import type { OgBrowserSession } from "./og-image";
+
+/**
+ * A stand-in for a browser session. Nothing here launches Chromium: what is
+ * under test is how work is handed to sessions, not what a session does with
+ * it.
+ */
+function fakeSessions(count: number): OgBrowserSession[] {
+  return Array.from({ length: count }, () => ({
+    renderPage: async () => Buffer.alloc(0),
+    async [Symbol.asyncDispose]() {},
+  }));
+}
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("mapWithSessions", () => {
+  it("returns results in input order however the sessions interleave", async () => {
+    // The first item is the slowest, so a run that returned results in
+    // completion order would put it last.
+    const items = [0, 1, 2, 3, 4, 5, 6, 7];
+    const results = await mapWithSessions(items, fakeSessions(4), async (item) => {
+      for (let wait = item === 0 ? 20 : 0; wait > 0; wait--) {
+        await tick();
+      }
+      return `item-${item}`;
+    });
+
+    expect(results).toEqual(items.map((item) => `item-${item}`));
+  });
+
+  it("renders every item exactly once", async () => {
+    const items = Array.from({ length: 50 }, (_, index) => index);
+    const seen: number[] = [];
+
+    await mapWithSessions(items, fakeSessions(7), async (item) => {
+      await tick();
+      seen.push(item);
+      return item;
+    });
+
+    expect(seen.sort((left, right) => left - right)).toEqual(items);
+  });
+
+  it("gives a session its next item without waiting for the others", async () => {
+    // The batched version paid for its slowest member before starting the
+    // next batch, so with one slow item and three sessions only two items
+    // could be in flight. A shared cursor keeps all three busy.
+    let inFlight = 0;
+    let peak = 0;
+
+    await mapWithSessions(
+      Array.from({ length: 12 }, (_, index) => index),
+      fakeSessions(3),
+      async (item) => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        for (let wait = item === 0 ? 30 : 1; wait > 0; wait--) {
+          await tick();
+        }
+        inFlight--;
+        return item;
+      },
+    );
+
+    expect(peak).toBe(3);
+  });
+
+  it("uses one session without stranding work", async () => {
+    const items = [1, 2, 3];
+    expect(await mapWithSessions(items, fakeSessions(1), async (item) => item * 2)).toEqual([
+      2, 4, 6,
+    ]);
+  });
+
+  it("does nothing when there is nothing to render", async () => {
+    expect(await mapWithSessions([], fakeSessions(4), async () => "x")).toEqual([]);
+  });
+});
+
+/**
+ * The Chromium path needs a browser, which the unit test job does not
+ * install. Probing once keeps the file runnable everywhere: it covers the
+ * real path where Chromium exists and skips where it does not.
+ */
+const chromiumSession = await openBrowser();
+const hasChromium = chromiumSession !== null;
+await chromiumSession?.[Symbol.asyncDispose]();
+
+describe.skipIf(!hasChromium)("generateOgImages with Chromium", () => {
+  it("writes every image the caller asked for", async () => {
+    // Regression: the pool is disposed when `generateOgImages` returns, so
+    // returning the render promise instead of awaiting it closed every
+    // browser before the first render finished. Each page then failed with
+    // "Target page, context or browser has been closed" — reported per page,
+    // never thrown, so the build stayed green and produced nothing.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-og-chromium-"));
+    try {
+      const pages = Array.from({ length: 6 }, (_, index) => ({
+        outputPath: path.join(dir, `og-${index}.png`),
+        props: { title: `Card ${index}`, description: "Rendered through Chromium" },
+      }));
+
+      const results = await generateOgImages(
+        pages,
+        resolveOgImageOptions({ cache: false, width: 300, height: 158 }),
+        dir,
+      );
+
+      expect(results.map((result) => result.error)).toEqual(pages.map(() => undefined));
+      expect(results.map((result) => result.outputPath)).toEqual(
+        pages.map((page) => page.outputPath),
+      );
+      for (const page of pages) {
+        const png = await fs.readFile(page.outputPath);
+        expect(png.subarray(0, 8).toString("hex"), page.outputPath).toBe("89504e470d0a1a0a");
+      }
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/npm/vite-plugin-ox-content/src/og-image/browser.ts
+++ b/npm/vite-plugin-ox-content/src/og-image/browser.ts
@@ -7,8 +7,8 @@
  *   // browser.close() is called automatically when session goes out of scope
  */
 
-import type { Page } from "playwright";
-import { renderHtmlToPng } from "./renderer";
+import type { Browser, Page } from "playwright";
+import { renderHtmlToPng, routePublicDir } from "./renderer";
 
 const PLAYWRIGHT_BROWSER_INSTALL_HINT =
   "Install Playwright browsers with `npx playwright install chromium` to enable OG image generation.";
@@ -21,6 +21,54 @@ let chromiumUnavailableWarned = false;
  */
 export interface OgBrowserSession extends AsyncDisposable {
   renderPage(html: string, width: number, height: number, publicDir?: string): Promise<Buffer>;
+}
+
+async function launchChromium(): Promise<Browser> {
+  const { chromium } = await import("playwright");
+  return chromium.launch({
+    headless: true,
+    args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
+  });
+}
+
+/** A set of independent sessions, closed together. */
+export interface OgBrowserPool extends AsyncDisposable {
+  sessions: OgBrowserSession[];
+}
+
+/**
+ * Opens up to `size` independent browsers.
+ *
+ * Rendering does not parallelize inside one browser: every page shares a
+ * single connection to it, so eight pages in one browser finish no sooner
+ * than one does. Measured on 120 cards, milliseconds per image:
+ *
+ *     browsers   1     2     4     8
+ *     pages 1    84.6  —     25.6  14.7
+ *     pages 8    80.5  42.0  23.1  —
+ *
+ * Pages buy nothing; browsers scale nearly linearly. Each one costs its own
+ * process, so this is bounded by the caller's `concurrency`, and
+ * `concurrency: 1` keeps the old single-process footprint.
+ *
+ * Returns null when Chromium cannot be launched at all. A launch that fails
+ * after the first still yields a working pool, one browser smaller.
+ */
+export async function openBrowserPool(size: number): Promise<OgBrowserPool | null> {
+  const wanted = Math.max(1, size);
+  const opened = await Promise.all(Array.from({ length: wanted }, () => openBrowser()));
+  const sessions = opened.filter((session): session is OgBrowserSession => session !== null);
+
+  if (sessions.length === 0) {
+    return null;
+  }
+
+  return {
+    sessions,
+    async [Symbol.asyncDispose]() {
+      await Promise.all(sessions.map((session) => session[Symbol.asyncDispose]()));
+    },
+  };
 }
 
 /**
@@ -36,16 +84,23 @@ export interface OgBrowserSession extends AsyncDisposable {
  */
 export async function openBrowser(): Promise<OgBrowserSession | null> {
   try {
-    const { chromium } = await import("playwright");
-    const browser = await chromium.launch({
-      headless: true,
-      args: [
-        "--no-sandbox",
-        "--disable-setuid-sandbox",
-        "--disable-dev-shm-usage",
-        "--disable-gpu",
-      ],
-    });
+    const browser = await launchChromium();
+
+    // One context for the session. `browser.newPage()` builds a fresh context
+    // per call, so a site paid a context setup and teardown per image — which
+    // is most of what an image costs and is why raising `concurrency` barely
+    // moved the total.
+    const context = await browser.newContext();
+
+    // Pages are reused instead of closed: `setContent` replaces the document
+    // outright, so there is nothing to carry over. The pool grows to whatever
+    // the caller runs at once and no further.
+    const idle: PooledPage[] = [];
+
+    const acquire = async (): Promise<PooledPage> => {
+      const pooled = idle.pop();
+      return pooled ?? { page: await context.newPage() };
+    };
 
     return {
       async renderPage(
@@ -54,11 +109,26 @@ export async function openBrowser(): Promise<OgBrowserSession | null> {
         height: number,
         publicDir?: string,
       ): Promise<Buffer> {
-        const page: Page = await browser.newPage();
+        const pooled = await acquire();
         try {
-          return await renderHtmlToPng(page, html, width, height, publicDir);
-        } finally {
-          await page.close();
+          if (pooled.routedFor !== publicDir) {
+            if (pooled.routedFor !== undefined) {
+              await pooled.page.unrouteAll();
+            }
+            if (publicDir) {
+              await routePublicDir(pooled.page, publicDir);
+            }
+            pooled.routedFor = publicDir;
+          }
+          const png = await renderHtmlToPng(pooled.page, html, width, height, publicDir);
+          idle.push(pooled);
+          return png;
+        } catch (error) {
+          // A page that threw may be mid-navigation or crashed; dropping it
+          // keeps the failure from spreading to the next entry that would
+          // have reused it.
+          await pooled.page.close().catch(() => {});
+          throw error;
         }
       },
 
@@ -74,6 +144,12 @@ export async function openBrowser(): Promise<OgBrowserSession | null> {
     warnChromiumUnavailableOnce(err);
     return null;
   }
+}
+
+/** A pooled page and the public directory its route handler was set up for. */
+interface PooledPage {
+  page: Page;
+  routedFor?: string;
 }
 
 function warnChromiumUnavailableOnce(err: unknown): void {

--- a/npm/vite-plugin-ox-content/src/og-image/index.ts
+++ b/npm/vite-plugin-ox-content/src/og-image/index.ts
@@ -7,7 +7,7 @@
 import * as path from "path";
 import * as crypto from "crypto";
 import { availableParallelism } from "os";
-import { openBrowser } from "./browser";
+import { openBrowser, openBrowserPool } from "./browser";
 import type { OgBrowserSession } from "./browser";
 import { renderHtmlToPngWithSatori } from "./satori-renderer";
 import { getDefaultSatoriTemplate, getDefaultTemplate } from "./template";
@@ -30,7 +30,8 @@ export type {
   OgImageSatoriOptions,
 } from "./types";
 
-export type { OgBrowserSession } from "./browser";
+export type { OgBrowserPool, OgBrowserSession } from "./browser";
+export { openBrowser, openBrowserPool } from "./browser";
 
 /**
  * Resolves user-provided OG image options with defaults.
@@ -624,9 +625,11 @@ export async function generateOgImages(
     return renderSatoriPages(keyed, templateFn, options, cacheDir, root);
   }
 
-  // Launch browser
-  await using session = await openBrowser();
-  if (!session) {
+  // One browser per worker: rendering does not parallelize inside a single
+  // browser, so this is where the concurrency option actually buys something.
+  const concurrency = Math.max(1, Math.min(options.concurrency, keyed.length));
+  await using pool = await openBrowserPool(concurrency);
+  if (!pool) {
     return pages.map((p) => ({
       outputPath: p.outputPath,
       cached: false,
@@ -634,23 +637,44 @@ export async function generateOgImages(
     }));
   }
 
-  const results: OgImageResult[] = [];
-
   // Resolve public directory for serving local assets in templates
   const publicDir = path.join(root, "public");
 
-  // Process pages with concurrency control
-  const concurrency = Math.max(1, options.concurrency);
+  // Awaited, not returned: `await using` disposes when this function returns,
+  // and returning the promise would close every browser before the first
+  // render finished.
+  return await mapWithSessions(keyed, pool.sessions, (entry, session) =>
+    renderSinglePage(entry, templateFn, options, cacheDir, session, publicDir),
+  );
+}
 
-  for (let i = 0; i < keyed.length; i += concurrency) {
-    const batch = keyed.slice(i, i + concurrency);
-    const batchResults = await Promise.all(
-      batch.map((entry) =>
-        renderSinglePage(entry, templateFn, options, cacheDir, session, publicDir),
-      ),
-    );
-    results.push(...batchResults);
-  }
+/**
+ * Runs `render` over `items`, one at a time per session, in input order.
+ *
+ * A shared cursor rather than fixed batches: a batch waits for its slowest
+ * member before the next one starts, so one heavy card idled every other
+ * worker until it finished. Results are written by index, so the order the
+ * caller gets back does not depend on which session finished first.
+ */
+export async function mapWithSessions<Item, Result>(
+  items: readonly Item[],
+  sessions: readonly OgBrowserSession[],
+  render: (item: Item, session: OgBrowserSession) => Promise<Result>,
+): Promise<Result[]> {
+  const results: Result[] = new Array(items.length);
+  let next = 0;
+
+  await Promise.all(
+    sessions.map(async (session) => {
+      for (;;) {
+        const index = next++;
+        if (index >= items.length) {
+          return;
+        }
+        results[index] = await render(items[index] as Item, session);
+      }
+    }),
+  );
 
   return results;
 }

--- a/npm/vite-plugin-ox-content/src/og-image/renderer.ts
+++ b/npm/vite-plugin-ox-content/src/og-image/renderer.ts
@@ -23,6 +23,50 @@ html, body { width: ${width}px; height: ${height}px; overflow: hidden; }
 </html>`;
 }
 
+const MIME_TYPES: Record<string, string> = {
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+  ".css": "text/css",
+  ".js": "application/javascript",
+};
+
+/**
+ * Serves local assets from `publicDir` for anything the card requests.
+ *
+ * Registered once per page rather than once per render: a handler added on
+ * every render stacks up on a page that is reused, and Playwright then walks
+ * the whole stack for every request.
+ */
+export async function routePublicDir(page: Page, publicDir: string): Promise<void> {
+  const fs = await import("fs/promises");
+  await page.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    // Only intercept paths that look like local assets (not data: or blob:)
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      await route.continue();
+      return;
+    }
+    const filePath = path.join(publicDir, url.pathname);
+    try {
+      const body = await fs.readFile(filePath);
+      const ext = path.extname(filePath).toLowerCase();
+      await route.fulfill({
+        body,
+        contentType: MIME_TYPES[ext] || "application/octet-stream",
+      });
+    } catch {
+      await route.continue();
+    }
+  });
+}
+
 /**
  * Renders an HTML string to a PNG buffer using Chromium.
  *
@@ -41,43 +85,6 @@ export async function renderHtmlToPng(
   publicDir?: string,
 ): Promise<Buffer> {
   await page.setViewportSize({ width, height });
-
-  // Serve local assets from the public directory
-  if (publicDir) {
-    const fs = await import("fs/promises");
-    await page.route("**/*", async (route) => {
-      const url = new URL(route.request().url());
-      // Only intercept paths that look like local assets (not data: or blob:)
-      if (url.protocol !== "http:" && url.protocol !== "https:") {
-        await route.continue();
-        return;
-      }
-      const filePath = path.join(publicDir, url.pathname);
-      try {
-        const body = await fs.readFile(filePath);
-        const ext = path.extname(filePath).toLowerCase();
-        const mimeTypes: Record<string, string> = {
-          ".svg": "image/svg+xml",
-          ".png": "image/png",
-          ".jpg": "image/jpeg",
-          ".jpeg": "image/jpeg",
-          ".gif": "image/gif",
-          ".webp": "image/webp",
-          ".woff": "font/woff",
-          ".woff2": "font/woff2",
-          ".ttf": "font/ttf",
-          ".css": "text/css",
-          ".js": "application/javascript",
-        };
-        await route.fulfill({
-          body,
-          contentType: mimeTypes[ext] || "application/octet-stream",
-        });
-      } catch {
-        await route.continue();
-      }
-    });
-  }
 
   const fullHtml = wrapHtml(html, width, height, !!publicDir);
   // `load` fires once the document and its subresources — images, fonts, the


### PR DESCRIPTION
## Problem

Two things kept OG generation pinned to roughly one image at a time.

**1. A fresh BrowserContext per image.** `browser.newPage()` builds a new context, and the session created and destroyed one around every render:

```ts
const page: Page = await browser.newPage();
try {
  return await renderHtmlToPng(page, html, width, height, publicDir);
} finally {
  await page.close();
}
```

That setup and teardown is most of what an image costs — the render itself is a few milliseconds.

**2. `concurrency` could not deliver what it promised.** Pages in one browser share a single connection to it, so raising the option added pages to the same browser and the total barely moved. Measured directly on 120 cards, milliseconds per image:

| | 1 browser | 2 browsers | 4 browsers | 8 browsers |
|---|---|---|---|---|
| 1 page each | 84.6 | — | 25.6 | **14.7** |
| 8 pages each | 80.5 | 42.0 | 23.1 | — |

Eight pages in one browser finish no sooner than one page does. Browsers scale nearly linearly.

## Fix

- **Pool pages instead of closing them.** `setContent` replaces the document outright, so there is nothing to carry between renders. The `public/` route handler moves to page creation — registered once per page rather than once per render, because handlers added per render stack up on a page that is reused and Playwright then walks the whole stack for every request.
- **`concurrency` opens that many browsers.** Which is what the option always described.
- **A shared cursor instead of fixed batches.** A batch waited for its slowest member before the next one started, so one heavy card idled every other worker until it finished.

## Result

160 images, same machine, alternating runs, **every run verified to have produced all 160 files**:

| concurrency | before | after | |
|---|---|---|---|
| default | 42.7 ms/img | 8.5 ms/img | **5.0x** |
| 1 | 67.2 | 23.0 | 2.9x |
| 2 | 43.5 | 12.7 | 3.4x |
| 4 | 31.3 | 9.8 | 3.2x |
| 8 | 28.0 | 9.5 | 2.9x |

Total for 160 images at the default: **6,825 ms → 1,357 ms**.

## Trade-off

The default stays `min(4, cores - 1)`, but those four workers are now four Chromium processes rather than four pages in one, so a build holds more memory during OG generation. `concurrency: 1` restores the old single-process footprint.

## Tests

`npm/vite-plugin-ox-content/src/og-image-pool.test.ts`:

- Five unit tests for the work distribution against fake sessions — results in input order however the sessions interleave, every item rendered exactly once, all sessions kept busy while one item is slow (the batching regression), a single session, and an empty list.
- One Chromium-gated integration test that renders six images and asserts six real PNGs. **This catches a bug I hit while writing the change**: `await using` disposes when the function returns, so returning the render promise instead of awaiting it closed every browser before the first render finished. Every page then failed with `Target page, context or browser has been closed` — reported per page and never thrown, so the build stayed green and produced nothing. Reintroducing the missing `await` fails this test.

The test file probes once for Chromium and skips that block where it is absent, so it runs everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790704443&installation_model_id=422833&pr_number=1232&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1232&signature=f8e4b13b9481db1008818a2acca2192bf16d4f980bc44c1093ca83346c931642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->