### PR TITLE
perf(ssg): bound concurrent page transforms

### DIFF
--- a/docs/content/built-in/site-generation.md
+++ b/docs/content/built-in/site-generation.md
@@ -90,8 +90,9 @@ export default defineConfig({
 | `navigation`           | derived        | Explicit navigation groups instead of the file tree.                                                       |
 
 `transformConcurrency` overlaps independent Markdown transforms, including
-build-time embed fetches. Values are truncated and then clamped to `1..32`;
-set it above `1` to opt into concurrency when custom transformers and embed
+build-time embed fetches. Finite values are truncated and then clamped to
+`1..32`; omitted or non-finite values use the default `1`. Set it above `1` to
+opt into concurrency when custom transformers and embed
 providers are safe to run concurrently. Custom `ssg.render` themes still run
 after collection in the deterministic page-render stage.
 

--- a/docs/content/built-in/site-generation.md
+++ b/docs/content/built-in/site-generation.md
@@ -59,7 +59,7 @@ export default defineConfig({
 | `enabled`              | `true`         | Set `ssg: false` to keep only `.md` modules. Import [component styles](./component-styles.md) in the host. |
 | `extension`            | `".html"`      | Generated page extension.                                                                                  |
 | `routePrefix`          | —              | Mount page routes under a path without changing `base` or `outDir`.                                        |
-| `transformConcurrency` | `8`            | Markdown pages transformed at once before deterministic render/write stages.                               |
+| `transformConcurrency` | `1`            | Markdown pages transformed at once before deterministic render/write stages.                               |
 | `clean`                | `false`        | Remove generated output before writing.                                                                    |
 | `bare`                 | `false`        | Emit unthemed HTML without navigation.                                                                     |
 | `render`               | —              | JSX component that owns the whole document.                                                                |
@@ -90,9 +90,10 @@ export default defineConfig({
 | `navigation`           | derived        | Explicit navigation groups instead of the file tree.                                                       |
 
 `transformConcurrency` overlaps independent Markdown transforms, including
-build-time embed fetches. It is clamped to `1..32`; set it to `1` when a custom
-transformer or embed provider must stay serial. Custom `ssg.render` themes still
-run after collection in the deterministic page-render stage.
+build-time embed fetches. Values are truncated and then clamped to `1..32`;
+set it above `1` to opt into concurrency when custom transformers and embed
+providers are safe to run concurrently. Custom `ssg.render` themes still run
+after collection in the deterministic page-render stage.
 
 `ssg.routePrefix` mounts Markdown page routes under a path such as `/blog`
 without changing the deployment `base` or moving root host files. `blog`,

--- a/docs/content/built-in/site-generation.md
+++ b/docs/content/built-in/site-generation.md
@@ -54,39 +54,45 @@ export default defineConfig({
 });
 ```
 
-| Option            | Default        | Purpose                                                                                                    |
-| ----------------- | -------------- | ---------------------------------------------------------------------------------------------------------- |
-| `enabled`         | `true`         | Set `ssg: false` to keep only `.md` modules. Import [component styles](./component-styles.md) in the host. |
-| `extension`       | `".html"`      | Generated page extension.                                                                                  |
-| `routePrefix`     | —              | Mount page routes under a path without changing `base` or `outDir`.                                        |
-| `clean`           | `false`        | Remove generated output before writing.                                                                    |
-| `bare`            | `false`        | Emit unthemed HTML without navigation.                                                                     |
-| `render`          | —              | JSX component that owns the whole document.                                                                |
-| `lang`            | `"en"`         | `lang` attribute on `<html>` (bare mode).                                                                  |
-| `head`            | —              | Raw markup appended to `<head>` (bare mode).                                                               |
-| `bodyStart`       | —              | Raw markup after `<body>` (bare mode).                                                                     |
-| `bodyEnd`         | —              | Raw markup before `</body>` (bare mode).                                                                   |
-| `siteName`        | —              | Suffix for `<title>` and OG site name.                                                                     |
-| `siteUrl`         | —              | Origin used for absolute OG URLs, canonical, and hreflang. See [SEO](./seo.md).                            |
-| `headValidation`  | `false`        | `warn` or `strict` for invalid head descriptors. See [SEO](./seo.md).                                      |
-| `ogImage`         | —              | Static fallback OG image URL.                                                                              |
-| `generateOgImage` | `false`        | Per-page OG images (see below).                                                                            |
-| `lastUpdated`     | `false`        | Show the git last-commit time per page.                                                                    |
-| `contributors`    | `false`        | Unique git authors per page. See [Contributors](./contributors.md).                                        |
-| `pagination`      | `false`        | Previous/next links after the article.                                                                     |
-| `breadcrumbs`     | `false`        | Trail from the site root through sidebar ancestors.                                                        |
-| `jsonLd`          | `false`        | JSON-LD for TechArticle / WebSite / BreadcrumbList.                                                        |
-| `readerChrome`    | `false`        | Copy, outbound-link icons, and back-to-top.                                                                |
-| `localeSwitcher`  | `false`        | Header locale dropdown when i18n locales are set.                                                          |
-| `a11y`            | `false`        | Skip link and print styles.                                                                                |
-| `notFound`        | `false`        | Themed 404 page. See [Custom 404](./not-found.md).                                                         |
-| `team`            | `false`        | Member cards on `layout: team`. See [Team](./team.md).                                                     |
-| `blog`            | `false`        | Paginated index, authors, tags, archive, optional external feeds. See [Blog](./blog.md).                   |
-| `sectionIndex`    | `false`        | Generated listings for directories without `index.md`. See [Section index pages](./section-index.md).      |
-| `pageChrome`      | `false`        | Honor per-page frontmatter chrome flags.                                                                   |
-| `markdownSource`  | `false`        | Publish original Markdown beside each page. See [Markdown source companions](./markdown-source.md).        |
-| `theme`           | `defaultTheme` | Theme configuration via `defineTheme()`.                                                                   |
-| `navigation`      | derived        | Explicit navigation groups instead of the file tree.                                                       |
+| Option                 | Default        | Purpose                                                                                                    |
+| ---------------------- | -------------- | ---------------------------------------------------------------------------------------------------------- |
+| `enabled`              | `true`         | Set `ssg: false` to keep only `.md` modules. Import [component styles](./component-styles.md) in the host. |
+| `extension`            | `".html"`      | Generated page extension.                                                                                  |
+| `routePrefix`          | —              | Mount page routes under a path without changing `base` or `outDir`.                                        |
+| `transformConcurrency` | `8`            | Markdown pages transformed at once before deterministic render/write stages.                               |
+| `clean`                | `false`        | Remove generated output before writing.                                                                    |
+| `bare`                 | `false`        | Emit unthemed HTML without navigation.                                                                     |
+| `render`               | —              | JSX component that owns the whole document.                                                                |
+| `lang`                 | `"en"`         | `lang` attribute on `<html>` (bare mode).                                                                  |
+| `head`                 | —              | Raw markup appended to `<head>` (bare mode).                                                               |
+| `bodyStart`            | —              | Raw markup after `<body>` (bare mode).                                                                     |
+| `bodyEnd`              | —              | Raw markup before `</body>` (bare mode).                                                                   |
+| `siteName`             | —              | Suffix for `<title>` and OG site name.                                                                     |
+| `siteUrl`              | —              | Origin used for absolute OG URLs, canonical, and hreflang. See [SEO](./seo.md).                            |
+| `headValidation`       | `false`        | `warn` or `strict` for invalid head descriptors. See [SEO](./seo.md).                                      |
+| `ogImage`              | —              | Static fallback OG image URL.                                                                              |
+| `generateOgImage`      | `false`        | Per-page OG images (see below).                                                                            |
+| `lastUpdated`          | `false`        | Show the git last-commit time per page.                                                                    |
+| `contributors`         | `false`        | Unique git authors per page. See [Contributors](./contributors.md).                                        |
+| `pagination`           | `false`        | Previous/next links after the article.                                                                     |
+| `breadcrumbs`          | `false`        | Trail from the site root through sidebar ancestors.                                                        |
+| `jsonLd`               | `false`        | JSON-LD for TechArticle / WebSite / BreadcrumbList.                                                        |
+| `readerChrome`         | `false`        | Copy, outbound-link icons, and back-to-top.                                                                |
+| `localeSwitcher`       | `false`        | Header locale dropdown when i18n locales are set.                                                          |
+| `a11y`                 | `false`        | Skip link and print styles.                                                                                |
+| `notFound`             | `false`        | Themed 404 page. See [Custom 404](./not-found.md).                                                         |
+| `team`                 | `false`        | Member cards on `layout: team`. See [Team](./team.md).                                                     |
+| `blog`                 | `false`        | Paginated index, authors, tags, archive, optional external feeds. See [Blog](./blog.md).                   |
+| `sectionIndex`         | `false`        | Generated listings for directories without `index.md`. See [Section index pages](./section-index.md).      |
+| `pageChrome`           | `false`        | Honor per-page frontmatter chrome flags.                                                                   |
+| `markdownSource`       | `false`        | Publish original Markdown beside each page. See [Markdown source companions](./markdown-source.md).        |
+| `theme`                | `defaultTheme` | Theme configuration via `defineTheme()`.                                                                   |
+| `navigation`           | derived        | Explicit navigation groups instead of the file tree.                                                       |
+
+`transformConcurrency` overlaps independent Markdown transforms, including
+build-time embed fetches. It is clamped to `1..32`; set it to `1` when a custom
+transformer or embed provider must stay serial. Custom `ssg.render` themes still
+run after collection in the deterministic page-render stage.
 
 `ssg.routePrefix` mounts Markdown page routes under a path such as `/blog`
 without changing the deployment `base` or moving root host files. `blog`,

--- a/docs/content/ja/built-in/site-generation.md
+++ b/docs/content/ja/built-in/site-generation.md
@@ -55,7 +55,7 @@ export default defineConfig({
 | `enabled`              | `true`         | `.md` モジュールだけ残すときは `ssg: false`。ホスト側で [コンポーネント CSS](./component-styles.md) を import する。 |
 | `extension`            | `".html"`      | 生成ページの拡張子。                                                                                                 |
 | `routePrefix`          | —              | `base` や `outDir` を変えずにページルートをマウントする。                                                            |
-| `transformConcurrency` | `8`            | 決定的な render/write 段階の前に同時変換する Markdown ページ数。                                                     |
+| `transformConcurrency` | `1`            | 決定的な render/write 段階の前に同時変換する Markdown ページ数。                                                     |
 | `clean`                | `false`        | 書き出す前に生成物を消す。                                                                                           |
 | `bare`                 | `false`        | ナビなしの、テーマなし HTML を出す。                                                                                 |
 | `render`               | —              | 文書全体を所有する JSX コンポーネント。                                                                              |
@@ -85,7 +85,7 @@ export default defineConfig({
 | `theme`                | `defaultTheme` | `defineTheme()` によるテーマ設定。                                                                                   |
 | `navigation`           | 派生           | ファイルツリーの代わりに明示的なナビグループ。                                                                       |
 
-`transformConcurrency` は独立した Markdown 変換を重ねます。ビルド時の埋め込み fetch もここで重なります。値は `1..32` に丸められるため、独自 transformer や埋め込み provider を直列に保ちたい場合は `1` を指定してください。独自 `ssg.render` テーマは collection のあと、決定的なページ render 段階で動きます。
+`transformConcurrency` は独立した Markdown 変換を重ねます。ビルド時の埋め込み fetch もここで重なります。値は整数に切り捨てられたあと `1..32` の範囲に制限されます。独自 transformer や埋め込み provider を直列に保つ既定値は `1` です。並行実行しても安全な場合にのみ `1` より大きい値を指定してください。独自 `ssg.render` テーマは collection のあと、決定的なページ render 段階で動きます。
 
 `ssg.routePrefix` はデプロイの `base` やルートのホストファイルを動かさずに、Markdown ページルートを `/blog` のようなパスへマウントします。`blog`、`/blog`、`/blog/` はどれも `/blog` 配下になります。ページ HTML とページ単位のアセットはプレフィックスに従い、`_redirects`、`_headers`、ルートのフィード、サイトマップ index は `outDir` に残ります。`base` は公開 URL のプレフィックスのままです。[パーマリンク](./permalinks.md) がオンのとき、frontmatter の `permalink` が勝ちます。
 

--- a/docs/content/ja/built-in/site-generation.md
+++ b/docs/content/ja/built-in/site-generation.md
@@ -50,39 +50,42 @@ export default defineConfig({
 });
 ```
 
-| オプション        | 既定           | 目的                                                                                                                 |
-| ----------------- | -------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `enabled`         | `true`         | `.md` モジュールだけ残すときは `ssg: false`。ホスト側で [コンポーネント CSS](./component-styles.md) を import する。 |
-| `extension`       | `".html"`      | 生成ページの拡張子。                                                                                                 |
-| `routePrefix`     | —              | `base` や `outDir` を変えずにページルートをマウントする。                                                            |
-| `clean`           | `false`        | 書き出す前に生成物を消す。                                                                                           |
-| `bare`            | `false`        | ナビなしの、テーマなし HTML を出す。                                                                                 |
-| `render`          | —              | 文書全体を所有する JSX コンポーネント。                                                                              |
-| `lang`            | `"en"`         | `<html>` の `lang` 属性（bare モード）。                                                                             |
-| `head`            | —              | `<head>` に足す生マークアップ（bare モード）。                                                                       |
-| `bodyStart`       | —              | `<body>` の直後に足す生マークアップ（bare モード）。                                                                 |
-| `bodyEnd`         | —              | `</body>` の直前に足す生マークアップ（bare モード）。                                                                |
-| `siteName`        | —              | `<title>` の接尾辞と OG サイト名。                                                                                   |
-| `siteUrl`         | —              | 絶対 OG URL、canonical、hreflang に使うオリジン。[SEO](./seo.md)。                                                   |
-| `headValidation`  | `false`        | 不正な head デスクリプタの `warn` / `strict`。[SEO](./seo.md)。                                                      |
-| `ogImage`         | —              | 静的フォールバックの OG 画像 URL。                                                                                   |
-| `generateOgImage` | `false`        | ページごとの OG 画像（後述）。                                                                                       |
-| `lastUpdated`     | `false`        | ページごとの git 最終コミット時刻を出す。                                                                            |
-| `contributors`    | `false`        | ページごとの一意な git 作者。[コントリビューター](./contributors.md) を見てください。                                |
-| `pagination`      | `false`        | 記事のあとに前へ / 次へリンク。                                                                                      |
-| `breadcrumbs`     | `false`        | サイトルートからサイドバー祖先までの道筋。                                                                           |
-| `jsonLd`          | `false`        | TechArticle / WebSite / BreadcrumbList の JSON-LD。                                                                  |
-| `readerChrome`    | `false`        | コピー、外部リンクアイコン、先頭へ戻る。                                                                             |
-| `localeSwitcher`  | `false`        | i18n ロケールがあるときのヘッダーロケールドロップダウン。                                                            |
-| `a11y`            | `false`        | スキップリンクと印刷スタイル。                                                                                       |
-| `notFound`        | `false`        | テーマ付き 404。 [カスタム 404](./not-found.md) を見てください。                                                     |
-| `team`            | `false`        | `layout: team` のメンバーカード。[チーム](./team.md) を見てください。                                                |
-| `blog`            | `false`        | ページ送り索引、著者、タグ、アーカイブ、任意の外部フィード。[ブログ](./blog.md) を見てください。                     |
-| `sectionIndex`    | `false`        | `index.md` がないディレクトリ向けの生成一覧。[セクション索引ページ](./section-index.md) を見てください。             |
-| `pageChrome`      | `false`        | ページ単位の frontmatter chrome フラグを尊重する。                                                                   |
-| `markdownSource`  | `false`        | 各ページの横に元の Markdown を公開する。[Markdown ソースの併記](./markdown-source.md)。                              |
-| `theme`           | `defaultTheme` | `defineTheme()` によるテーマ設定。                                                                                   |
-| `navigation`      | 派生           | ファイルツリーの代わりに明示的なナビグループ。                                                                       |
+| オプション             | 既定           | 目的                                                                                                                 |
+| ---------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `enabled`              | `true`         | `.md` モジュールだけ残すときは `ssg: false`。ホスト側で [コンポーネント CSS](./component-styles.md) を import する。 |
+| `extension`            | `".html"`      | 生成ページの拡張子。                                                                                                 |
+| `routePrefix`          | —              | `base` や `outDir` を変えずにページルートをマウントする。                                                            |
+| `transformConcurrency` | `8`            | 決定的な render/write 段階の前に同時変換する Markdown ページ数。                                                     |
+| `clean`                | `false`        | 書き出す前に生成物を消す。                                                                                           |
+| `bare`                 | `false`        | ナビなしの、テーマなし HTML を出す。                                                                                 |
+| `render`               | —              | 文書全体を所有する JSX コンポーネント。                                                                              |
+| `lang`                 | `"en"`         | `<html>` の `lang` 属性（bare モード）。                                                                             |
+| `head`                 | —              | `<head>` に足す生マークアップ（bare モード）。                                                                       |
+| `bodyStart`            | —              | `<body>` の直後に足す生マークアップ（bare モード）。                                                                 |
+| `bodyEnd`              | —              | `</body>` の直前に足す生マークアップ（bare モード）。                                                                |
+| `siteName`             | —              | `<title>` の接尾辞と OG サイト名。                                                                                   |
+| `siteUrl`              | —              | 絶対 OG URL、canonical、hreflang に使うオリジン。[SEO](./seo.md)。                                                   |
+| `headValidation`       | `false`        | 不正な head デスクリプタの `warn` / `strict`。[SEO](./seo.md)。                                                      |
+| `ogImage`              | —              | 静的フォールバックの OG 画像 URL。                                                                                   |
+| `generateOgImage`      | `false`        | ページごとの OG 画像（後述）。                                                                                       |
+| `lastUpdated`          | `false`        | ページごとの git 最終コミット時刻を出す。                                                                            |
+| `contributors`         | `false`        | ページごとの一意な git 作者。[コントリビューター](./contributors.md) を見てください。                                |
+| `pagination`           | `false`        | 記事のあとに前へ / 次へリンク。                                                                                      |
+| `breadcrumbs`          | `false`        | サイトルートからサイドバー祖先までの道筋。                                                                           |
+| `jsonLd`               | `false`        | TechArticle / WebSite / BreadcrumbList の JSON-LD。                                                                  |
+| `readerChrome`         | `false`        | コピー、外部リンクアイコン、先頭へ戻る。                                                                             |
+| `localeSwitcher`       | `false`        | i18n ロケールがあるときのヘッダーロケールドロップダウン。                                                            |
+| `a11y`                 | `false`        | スキップリンクと印刷スタイル。                                                                                       |
+| `notFound`             | `false`        | テーマ付き 404。 [カスタム 404](./not-found.md) を見てください。                                                     |
+| `team`                 | `false`        | `layout: team` のメンバーカード。[チーム](./team.md) を見てください。                                                |
+| `blog`                 | `false`        | ページ送り索引、著者、タグ、アーカイブ、任意の外部フィード。[ブログ](./blog.md) を見てください。                     |
+| `sectionIndex`         | `false`        | `index.md` がないディレクトリ向けの生成一覧。[セクション索引ページ](./section-index.md) を見てください。             |
+| `pageChrome`           | `false`        | ページ単位の frontmatter chrome フラグを尊重する。                                                                   |
+| `markdownSource`       | `false`        | 各ページの横に元の Markdown を公開する。[Markdown ソースの併記](./markdown-source.md)。                              |
+| `theme`                | `defaultTheme` | `defineTheme()` によるテーマ設定。                                                                                   |
+| `navigation`           | 派生           | ファイルツリーの代わりに明示的なナビグループ。                                                                       |
+
+`transformConcurrency` は独立した Markdown 変換を重ねます。ビルド時の埋め込み fetch もここで重なります。値は `1..32` に丸められるため、独自 transformer や埋め込み provider を直列に保ちたい場合は `1` を指定してください。独自 `ssg.render` テーマは collection のあと、決定的なページ render 段階で動きます。
 
 `ssg.routePrefix` はデプロイの `base` やルートのホストファイルを動かさずに、Markdown ページルートを `/blog` のようなパスへマウントします。`blog`、`/blog`、`/blog/` はどれも `/blog` 配下になります。ページ HTML とページ単位のアセットはプレフィックスに従い、`_redirects`、`_headers`、ルートのフィード、サイトマップ index は `outDir` に残ります。`base` は公開 URL のプレフィックスのままです。[パーマリンク](./permalinks.md) がオンのとき、frontmatter の `permalink` が勝ちます。
 

--- a/npm/vite-plugin-ox-content/src/ssg.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.test.ts
@@ -240,12 +240,12 @@ describe("resolveSsgOptions", () => {
   });
 
   it("bounds Markdown transform concurrency", () => {
-    expect(resolveSsgOptions(undefined).transformConcurrency).toBe(8);
+    expect(resolveSsgOptions(undefined).transformConcurrency).toBe(1);
     expect(resolveSsgOptions({ transformConcurrency: 2 }).transformConcurrency).toBe(2);
     expect(resolveSsgTransformConcurrency(0)).toBe(1);
     expect(resolveSsgTransformConcurrency(2.8)).toBe(2);
     expect(resolveSsgTransformConcurrency(100)).toBe(32);
-    expect(resolveSsgTransformConcurrency(Number.NaN)).toBe(8);
+    expect(resolveSsgTransformConcurrency(Number.NaN)).toBe(1);
   });
 });
 

--- a/npm/vite-plugin-ox-content/src/ssg.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.test.ts
@@ -16,6 +16,7 @@ import {
   getUrlPath,
   resolveNavigationGroups,
   resolveSsgOptions,
+  resolveSsgTransformConcurrency,
   shouldGenerateOgImages,
 } from "./ssg";
 import { applyContributorOptions, filterGitContributors, gravatarAvatar } from "./contributors";
@@ -24,8 +25,10 @@ import type { ResolvedOptions } from "./types";
 import { createDocsResolvedOptions } from "../test/fixtures/docs-fixture";
 
 const tempDirs: string[] = [];
+const originalFetch = globalThis.fetch;
 
 afterEach(async () => {
+  globalThis.fetch = originalFetch;
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
 
@@ -234,6 +237,15 @@ describe("resolveSsgOptions", () => {
   it("rejects path-escape routePrefix values", () => {
     expect(resolveSsgOptions({ routePrefix: "../secret" }).routePrefix).toBeUndefined();
     expect(resolveSsgOptions({ routePrefix: "//evil.example" }).routePrefix).toBeUndefined();
+  });
+
+  it("bounds Markdown transform concurrency", () => {
+    expect(resolveSsgOptions(undefined).transformConcurrency).toBe(8);
+    expect(resolveSsgOptions({ transformConcurrency: 2 }).transformConcurrency).toBe(2);
+    expect(resolveSsgTransformConcurrency(0)).toBe(1);
+    expect(resolveSsgTransformConcurrency(2.8)).toBe(2);
+    expect(resolveSsgTransformConcurrency(100)).toBe(32);
+    expect(resolveSsgTransformConcurrency(Number.NaN)).toBe(8);
   });
 });
 
@@ -684,6 +696,60 @@ describe("SSG routePrefix", () => {
     );
     expect(built.files.some((file) => file.includes(path.join("blog", "first-post")))).toBe(false);
     expect(built.errors).toEqual([]);
+  });
+
+  it("overlaps independent Markdown transforms without exceeding the SSG bound", async () => {
+    const root = await makeSite({
+      "a.md": '# A\n\n<OgCard url="https://example.com/a"></OgCard>\n',
+      "b.md": '# B\n\n<OgCard url="https://example.com/b"></OgCard>\n',
+      "c.md": '# C\n\n<OgCard url="https://example.com/c"></OgCard>\n',
+      "d.md": '# D\n\n<OgCard url="https://example.com/d"></OgCard>\n',
+    });
+    let active = 0;
+    let maxActive = 0;
+    const requested: string[] = [];
+    globalThis.fetch = async (input) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : "url" in input
+              ? input.url
+              : String(input);
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      requested.push(url);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      active -= 1;
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          `<html><head><meta property="og:title" content="${path.basename(url)}"></head></html>`,
+      } as Response;
+    };
+
+    const base = createDocsResolvedOptions();
+    const built = await buildSsg(
+      createDocsResolvedOptions({
+        highlight: false,
+        search: { ...base.search, enabled: false },
+        ssg: { ...base.ssg, bare: true, transformConcurrency: 2 },
+        embeds: { ...base.embeds, openGraph: { cache: false, timeout: 1_000 } },
+      }),
+      root,
+    );
+
+    expect(built.errors).toEqual([]);
+    expect(requested).toHaveLength(4);
+    expect(maxActive).toBe(2);
+    await expect(
+      fs.readFile(path.join(root, "dist", "a", "index.html"), "utf-8"),
+    ).resolves.toContain("A");
+    await expect(
+      fs.readFile(path.join(root, "dist", "d", "index.html"), "utf-8"),
+    ).resolves.toContain("D");
   });
 });
 

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -177,7 +177,7 @@ interface SsgRoutePaths {
   ogImageUrl: string;
 }
 
-const DEFAULT_SSG_TRANSFORM_CONCURRENCY = 8;
+const DEFAULT_SSG_TRANSFORM_CONCURRENCY = 1;
 const MAX_SSG_TRANSFORM_CONCURRENCY = 32;
 
 /**

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -177,6 +177,9 @@ interface SsgRoutePaths {
   ogImageUrl: string;
 }
 
+const DEFAULT_SSG_TRANSFORM_CONCURRENCY = 8;
+const MAX_SSG_TRANSFORM_CONCURRENCY = 32;
+
 /**
  * Deprecated compatibility export for consumers that imported the former
  * TypeScript SSG template. HTML generation is Rust-backed now.
@@ -214,6 +217,13 @@ export function normalizeRoutePrefix(value?: string): string | undefined {
 function resolvedRoutePrefix(value?: string): { routePrefix: string } | Record<string, never> {
   const prefix = normalizeRoutePrefix(value);
   return prefix ? { routePrefix: prefix } : {};
+}
+
+export function resolveSsgTransformConcurrency(value?: number): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return DEFAULT_SSG_TRANSFORM_CONCURRENCY;
+  }
+  return Math.min(MAX_SSG_TRANSFORM_CONCURRENCY, Math.max(1, Math.trunc(value)));
 }
 
 function applyUrlPrefix(urlPath: string, routePrefix?: string): string {
@@ -309,6 +319,7 @@ export function resolveSsgOptions(ssg: SsgOptions | boolean | undefined): Resolv
     return {
       enabled: false,
       extension: ".html",
+      transformConcurrency: resolveSsgTransformConcurrency(undefined),
       clean: false,
       bare: false,
       generateOgImage: false,
@@ -334,6 +345,7 @@ export function resolveSsgOptions(ssg: SsgOptions | boolean | undefined): Resolv
     return {
       enabled: true,
       extension: ".html",
+      transformConcurrency: resolveSsgTransformConcurrency(undefined),
       clean: false,
       bare: false,
       generateOgImage: false,
@@ -360,6 +372,7 @@ export function resolveSsgOptions(ssg: SsgOptions | boolean | undefined): Resolv
     enabled: ssg.enabled ?? true,
     extension: ssg.extension ?? ".html",
     ...resolvedRoutePrefix(ssg.routePrefix),
+    transformConcurrency: resolveSsgTransformConcurrency(ssg.transformConcurrency),
     clean: ssg.clean ?? false,
     bare: ssg.bare ?? false,
     render: ssg.render,
@@ -1055,6 +1068,12 @@ interface CollectedPageResults {
   errors: string[];
 }
 
+interface CollectedPageSlot {
+  inputPath: string;
+  pageResult?: PageProcessResult;
+  error?: string;
+}
+
 /** Result of an SSG build. */
 export interface SsgBuildResult {
   /** Every file written, HTML pages and generated OG images alike. */
@@ -1349,6 +1368,8 @@ async function collectPageResults(
   context: BuildSsgContext,
   markdownFiles: string[],
 ): Promise<CollectedPageResults> {
+  await warmNapiBeforeConcurrentTransforms();
+
   const collected: CollectedPageResults = {
     pageResults: [],
     ogImageEntries: [],
@@ -1357,18 +1378,73 @@ async function collectPageResults(
     errors: [],
   };
 
-  for (const inputPath of markdownFiles) {
-    try {
-      const pageResult = await transformSsgPage(context, inputPath);
+  const slots = await mapWithConcurrency(
+    markdownFiles,
+    resolveSsgTransformConcurrency(context.ssgOptions.transformConcurrency),
+    async (inputPath): Promise<CollectedPageSlot> => {
+      try {
+        return {
+          inputPath,
+          pageResult: await transformSsgPage(context, inputPath),
+        };
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        return {
+          inputPath,
+          error: `Failed to process ${inputPath}: ${errorMessage}`,
+        };
+      }
+    },
+  );
+
+  for (const slot of slots) {
+    if (slot.pageResult) {
+      const pageResult = slot.pageResult;
       collected.pageResults.push(pageResult);
       collectOgImageEntry(context, pageResult, collected);
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : String(err);
-      collected.errors.push(`Failed to process ${inputPath}: ${errorMessage}`);
+    } else if (slot.error) {
+      collected.errors.push(slot.error);
     }
   }
 
   return collected;
+}
+
+async function warmNapiBeforeConcurrentTransforms(): Promise<void> {
+  try {
+    await importNapiModule();
+  } catch {
+    // `transformMarkdown()` reports the same per-page binding error as before.
+  }
+}
+
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  run: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = Array.from({ length: items.length }, () => undefined as R);
+  let next = 0;
+
+  async function worker(): Promise<void> {
+    for (;;) {
+      const index = next;
+      next += 1;
+      if (index >= items.length) {
+        return;
+      }
+      results[index] = await run(items[index] as T, index);
+    }
+  }
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(resolveSsgTransformConcurrency(concurrency), items.length) },
+      () => worker(),
+    ),
+  );
+
+  return results;
 }
 
 function applyPublishState(

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -231,6 +231,17 @@ export interface SsgOptions {
   routePrefix?: string;
 
   /**
+   * Maximum number of Markdown pages transformed at once during SSG.
+   *
+   * This overlaps independent page work such as build-time embed fetches while
+   * keeping network, memory, and file descriptor use bounded. Page rendering
+   * and writes still run through the deterministic output stages.
+   *
+   * @default 8
+   */
+  transformConcurrency?: number;
+
+  /**
    * Remove previously generated files from the output directory before writing
    * the new SSG result.
    *
@@ -646,6 +657,7 @@ export interface ResolvedSsgOptions {
    * Present after `resolveSsgOptions`. Omitted / empty means off.
    */
   routePrefix?: string;
+  transformConcurrency?: number;
   clean: boolean;
   bare: boolean;
   render?: ThemeComponent;

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -237,7 +237,7 @@ export interface SsgOptions {
    * keeping network, memory, and file descriptor use bounded. Page rendering
    * and writes still run through the deterministic output stages.
    *
-   * @default 8
+   * @default 1
    */
   transformConcurrency?: number;
 


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable concurrency for static site generation Markdown transformations.
  - Transform concurrency defaults to 1 and accepts values from 1 to 32.
  - Concurrent processing can overlap build-time embed fetches while preserving deterministic rendering and writing.
  - Added guidance for serial processing when custom transformers or embed providers require it.

- **Documentation**
  - Updated English and Japanese site-generation documentation with configuration details and usage guidance.

- **Tests**
  - Added coverage for defaults, limits, concurrency behavior, page generation, and OG metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->