### PR TITLE
feat(vite-plugin): expose self-hosted asset contract

### DIFF
--- a/docs/content/built-in/icons.md
+++ b/docs/content/built-in/icons.md
@@ -59,5 +59,8 @@ an installed collection are not written to CSS.
 Generated CSS is written to `__ox_icons__/icons.css` and linked from the theme
 `<head>`, next to [self-hosted fonts](../theming.md#fonts). Existing
 `icon-[prefix--name]` markup can keep working while you migrate templates.
+Custom Vite hosts can import `virtual:ox-content/assets.css` or read
+`virtual:ox-content/asset-manifest`; the same stylesheet is served in dev and
+written during production builds.
 
 `false` or omitted keeps the current CDN fallback on entry-page Iconify icons.

--- a/docs/content/built-in/ssg-output.md
+++ b/docs/content/built-in/ssg-output.md
@@ -9,6 +9,7 @@ Custom hosts that set `ssg: false` keep their own page templates. They can
 still ask Ox Content to plan and emit:
 
 - content-addressed resource fingerprinting and URL rewriting
+- self-hosted font and Iconify asset files
 - Markdown companion files for host-rendered HTML pages
 - RSS / Atom / JSON feeds and sitemap metadata
 - git-derived `lastmod`
@@ -24,6 +25,7 @@ import {
   writeMarkdownCompanions,
   writeFeedFiles,
   writeSiteMapFiles,
+  writeSelfHostedAssets,
 } from "@ox-content/vite-plugin";
 
 const plan = planSsgOutputs({
@@ -55,6 +57,7 @@ const plan = planSsgOutputs({
 });
 
 await writeResourceFiles(plan.resources);
+await writeSelfHostedAssets(plan.selfHostedAssets);
 await writeMarkdownCompanions(plan.markdownCompanions);
 const feedFiles = await renderFeedFiles(plan.feeds);
 await writeFeedFiles(plan.feeds);
@@ -71,6 +74,7 @@ fields should still resolve.
 | ------------------------- | --------------------------------------------------------------------------------------- |
 | `planSsgOutputs`          | Build writer inputs from host pages and the same option objects `buildSsg()` reads.     |
 | `writeResourceFiles`      | Fingerprint page-bundle assets and rewrite host HTML URLs.                              |
+| `writeSelfHostedAssets`   | Write self-hosted `__ox_icons__` and `__ox_fonts__` files for a custom host.            |
 | `writeMarkdownCompanions` | Write original Markdown beside host-rendered pages. Reuses the copy-as-markdown writer. |
 | `renderFeedFiles`         | Render RSS / Atom / JSON feed files without filesystem writes.                          |
 | `writeFeedFiles`          | Write RSS / Atom / JSON feeds, including [named feeds](./feeds.md).                     |
@@ -83,7 +87,8 @@ or `siteMaps` is on, the planner calls `resolveGitLastmod(inputPath, root)`.
 Hosts can skip the planner and call a writer with the same resolved option
 objects `buildSsg()` already uses (`resolveResourcesOptions`,
 `resolveFeedsOptions`, `resolveSiteMapsOptions`,
-`resolveMarkdownSourceOptions`).
+`resolveMarkdownSourceOptions`). Use `resolveSelfHostedAssetManifest()` when a
+custom renderer needs the matching stylesheet and preload tags for `<head>`.
 
 ## Related
 

--- a/docs/content/ja/built-in/icons.md
+++ b/docs/content/ja/built-in/icons.md
@@ -60,6 +60,9 @@ oxContent({
 [セルフホストフォント](../theming.md#フォント) と同じアセット経路です。既存の
 `icon-[prefix--name]` マークアップは、テンプレートを一気に書き換えなくても
 動き続けます。
+独自 Vite ホストは `virtual:ox-content/assets.css` を import するか、
+`virtual:ox-content/asset-manifest` を読めます。同じ stylesheet が dev で配信され、
+本番 build で書き込まれます。
 
 `false` または省略では、エントリページの Iconify アイコンはこれまでどおり
 CDN フォールバックです。

--- a/docs/content/ja/built-in/ssg-output.md
+++ b/docs/content/ja/built-in/ssg-output.md
@@ -9,6 +9,7 @@ description: 既定テーマなしで、リソース・Markdown 併記・フィ�
 Ox Content に次の出力の計画と書き出しを任せられます。
 
 - コンテンツアドレスのリソース指紋と URL 書き換え
+- セルフホストフォントと Iconify アセットファイル
 - ホストが描画した HTML ページ向けの Markdown 併記
 - RSS / Atom / JSON フィードと sitemap メタデータ
 - git 由来の `lastmod`
@@ -24,6 +25,7 @@ import {
   writeMarkdownCompanions,
   writeFeedFiles,
   writeSiteMapFiles,
+  writeSelfHostedAssets,
 } from "@ox-content/vite-plugin";
 
 const plan = planSsgOutputs({
@@ -55,6 +57,7 @@ const plan = planSsgOutputs({
 });
 
 await writeResourceFiles(plan.resources);
+await writeSelfHostedAssets(plan.selfHostedAssets);
 await writeMarkdownCompanions(plan.markdownCompanions);
 const feedFiles = await renderFeedFiles(plan.feeds);
 await writeFeedFiles(plan.feeds);
@@ -71,6 +74,7 @@ boolean の `ssg: false` は SSG を切ると同時に `markdownSource`、
 | ------------------------- | ------------------------------------------------------------------------------------- |
 | `planSsgOutputs`          | ホストのページと `buildSsg()` と同じオプションから writer 入力を作る。                |
 | `writeResourceFiles`      | ページバンドル資産に指紋を付け、ホスト HTML の URL を書き換える。                     |
+| `writeSelfHostedAssets`   | 独自ホスト向けに `__ox_icons__` と `__ox_fonts__` のファイルを書く。                  |
 | `writeMarkdownCompanions` | ホスト描画ページの横に元の Markdown を書く。copy-as-markdown の writer を再利用する。 |
 | `renderFeedFiles`         | filesystem に書かずに RSS / Atom / JSON フィードファイルを描画する。                  |
 | `writeFeedFiles`          | RSS / Atom / JSON フィードを書く。[名前付きフィード](./feeds.md) も含む。             |
@@ -84,7 +88,8 @@ boolean の `ssg: false` は SSG を切ると同時に `markdownSource`、
 プランナーを使わず、`buildSsg()` と同じ解決済みオプション
 （`resolveResourcesOptions`、`resolveFeedsOptions`、
 `resolveSiteMapsOptions`、`resolveMarkdownSourceOptions`）で writer を
-直接呼ぶこともできます。
+直接呼ぶこともできます。独自 renderer が `<head>` 用の stylesheet / preload
+タグを必要とするときは `resolveSelfHostedAssetManifest()` を使います。
 
 ## 関連
 

--- a/docs/content/ja/theming.md
+++ b/docs/content/ja/theming.md
@@ -255,6 +255,51 @@ fonts: {
 
 `selfHost: true` がないオブジェクトは CSS スタックだけを設定し、ファイルの取得や出力はしません。
 
+### 独自ホストでのセルフホストアセット
+
+組み込み SSG テーマは、セルフホストフォントと Iconify CSS を自動で `<head>` に
+リンクします。独自ホストは document shell を自分で持つので、Vite の virtual
+asset contract を使います。
+
+```ts
+import "virtual:ox-content/assets.css";
+
+// または、server renderer が <head> を持つ場合:
+import { headTags } from "virtual:ox-content/asset-manifest";
+```
+
+クライアント entry が stylesheet を管理するなら CSS import を使います。サーバ
+renderer が `<head>` を持つなら `headTags`（または `stylesheets` と
+`preloads`）を使います。どちらも組み込みテーマと同じ `__ox_fonts__` /
+`__ox_icons__` URL を使い、dev で配信され、本番 build ではローカルアセットを
+書きます。
+
+Ox Content がページを描画しない場合でも、plugin から theme が見える形にしてください。
+
+```ts
+oxContent({
+  icons: { safelist: ["carbon:checkbox"] },
+  ssg: {
+    enabled: false,
+    theme: {
+      fonts: {
+        sans: {
+          family: "Inter",
+          provider: "local",
+          path: "@fontsource/inter",
+          weights: [400, 600],
+          selfHost: true,
+        },
+      },
+    },
+  },
+});
+```
+
+boolean の `ssg: false` でも SSG は無効になりますが、theme を運ぶ場所がありません。
+bare / 独自 Vite ホストでセルフホストアセットを使う場合は
+`ssg: { enabled: false, theme }` にしてください。
+
 セットしたキーだけが出ます。省略した色、フォント、レイアウトは [既定テーマの値](#既定テーマの値) に落ちるので、アクセント 1 つを上書きするためにパレット全体を書き直す必要はありません。
 
 ## ダークモード

--- a/docs/content/theming.md
+++ b/docs/content/theming.md
@@ -294,6 +294,51 @@ fonts: {
 Object families without `selfHost: true` only set the CSS stack; they do not
 download or emit font files.
 
+### Self-hosted assets in a custom host
+
+The built-in SSG theme links self-hosted fonts and Iconify CSS automatically.
+Custom hosts own their document shell, so they can use the Vite virtual asset
+contract instead:
+
+```ts
+import "virtual:ox-content/assets.css";
+
+// Or, when the server renderer owns <head>:
+import { headTags } from "virtual:ox-content/asset-manifest";
+```
+
+Use the CSS import when the host's client entry owns styles. Use `headTags` (or
+the exported `stylesheets` and `preloads`) when the server renderer owns
+`<head>`. Both paths use the same `__ox_fonts__` and `__ox_icons__` URLs as the
+built-in theme, work in dev, and write local assets during production builds.
+
+Keep the theme visible to the plugin even when Ox Content is not rendering
+pages:
+
+```ts
+oxContent({
+  icons: { safelist: ["carbon:checkbox"] },
+  ssg: {
+    enabled: false,
+    theme: {
+      fonts: {
+        sans: {
+          family: "Inter",
+          provider: "local",
+          path: "@fontsource/inter",
+          weights: [400, 600],
+          selfHost: true,
+        },
+      },
+    },
+  },
+});
+```
+
+Boolean `ssg: false` still disables SSG, but it has no place to carry the
+theme. Use `ssg: { enabled: false, theme }` for self-hosted assets in a
+bare/custom Vite host.
+
 Only the keys you set are emitted. Omitted colors, fonts, and layout values fall
 back to the [default theme](#default-theme-values), so overriding a single accent
 never forces you to redeclare the rest of the palette.

--- a/npm/vite-plugin-ox-content/src/assets.test.ts
+++ b/npm/vite-plugin-ox-content/src/assets.test.ts
@@ -1,0 +1,222 @@
+import * as fs from "node:fs/promises";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { build as viteBuild, createServer, type InlineConfig, type ViteDevServer } from "vite";
+import { oxContent, type OxContentOptions } from ".";
+import { resolveSelfHostedAssetManifest, writeSelfHostedAssets } from "./assets";
+import { resolveOptions } from "./resolve-options";
+
+const fixtureFont = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "fixtures",
+  "ox-test-font.woff2",
+);
+const tempDirs: string[] = [];
+const activeServers: ViteDevServer[] = [];
+const activeListeners: http.Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(activeListeners.splice(0).map((server) => closeHttpServer(server)));
+  await Promise.all(activeServers.splice(0).map((server) => server.close().catch(() => {})));
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("self-hosted asset contract", () => {
+  it("publishes stable head metadata for custom hosts", () => {
+    const manifest = resolveSelfHostedAssetManifest(assetOptions("/docs/"));
+
+    expect(manifest.stylesheets).toEqual([
+      "/docs/__ox_icons__/icons.css",
+      "/docs/__ox_fonts__/fonts.css",
+    ]);
+    expect(manifest.preloads).toEqual([
+      {
+        href: "/docs/__ox_fonts__/ox-test-400-normal-latin.woff2",
+        as: "font",
+        type: "font/woff2",
+        crossorigin: true,
+      },
+    ]);
+    expect(manifest.headTags).toContain(
+      '<link rel="stylesheet" href="/docs/__ox_icons__/icons.css">',
+    );
+    expect(manifest.headTags).toContain('href="/docs/__ox_fonts__/ox-test-400-normal-latin.woff2"');
+  });
+
+  it("writes the same icon and font assets without buildSsg", async () => {
+    const root = await createProject("ox-assets-write-");
+    const outDir = path.join(root, "dist");
+
+    const result = await writeSelfHostedAssets({ options: assetOptions("/", root), root, outDir });
+
+    expect(result.errors).toEqual([]);
+    expect(result.files).toEqual(
+      expect.arrayContaining([
+        path.join(outDir, "__ox_icons__", "icons.css"),
+        path.join(outDir, "__ox_fonts__", "fonts.css"),
+        path.join(outDir, "__ox_fonts__", "ox-test-400-normal-latin.woff2"),
+      ]),
+    );
+    expect(await fs.readFile(path.join(outDir, "__ox_icons__", "icons.css"), "utf8")).toContain(
+      "icon-\\[ox--mark\\]",
+    );
+    expect(await fs.readFile(path.join(outDir, "__ox_fonts__", "fonts.css"), "utf8")).not.toMatch(
+      /fonts\.(?:googleapis|gstatic)\.com/,
+    );
+  });
+
+  it("serves and builds assets for an ssg-disabled custom Vite host", async () => {
+    const root = await createProject("ox-assets-vite-");
+    const server = await trackDevServer(createServer(viteConfig(root)));
+    const listener = await listen(server);
+
+    const [iconCss, fontCss, fontBytes] = await Promise.all([
+      readDevAsset(listener.port, "/__ox_icons__/icons.css"),
+      readDevAsset(listener.port, "/__ox_fonts__/fonts.css"),
+      readDevAsset(listener.port, "/__ox_fonts__/ox-test-400-normal-latin.woff2"),
+    ]);
+
+    expect(iconCss.text).toContain("icon-\\[ox--mark\\]");
+    expect(iconCss.text).not.toContain("api.iconify.design");
+    expect(fontCss.text).toContain('font-family: "Ox Test"');
+    expect(fontCss.text).not.toMatch(/fonts\.(?:googleapis|gstatic)\.com/);
+    expect(fontBytes.bytes.length).toBeGreaterThan(0);
+
+    await server.close();
+    await viteBuild(viteConfig(root));
+
+    const distIconCss = await fs.readFile(
+      path.join(root, "dist", "__ox_icons__", "icons.css"),
+      "utf8",
+    );
+    const distFont = await fs.readFile(
+      path.join(root, "dist", "__ox_fonts__", "ox-test-400-normal-latin.woff2"),
+    );
+    const builtClient = await readBuiltClient(root);
+
+    expect(distIconCss).toContain("icon-\\[ox--mark\\]");
+    expect(distFont.length).toBeGreaterThan(0);
+    expect(builtClient).toContain("__ox_icons__/icons.css");
+    expect(builtClient).toContain("headTags");
+  });
+});
+
+async function createProject(prefix: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(root);
+  await writeFixtureCollection(root);
+  await fs.mkdir(path.join(root, "content"), { recursive: true });
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.writeFile(path.join(root, "content", "index.md"), "# Home\n");
+  await fs.writeFile(
+    path.join(root, "index.html"),
+    '<div id="app"></div><script type="module" src="/src/main.js"></script>\n',
+  );
+  await fs.writeFile(
+    path.join(root, "src", "main.js"),
+    [
+      'import "virtual:ox-content/assets.css";',
+      'import { headTags } from "virtual:ox-content/asset-manifest";',
+      'document.head.insertAdjacentHTML("beforeend", headTags);',
+      'document.querySelector("#app").innerHTML = "<span class=\\"icon-[ox--mark]\\"></span>";',
+    ].join("\n"),
+  );
+  return root;
+}
+
+async function writeFixtureCollection(root: string): Promise<void> {
+  const dir = path.join(root, "node_modules", "@iconify-json", "ox");
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await fs.writeFile(
+    path.join(dir, "icons.json"),
+    JSON.stringify({
+      prefix: "ox",
+      width: 24,
+      height: 24,
+      icons: { mark: { body: '<path fill="currentColor" d="M2 2h20v20H2z"/>' } },
+    }),
+  );
+}
+
+function assetOptions(base = "/", root = process.cwd()) {
+  return resolveOptions(assetInputOptions(base, root));
+}
+
+function assetInputOptions(base = "/", root = process.cwd()): OxContentOptions {
+  return {
+    base,
+    srcDir: "content",
+    icons: { safelist: ["ox:mark"] },
+    ssg: {
+      enabled: false,
+      theme: {
+        fonts: {
+          sans: {
+            family: "Ox Test",
+            provider: "local",
+            path: fixtureFont,
+            weights: [400],
+            selfHost: true,
+            preload: true,
+          },
+        },
+      },
+    },
+    outDir: path.join(root, "dist"),
+    search: false,
+    ogViewer: false,
+  };
+}
+
+function viteConfig(root: string): InlineConfig {
+  return {
+    root,
+    configFile: false,
+    logLevel: "silent",
+    appType: "custom",
+    plugins: oxContent(assetInputOptions("/", root)),
+    build: { outDir: "dist", emptyOutDir: true },
+  };
+}
+
+async function trackDevServer(serverPromise: Promise<ViteDevServer>): Promise<ViteDevServer> {
+  const server = await serverPromise;
+  activeServers.push(server);
+  return server;
+}
+
+async function listen(server: ViteDevServer): Promise<{ port: number }> {
+  const listener = http.createServer(server.middlewares);
+  activeListeners.push(listener);
+  await new Promise<void>((resolve) => listener.listen(0, "127.0.0.1", resolve));
+  const address = listener.address() as AddressInfo;
+  return { port: address.port };
+}
+
+async function readDevAsset(port: number, assetPath: string) {
+  const response = await fetch(`http://127.0.0.1:${port}${assetPath}`);
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  expect(response.status).toBe(200);
+  return { bytes, text: new TextDecoder().decode(bytes) };
+}
+
+async function readBuiltClient(root: string): Promise<string> {
+  const assetsDir = path.join(root, "dist", "assets");
+  const files = await fs.readdir(assetsDir);
+  const jsFile = files.find((file) => file.endsWith(".js"));
+  if (!jsFile) {
+    throw new Error("Expected a built client asset.");
+  }
+  return fs.readFile(path.join(assetsDir, jsFile), "utf8");
+}
+
+function closeHttpServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}

--- a/npm/vite-plugin-ox-content/src/assets.ts
+++ b/npm/vite-plugin-ox-content/src/assets.ts
@@ -1,0 +1,330 @@
+import * as fs from "node:fs/promises";
+import type { IncomingMessage } from "node:http";
+import * as path from "node:path";
+import type { Plugin, ResolvedConfig } from "vite";
+import {
+  ICON_ASSET_DIR,
+  iconStylesheetHref,
+  renderSelfHostedIconsCss,
+  writeSelfHostedIcons,
+} from "./icons";
+import {
+  FONT_ASSET_DIR,
+  normalizeBasePath,
+  planSelfHostedFaces,
+  themeFontStylesheetHref,
+  writeSelfHostedThemeFonts,
+  type ThemeFontsLike,
+} from "./theme-fonts";
+import { fontMime, renderFontFaceCss, type AcquiredSelfHostFace } from "./theme-fonts-acquire";
+import type { ResolvedOptions } from "./types";
+
+const ASSETS_CSS_ID = "\0virtual:ox-content/assets.css";
+const ASSET_MANIFEST_ID = "\0virtual:ox-content/asset-manifest";
+
+export interface OxContentAssetPreload {
+  href: string;
+  as: "font";
+  type: string;
+  crossorigin: true;
+}
+
+export interface OxContentAssetManifest {
+  stylesheets: string[];
+  preloads: OxContentAssetPreload[];
+  headTags: string;
+}
+
+export type SelfHostedAssetOptions = Pick<ResolvedOptions, "base" | "srcDir" | "icons" | "ssg">;
+
+export interface WriteSelfHostedAssetsInput {
+  options: SelfHostedAssetOptions;
+  outDir: string;
+  root?: string;
+  cacheDir?: string;
+}
+
+export interface WriteSelfHostedAssetsResult {
+  files: string[];
+  errors: string[];
+}
+
+export interface RenderSelfHostedAssetsCssResult {
+  css: string;
+  errors: string[];
+}
+
+export function resolveSelfHostedAssetManifest(
+  options: SelfHostedAssetOptions,
+): OxContentAssetManifest {
+  const base = options.base;
+  const stylesheets: string[] = [];
+  const preloads: OxContentAssetPreload[] = [];
+
+  if (options.icons?.enabled) {
+    stylesheets.push(iconStylesheetHref(base));
+  }
+
+  const fontFaces = planSelfHostedFaces(assetFonts(options));
+  if (fontFaces.length > 0) {
+    stylesheets.push(themeFontStylesheetHref(base));
+    const root = normalizeBasePath(base);
+    for (const face of fontFaces) {
+      if (face.preload) {
+        preloads.push({
+          href: `${root}${FONT_ASSET_DIR}/${face.fileName}`,
+          as: "font",
+          type: fontMime(face.fileName),
+          crossorigin: true,
+        });
+      }
+    }
+  }
+
+  const headTags = [
+    ...stylesheets.map((href) => `<link rel="stylesheet" href="${href}">`),
+    ...preloads.map(
+      (item) =>
+        `<link rel="preload" href="${item.href}" as="${item.as}" type="${item.type}" crossorigin>`,
+    ),
+  ].join("\n");
+
+  return { stylesheets, preloads, headTags };
+}
+
+export async function writeSelfHostedAssets(
+  input: WriteSelfHostedAssetsInput,
+): Promise<WriteSelfHostedAssetsResult> {
+  const root = input.root ?? process.cwd();
+  const files: string[] = [];
+  const errors: string[] = [];
+  const fonts = assetFonts(input.options);
+
+  if (planSelfHostedFaces(fonts).length > 0) {
+    files.push(
+      ...(await writeSelfHostedThemeFonts({
+        fonts,
+        outDir: input.outDir,
+        root,
+        cacheDir: input.cacheDir,
+      })),
+    );
+  }
+
+  if (input.options.icons?.enabled) {
+    const icons = await writeSelfHostedIcons({
+      options: input.options.icons,
+      outDir: input.outDir,
+      root,
+      srcDir: path.resolve(root, input.options.srcDir),
+      socialLinks: input.options.ssg.theme?.socialLinks,
+    });
+    files.push(...icons.files);
+    errors.push(...icons.errors);
+  }
+
+  return { files, errors };
+}
+
+export async function renderSelfHostedAssetsCss(
+  options: SelfHostedAssetOptions,
+  root = process.cwd(),
+): Promise<RenderSelfHostedAssetsCssResult> {
+  const css: string[] = [];
+  const errors: string[] = [];
+  const fonts = assetFonts(options);
+  const faces = planSelfHostedFaces(fonts);
+
+  if (faces.length > 0) {
+    css.push(
+      renderFontFaceCss(
+        faces.map((face) => ({ ...face, bytes: new Uint8Array() }) satisfies AcquiredSelfHostFace),
+        { urlPrefix: `${normalizeBasePath(options.base)}${FONT_ASSET_DIR}/` },
+      ),
+    );
+  }
+
+  if (options.icons?.enabled) {
+    const icons = await renderSelfHostedIconsCss({
+      options: options.icons,
+      root,
+      srcDir: path.resolve(root, options.srcDir),
+      socialLinks: options.ssg.theme?.socialLinks,
+    });
+    css.push(icons.css);
+    errors.push(...icons.errors);
+  }
+
+  return {
+    css: css.length > 0 ? `${css.join("\n\n")}\n` : "/* ox-content: no self-hosted assets */\n",
+    errors,
+  };
+}
+
+export function createAssetsPlugin(
+  options: ResolvedOptions,
+  getRoot: () => string,
+  getConfig: () => ResolvedConfig | undefined,
+): Plugin {
+  let devWrite: Promise<WriteSelfHostedAssetsResult> | undefined;
+
+  return {
+    name: "ox-content:assets",
+
+    resolveId(id) {
+      if (id === "virtual:ox-content/assets.css") {
+        return ASSETS_CSS_ID;
+      }
+      if (id === "virtual:ox-content/asset-manifest") {
+        return ASSET_MANIFEST_ID;
+      }
+      return null;
+    },
+
+    async load(id) {
+      if (id === ASSETS_CSS_ID) {
+        const result = await renderSelfHostedAssetsCss(options, getRoot());
+        for (const error of result.errors) {
+          this.warn(error);
+        }
+        return result.css;
+      }
+      if (id === ASSET_MANIFEST_ID) {
+        return generateAssetManifestModule(resolveSelfHostedAssetManifest(options));
+      }
+      return null;
+    },
+
+    configureServer(server) {
+      const root = getRoot();
+      const outDir = path.join(resolveConfigDir(root, server.config.cacheDir), "ox-content-assets");
+      const cacheDir = path.join(outDir, ".font-cache");
+      const ensureWritten = () => {
+        devWrite ??= writeSelfHostedAssets({ options, outDir, root, cacheDir });
+        return devWrite;
+      };
+
+      server.watcher.on("all", () => {
+        devWrite = undefined;
+      });
+      server.middlewares.use(async (req, res, next) => {
+        const rel = assetRequestPath(req, options.base);
+        if (!rel || (req.method !== "GET" && req.method !== "HEAD")) {
+          next();
+          return;
+        }
+        try {
+          await ensureWritten();
+          const file = resolveAssetFile(outDir, rel);
+          if (!file) {
+            next();
+            return;
+          }
+          const bytes = await fs.readFile(file).catch(() => undefined);
+          if (!bytes) {
+            next();
+            return;
+          }
+          res.statusCode = 200;
+          res.setHeader("Content-Type", contentType(rel));
+          if (req.method === "HEAD") {
+            res.end();
+          } else {
+            res.end(bytes);
+          }
+        } catch (error) {
+          res.statusCode = 500;
+          res.end(error instanceof Error ? error.message : String(error));
+        }
+      });
+    },
+
+    async closeBundle() {
+      const config = getConfig();
+      const root = getRoot();
+      const outDir = resolveBuildOutDir(config, options, root);
+      const result = await writeSelfHostedAssets({ options, outDir, root });
+      for (const error of result.errors) {
+        this.warn(error);
+      }
+    },
+  };
+}
+
+function assetFonts(options: SelfHostedAssetOptions): ThemeFontsLike {
+  return options.ssg.theme?.fonts ?? {};
+}
+
+function generateAssetManifestModule(manifest: OxContentAssetManifest): string {
+  const json = JSON.stringify(manifest);
+  return [
+    `const manifest = ${json};`,
+    "export const stylesheets = manifest.stylesheets;",
+    "export const preloads = manifest.preloads;",
+    "export const headTags = manifest.headTags;",
+    "export default manifest;",
+  ].join("\n");
+}
+
+function assetRequestPath(req: IncomingMessage, base: string): string | undefined {
+  const rawUrl = req.url;
+  if (!rawUrl) {
+    return undefined;
+  }
+  const pathname = new URL(rawUrl, "http://ox-content.local").pathname;
+  const normalizedBase = normalizeBasePath(base);
+  const rel =
+    normalizedBase === "/"
+      ? pathname.slice(1)
+      : pathname.startsWith(normalizedBase)
+        ? pathname.slice(normalizedBase.length)
+        : "";
+  if (!rel || !isSafeAssetPath(rel)) {
+    return undefined;
+  }
+  return rel;
+}
+
+function isSafeAssetPath(rel: string): boolean {
+  const first = rel.split("/")[0];
+  if (first !== ICON_ASSET_DIR && first !== FONT_ASSET_DIR) {
+    return false;
+  }
+  return (
+    !rel.includes("\0") &&
+    !rel.includes("\\") &&
+    path.posix.normalize(rel) === rel &&
+    !path.posix.isAbsolute(rel)
+  );
+}
+
+function resolveAssetFile(outDir: string, rel: string): string | undefined {
+  const file = path.resolve(outDir, ...rel.split("/"));
+  const root = path.resolve(outDir);
+  const prefix = `${root}${path.sep}`;
+  return file.startsWith(prefix) ? file : undefined;
+}
+
+function contentType(rel: string): string {
+  if (rel.endsWith(".css")) {
+    return "text/css; charset=utf-8";
+  }
+  if (rel.startsWith(`${FONT_ASSET_DIR}/`)) {
+    return fontMime(rel);
+  }
+  return "application/octet-stream";
+}
+
+function resolveBuildOutDir(
+  config: ResolvedConfig | undefined,
+  options: ResolvedOptions,
+  root: string,
+): string {
+  return config?.build.outDir
+    ? resolveConfigDir(root, config.build.outDir)
+    : path.resolve(root, options.outDir);
+}
+
+function resolveConfigDir(root: string, dir: string): string {
+  return path.isAbsolute(dir) ? dir : path.resolve(root, dir);
+}

--- a/npm/vite-plugin-ox-content/src/icons.ts
+++ b/npm/vite-plugin-ox-content/src/icons.ts
@@ -181,6 +181,31 @@ export interface WriteSelfHostedIconsResult {
   names: string[];
 }
 
+export interface RenderSelfHostedIconsCssOptions {
+  options: ResolvedIconsOptions;
+  root: string;
+  srcDir?: string;
+  socialLinks?: unknown;
+}
+
+export interface RenderSelfHostedIconsCssResult {
+  css: string;
+  errors: string[];
+  names: string[];
+}
+
+/** Render resolved icon CSS. Missing collections or names become errors. */
+export async function renderSelfHostedIconsCss(
+  input: RenderSelfHostedIconsCssOptions,
+): Promise<RenderSelfHostedIconsCssResult> {
+  if (!input.options.enabled) {
+    return { css: "", errors: [], names: [] };
+  }
+  const names = await collectResolvedIconNames(input);
+  const { icons, errors } = await resolveIconBodies(names, input.root);
+  return { css: renderIconsCss(icons), errors, names };
+}
+
 /** Copy resolved icon CSS into `outDir`. Missing collections or names become errors. */
 export async function writeSelfHostedIcons(
   input: WriteSelfHostedIconsOptions,
@@ -188,18 +213,17 @@ export async function writeSelfHostedIcons(
   if (!input.options.enabled) {
     return { files: [], errors: [], names: [] };
   }
-  const names = await collectResolvedIconNames(input);
-  const { icons, errors } = await resolveIconBodies(names, input.root);
+  const result = await renderSelfHostedIconsCss(input);
   const destDir = join(input.outDir, ICON_ASSET_DIR);
   await mkdir(destDir, { recursive: true });
   const cssPath = join(destDir, ICON_CSS_NAME);
-  await writeFile(cssPath, renderIconsCss(icons), "utf8");
-  return { files: [cssPath], errors, names };
+  await writeFile(cssPath, result.css, "utf8");
+  return { files: [cssPath], errors: result.errors, names: result.names };
 }
 
 export { iconClassName };
 
-async function collectResolvedIconNames(input: WriteSelfHostedIconsOptions): Promise<string[]> {
+async function collectResolvedIconNames(input: RenderSelfHostedIconsCssOptions): Promise<string[]> {
   const names = new Set<string>();
   for (const item of input.options.safelist) {
     addName(names, item);

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -25,6 +25,7 @@ import {
 } from "./dev-server";
 import { createOgViewerPlugin } from "./og-viewer";
 import { createI18nPlugin } from "./i18n";
+import { createAssetsPlugin } from "./assets";
 import { isMarkdownFilePath } from "./markdown";
 import { generateCollectionsVirtualModule } from "./collections";
 import type { OxContentOptions, ResolvedOptions } from "./types";
@@ -249,6 +250,7 @@ export function oxContent(options: OxContentOptions = {}): Plugin[] {
     createEnvironmentPlugin(resolvedOptions),
     createDocsPlugin(resolvedOptions, getRoot),
     createSsgPlugin(resolvedOptions, getRoot, ssgDevCache),
+    createAssetsPlugin(resolvedOptions, getRoot, () => config),
     createCollectionsPlugin(resolvedOptions, getRoot),
     createSearchPlugin(resolvedOptions, getRoot),
   ];
@@ -930,6 +932,15 @@ export { resolvePwaOptions } from "./pwa";
 export { resolveTaxonomiesOptions } from "./taxonomies";
 export { resolveVersionsOptions } from "./versions";
 export { resolveResourcesOptions, PageResourceError } from "./resources";
+export {
+  resolveSelfHostedAssetManifest,
+  writeSelfHostedAssets,
+  type OxContentAssetManifest,
+  type OxContentAssetPreload,
+  type SelfHostedAssetOptions,
+  type WriteSelfHostedAssetsInput,
+  type WriteSelfHostedAssetsResult,
+} from "./assets";
 export { resolveTeamOptions } from "./team";
 export { resolveSectionIndexOptions } from "./section-index";
 export { resolveSearchOptions, buildSearchIndex, writeSearchIndex } from "./search";

--- a/npm/vite-plugin-ox-content/src/public-exports.test.ts
+++ b/npm/vite-plugin-ox-content/src/public-exports.test.ts
@@ -42,6 +42,7 @@ describe("public export surface", () => {
       "readerChromeCss",
       "readerChromeIsEnabled",
       "readerChromeNeedsJs",
+      "resolveSelfHostedAssetManifest",
       "readerChromeScript",
       "renderReaderChromeAttributes",
       "renderReaderChromeScriptTag",
@@ -78,6 +79,7 @@ describe("public export surface", () => {
       "writeMarkdownCompanions",
       "writeResourceFiles",
       "writeSearchIndex",
+      "writeSelfHostedAssets",
       "writeSiteMapFiles",
     ].sort();
 

--- a/npm/vite-plugin-ox-content/src/ssg-output.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg-output.test.ts
@@ -38,7 +38,7 @@ describe("planSsgOutputs", () => {
       ],
     });
 
-    expect(plan.resources.options.enabled).toBe(false);
+    expect(plan.resources.options?.enabled).toBe(false);
     expect(plan.resources.pages).toEqual([]);
     expect(plan.markdownCompanions.options.enabled).toBe(false);
     expect(plan.markdownCompanions.pages).toEqual([]);
@@ -87,6 +87,64 @@ describe("planSsgOutputs", () => {
       lastUpdated: 1_704_067_200_000,
     });
     expect(plan.siteMaps.pages[1]?.draft).toBe(true);
+  });
+
+  it("keeps self-hosted assets available for host-rendered pages", () => {
+    const plan = planSsgOutputs({
+      outDir: "/site/dist",
+      root: "/site",
+      srcDir: "content",
+      options: {
+        base: "/docs/",
+        icons: { safelist: ["mdi:github"] },
+        ssg: {
+          enabled: false,
+          theme: {
+            fonts: {
+              sans: {
+                family: "Ox Test",
+                provider: "local",
+                path: "./fonts/ox-test.woff2",
+                selfHost: true,
+                preload: true,
+              },
+            },
+            socialLinks: [{ icon: "mdi:discord", link: "https://discord.example" }],
+          },
+        },
+      },
+      pages: [],
+    });
+
+    expect(plan.selfHostedAssets).toMatchObject({
+      outDir: "/site/dist",
+      root: "/site",
+      options: {
+        base: "/docs/",
+        srcDir: "content",
+        icons: {
+          enabled: true,
+          mode: "css-mask",
+          syntax: "unocss",
+          include: [],
+          safelist: ["mdi:github"],
+        },
+        ssg: {
+          enabled: false,
+          theme: {
+            fonts: {
+              sans: {
+                family: "Ox Test",
+                path: "./fonts/ox-test.woff2",
+                selfHost: true,
+                preload: true,
+              },
+            },
+            socialLinks: [{ icon: "mdi:discord", link: "https://discord.example" }],
+          },
+        },
+      },
+    });
   });
 });
 

--- a/npm/vite-plugin-ox-content/src/ssg-output.ts
+++ b/npm/vite-plugin-ox-content/src/ssg-output.ts
@@ -6,11 +6,18 @@
  */
 
 import { renderFeedFiles, resolveFeedsOptions, writeFeedFiles, type FeedItemInput } from "./feeds";
+import { resolveIconsOptions } from "./icons";
 import { shouldPublishMarkdownSource, type MarkdownSourcePageInput } from "./markdown-source";
 import { resolvePublishStateOptions } from "./publish-state";
 import { resolveResourcesOptions } from "./resources";
 import { resolveSiteMapsOptions, writeSiteMapFiles, type SiteMapPageInput } from "./site-maps";
 import { resolveSsgOptions } from "./ssg";
+import {
+  writeSelfHostedAssets,
+  type SelfHostedAssetOptions,
+  type WriteSelfHostedAssetsInput,
+  type WriteSelfHostedAssetsResult,
+} from "./assets";
 import {
   resolveGitLastmod,
   writeMarkdownCompanions,
@@ -20,6 +27,7 @@ import {
 } from "./ssg-output-write";
 import type {
   FeedsOptions,
+  IconsOptions,
   OxContentOptions,
   PublishStateOptions,
   ResolvedFeedsOptions,
@@ -39,8 +47,10 @@ export {
   writeFeedFiles,
   writeMarkdownCompanions,
   writeResourceFiles,
+  writeSelfHostedAssets,
   writeSiteMapFiles,
 };
+export type { SelfHostedAssetOptions, WriteSelfHostedAssetsInput, WriteSelfHostedAssetsResult };
 export type {
   FeedItemInput,
   WriteMarkdownSourceFilesInput,
@@ -61,6 +71,7 @@ export type { SsgOutputPageInput } from "./types";
 /** Same option objects `oxContent()` / `buildSsg()` accept. `ssg.enabled` is ignored. */
 export interface PlanSsgOutputsOptions {
   base?: string;
+  icons?: boolean | IconsOptions;
   resources?: boolean | ResourcesOptions;
   feeds?: boolean | FeedsOptions;
   siteMaps?: boolean | SiteMapsOptions;
@@ -83,6 +94,7 @@ export interface PlanSsgOutputsInput {
 
 /** Planned writer inputs. Call the matching `write*` function for each feature. */
 export interface SsgOutputPlan {
+  selfHostedAssets: WriteSelfHostedAssetsInput;
   resources: WriteResourceFilesInput;
   markdownCompanions: {
     outDir: string;
@@ -123,6 +135,7 @@ export interface SsgOutputPlan {
 export function planSsgOutputs(input: PlanSsgOutputsInput): SsgOutputPlan {
   const raw = input.options ?? {};
   const ssg = resolveSsgOptions(raw.ssg);
+  const icons = resolveIconsOptions(raw.icons);
   const resources = resolveResourcesOptions(raw.resources);
   const feeds = resolveFeedsOptions(raw.feeds);
   const siteMaps = resolveSiteMapsOptions(raw.siteMaps);
@@ -132,6 +145,16 @@ export function planSsgOutputs(input: PlanSsgOutputsInput): SsgOutputPlan {
   const lastmod = ssg.lastUpdated || siteMaps.enabled;
 
   return {
+    selfHostedAssets: {
+      outDir: input.outDir,
+      root: input.root,
+      options: {
+        base,
+        srcDir: input.srcDir ?? "",
+        icons,
+        ssg,
+      },
+    },
     resources: {
       pages: resourcePages(input.pages, resources),
       srcDir: input.srcDir ?? "",

--- a/npm/vite-plugin-ox-content/src/theme-fonts-acquire.ts
+++ b/npm/vite-plugin-ox-content/src/theme-fonts-acquire.ts
@@ -34,7 +34,10 @@ export function fontMime(fileName: string): string {
   return "font/woff2";
 }
 
-export function renderFontFaceCss(faces: AcquiredSelfHostFace[]): string {
+export function renderFontFaceCss(
+  faces: AcquiredSelfHostFace[],
+  options: { urlPrefix?: string } = {},
+): string {
   return faces
     .map((face) => {
       const range = face.unicodeRange ? `\n  unicode-range: ${face.unicodeRange};` : "";
@@ -54,7 +57,7 @@ export function renderFontFaceCss(faces: AcquiredSelfHostFace[]): string {
   font-style: ${face.style};
   font-weight: ${face.weight};
   font-display: ${face.display};
-  src: url(./${fileName}) format("${format}");${range}
+  src: url(${options.urlPrefix ?? "./"}${fileName}) format("${format}");${range}
 }`;
     })
     .join("\n\n");

--- a/npm/vite-plugin-ox-content/src/theme-fonts.ts
+++ b/npm/vite-plugin-ox-content/src/theme-fonts.ts
@@ -220,7 +220,7 @@ export function themeFontHeadHtml(fonts: ThemeFontsLike, base?: string): string 
     return "";
   }
   const root = normalizeBasePath(base);
-  const tags = [`<link rel="stylesheet" href="${root}${FONT_ASSET_DIR}/${FONT_CSS_NAME}">`];
+  const tags = [`<link rel="stylesheet" href="${themeFontStylesheetHref(base)}">`];
   for (const face of faces) {
     if (!face.preload) {
       continue;
@@ -230,6 +230,10 @@ export function themeFontHeadHtml(fonts: ThemeFontsLike, base?: string): string 
     );
   }
   return tags.join("\n");
+}
+
+export function themeFontStylesheetHref(base?: string): string {
+  return `${normalizeBasePath(base)}${FONT_ASSET_DIR}/${FONT_CSS_NAME}`;
 }
 
 export function withSelfHostedFontHead<T extends { head?: string }>(

--- a/npm/vite-plugin-ox-content/src/virtual.ts
+++ b/npm/vite-plugin-ox-content/src/virtual.ts
@@ -31,3 +31,29 @@ declare module "virtual:ox-content/collections" {
   };
   export default api;
 }
+
+declare module "virtual:ox-content/assets.css" {
+  const css: string;
+  export default css;
+}
+
+declare module "virtual:ox-content/asset-manifest" {
+  export interface OxContentAssetPreload {
+    href: string;
+    as: "font";
+    type: string;
+    crossorigin: true;
+  }
+
+  export interface OxContentAssetManifest {
+    stylesheets: string[];
+    preloads: OxContentAssetPreload[];
+    headTags: string;
+  }
+
+  export const stylesheets: string[];
+  export const preloads: OxContentAssetPreload[];
+  export const headTags: string;
+  const manifest: OxContentAssetManifest;
+  export default manifest;
+}

--- a/scripts/package-dry-run-vite-plugin.mjs
+++ b/scripts/package-dry-run-vite-plugin.mjs
@@ -1,0 +1,27 @@
+const publicValues = ["resolveSelfHostedAssetManifest", "writeSelfHostedAssets"];
+const publicTypes = [
+  "OxContentAssetManifest",
+  "OxContentAssetPreload",
+  "SelfHostedAssetOptions",
+  "WriteSelfHostedAssetsInput",
+  "WriteSelfHostedAssetsResult",
+];
+const virtualModules = ["virtual:ox-content/assets.css", "virtual:ox-content/asset-manifest"];
+
+export function checkVitePluginDeclarations({ pkg, tarball, failures, readPackedFile }) {
+  for (const extension of ["mts", "cts"]) {
+    const declaration = readPackedFile(tarball, `dist/index.d.${extension}`);
+
+    for (const name of [...publicValues, ...publicTypes]) {
+      if (!new RegExp(`\\b${name}\\b`).test(declaration)) {
+        failures.push(`${pkg.name} index.d.${extension} is missing ${name}`);
+      }
+    }
+
+    for (const moduleId of virtualModules) {
+      if (!declaration.includes(`declare module "${moduleId}"`)) {
+        failures.push(`${pkg.name} index.d.${extension} is missing ${moduleId}`);
+      }
+    }
+  }
+}

--- a/scripts/package-dry-run.mjs
+++ b/scripts/package-dry-run.mjs
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 import { checkReaderChromeDeclarations } from "./package-dry-run-reader-chrome.mjs";
 import { checkTwitterClientDeclarations } from "./package-dry-run-twitter-client.mjs";
+import { checkVitePluginDeclarations } from "./package-dry-run-vite-plugin.mjs";
 
 const packages = [
   "crates/ox_content_napi",
@@ -73,6 +74,12 @@ function checkPackage(packageDir) {
     checkNapiPackage(packageDir, pkg, files);
   }
   if (pkg.name === "@ox-content/vite-plugin") {
+    checkVitePluginDeclarations({
+      pkg,
+      tarball: packed.filename,
+      failures,
+      readPackedFile,
+    });
     checkReaderChromeDeclarations({
       pkg,
       tarball: packed.filename,


### PR DESCRIPTION
## Summary

- expose a public self-hosted asset contract for custom Vite hosts via `virtual:ox-content/assets.css`, `virtual:ox-content/asset-manifest`, `resolveSelfHostedAssetManifest()`, and `writeSelfHostedAssets()`
- serve/write `__ox_icons__` and `__ox_fonts__` when `ssg.enabled` is false, while reusing the existing SSG font/icon pipeline
- add a custom-host dev/build canary plus packed declaration checks in `package-dry-run`
- document the custom-host path in English and Japanese

## Verification

- `vp test src/assets.test.ts src/public-exports.test.ts src/theme-fonts.test.ts src/ssg-output.test.ts`
- `vp run check:ts`
- `vp run build:npm`
- `vp run --filter ./npm/vite-plugin-ox-content build`
- `node scripts/package-dry-run.mjs`
- `node scripts/check-file-lines.ts --base origin/main`
- `git diff --check`

Refs #1239.
Refs ryoppippi/ryoppippi.com#2112; thanks @ryoppippi for the reproduction.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790785001&installation_model_id=422833&pr_number=1240&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1240&signature=facd545e755ff0a18da8969ff676ff6750aba07557b4f2e04c03d6b5cd7944d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for self-hosting fonts and Iconify assets on custom Vite hosts.
  * Added virtual stylesheet and asset-manifest access for development and production builds.
  * Added utilities for generating asset metadata and writing assets during SSG output.
  * Added support for matching stylesheet and font preload tags.

* **Documentation**
  * Updated English and Japanese guides with setup instructions and custom-host configuration details.

* **Tests**
  * Added coverage for asset generation, serving, production output, and public exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->