### PR TITLE
fix(ci): repair the editor extension publish under pnpm 12

### DIFF
--- a/.github/workflows/publish-editors.yml
+++ b/.github/workflows/publish-editors.yml
@@ -89,7 +89,15 @@ jobs:
           fi
           vp run vscode:build
           cd npm/vscode-ox-content
-          vp exec -- pnpm dlx @vscode/vsce package \
+          # pnpm 12 fails any install whose dependencies carry unapproved
+          # build scripts, and `pnpm dlx` installs outside the workspace, so
+          # the `allowBuilds` list in pnpm-workspace.yaml never reaches vsce's
+          # tree. The approval is accepted only as a CLI flag, so name the two
+          # packages here.
+          vp exec -- pnpm dlx \
+            --allow-build @vscode/vsce-sign \
+            --allow-build keytar \
+            @vscode/vsce package \
             --target "${{ matrix.vscode-target }}" \
             --out "../../dist/vscode/vscode-ox-content-${{ matrix.vscode-target }}.vsix" \
             --no-dependencies

--- a/scripts/publish-editor-extensions.ts
+++ b/scripts/publish-editor-extensions.ts
@@ -20,6 +20,12 @@ const initialDelayMs = 30_000;
 const maxDelayMs = 300_000;
 const vsixDir = "dist/vscode";
 
+// pnpm 12 fails any install whose dependencies carry unapproved build scripts,
+// and `pnpm dlx` installs outside the workspace, so the `allowBuilds` list in
+// pnpm-workspace.yaml never reaches these trees. The approval is accepted only
+// as a CLI flag; ovsx pulls vsce, so both registries need the same pair.
+const allowBuildFlags = ["@vscode/vsce-sign", "keytar"].flatMap((name) => ["--allow-build", name]);
+
 const registries: Record<string, Registry> = {
   "vscode-marketplace": {
     label: "VS Code Marketplace",
@@ -29,6 +35,7 @@ const registries: Record<string, Registry> = {
       "--",
       "pnpm",
       "dlx",
+      ...allowBuildFlags,
       "@vscode/vsce",
       "publish",
       "--skip-duplicate",
@@ -44,6 +51,7 @@ const registries: Record<string, Registry> = {
       "--",
       "pnpm",
       "dlx",
+      ...allowBuildFlags,
       "ovsx",
       "publish",
       vsix,


### PR DESCRIPTION
`Publish editor extensions` failed on the `v3.0.0-beta.1` tag, the first
tag since #1207 upgraded pnpm to v12. All four VSIX jobs died on
`ERR_PNPM_IGNORED_BUILDS`; the last green run was `v3.0.0-beta.0`. The
failure is outside `CI`, so nothing flagged it until the release.

Same shape as #1229. pnpm 12 fails an install whose dependencies carry
unapproved build scripts, and vsce's tree pulls `@vscode/vsce-sign` and
`keytar`. The `allowBuilds` list in `pnpm-workspace.yaml` does not reach
them because `pnpm dlx` installs outside the workspace, and the approval
is accepted only as a CLI flag, so both packages are named on the dlx
call.

`scripts/publish-editor-extensions.ts` needs the same treatment. It
shells out to `pnpm dlx @vscode/vsce publish` and `pnpm dlx ovsx
publish`, and ovsx pulls vsce, so both registries hit the identical
pair — fixing only the packaging step would have moved the failure one
job down as soon as a stable tag reaches a registry.

Verified against pnpm 12.1.0 that `--allow-build @vscode/vsce-sign
--allow-build keytar` clears the error for `@vscode/vsce` and `ovsx`
alike, and that neither `--ignore-scripts` (parsed as a package name by
`dlx`) nor a `--deny-build` counterpart exists as an alternative. A
packaging-only `workflow_dispatch` on this branch builds all four VSIXs
green again: linux-x64, darwin-x64, darwin-arm64, win32-x64.

This does not leave anything unpublished for v3.0.0-beta.1. Both
registries skip a prerelease regardless: the VS Code Marketplace publish
bails on prerelease semver by design, and Open VSX bails because
`OVSX_PAT` is not configured — the same two skips that made
`v3.0.0-beta.0` green. What the fix restores is the workflow itself,
which is red on every tag until it lands, and with it the VSIX
artifacts.