### PR TITLE
feat(vite-plugin-solid): support Solid 2 native compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ npm install @ox-content/vite-plugin-react
 # Svelte
 npm install @ox-content/vite-plugin-svelte
 
-# Solid (vite-plugin-solid compiles the generated JSX, so it is required)
-npm install @ox-content/vite-plugin-solid solid-js vite-plugin-solid
+# Solid (@solidjs/vite-plugin compiles generated Markdown JSX)
+npm install @ox-content/vite-plugin-solid solid-js@next @solidjs/web@next @solidjs/vite-plugin
 ```
 
 ### i18n Static Checker (CLI)

--- a/docs/content/examples/index.md
+++ b/docs/content/examples/index.md
@@ -65,7 +65,7 @@ Embed Solid components in Markdown using `@ox-content/vite-plugin-solid`.
 
 ```ts
 import { defineConfig } from "vite";
-import solid from "vite-plugin-solid";
+import solid from "@solidjs/vite-plugin";
 import { oxContentSolid } from "@ox-content/vite-plugin-solid";
 
 export default defineConfig({
@@ -75,7 +75,7 @@ export default defineConfig({
     }),
     // Solid's JSX is compile-time only, so this plugin runs after
     // oxContentSolid() and needs the Markdown extensions.
-    solid({ extensions: [".md", ".markdown", ".mdx"] }),
+    solid({ extensions: [".md", ".markdown", ".mdx"], compiler: "native" }),
   ],
 });
 ```

--- a/docs/content/examples/integ-solid.md
+++ b/docs/content/examples/integ-solid.md
@@ -15,7 +15,7 @@ corepack pnpm --filter ./examples/integ-solid dev
 ```ts
 // vite.config.ts
 import { defineConfig } from "vite";
-import solid from "vite-plugin-solid";
+import solid from "@solidjs/vite-plugin";
 import { oxContentSolid } from "@ox-content/vite-plugin-solid";
 
 export default defineConfig({
@@ -25,14 +25,14 @@ export default defineConfig({
       // Auto-discover all Solid components
       components: "./src/components/*.tsx",
     }),
-    solid({ extensions: [".md", ".markdown", ".mdx"] }),
+    solid({ extensions: [".md", ".markdown", ".mdx"], compiler: "native" }),
   ],
 });
 ```
 
 Solid's JSX is compile-time only, so `oxContentSolid()` has to run first (it
 produces the JSX) and `solid()` has to be told about the Markdown extensions
-(it compiles the JSX). See
+while using Solid 2's native compiler. See
 [the package reference](../packages/vite-plugin-ox-content-solid.md#plugin-order-and-extensions).
 
 ## Components

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -100,7 +100,7 @@ vp install @ox-content/vite-plugin-react@alpha react react-dom @vitejs/plugin-re
 vp install @ox-content/vite-plugin-svelte@alpha svelte @sveltejs/vite-plugin-svelte
 
 # Solid
-vp install @ox-content/vite-plugin-solid@alpha solid-js vite-plugin-solid
+vp install @ox-content/vite-plugin-solid@alpha solid-js@next @solidjs/web@next @solidjs/vite-plugin
 ```
 
 Read more:

--- a/docs/content/ja/examples/index.md
+++ b/docs/content/ja/examples/index.md
@@ -68,7 +68,7 @@ export default defineConfig({
 
 ```ts
 import { defineConfig } from "vite";
-import solid from "vite-plugin-solid";
+import solid from "@solidjs/vite-plugin";
 import { oxContentSolid } from "@ox-content/vite-plugin-solid";
 
 export default defineConfig({
@@ -78,7 +78,7 @@ export default defineConfig({
     }),
     // Solid's JSX is compile-time only, so this plugin runs after
     // oxContentSolid() and needs the Markdown extensions.
-    solid({ extensions: [".md", ".markdown", ".mdx"] }),
+    solid({ extensions: [".md", ".markdown", ".mdx"], compiler: "native" }),
   ],
 });
 ```

--- a/docs/content/ja/getting-started.md
+++ b/docs/content/ja/getting-started.md
@@ -104,7 +104,7 @@ vp install @ox-content/vite-plugin-react@alpha react react-dom @vitejs/plugin-re
 vp install @ox-content/vite-plugin-svelte@alpha svelte @sveltejs/vite-plugin-svelte
 
 # Solid
-vp install @ox-content/vite-plugin-solid@alpha solid-js vite-plugin-solid
+vp install @ox-content/vite-plugin-solid@alpha solid-js@next @solidjs/web@next @solidjs/vite-plugin
 ```
 
 続き:

--- a/docs/content/ja/mdx.md
+++ b/docs/content/ja/mdx.md
@@ -97,7 +97,7 @@ Vue、Svelte、Solid も同じように `@ox-content/vite-plugin-vue`
 `@ox-content/vite-plugin-solid`（`oxContentSolid`）で動きます。`components` が glob のとき、
 コンポーネント名は PascalCase にしたファイル名です。
 
-Solid 連携は加えて `vite-plugin-solid` より前に動かす必要があり、
+Solid 連携は加えて `@solidjs/vite-plugin` より前に動かす必要があり、
 そちらには Markdown 拡張子を渡す必要があります。
 [そのリファレンスページ](/packages/vite-plugin-ox-content-solid.md#plugin-order-and-extensions) を見てください。
 
@@ -133,7 +133,7 @@ specifier はそのファイルのディレクトリから解決されます。�
 island の内側 HTML を差し替えられます。アダプタがサーバーで描画した HTML は
 server-rendered として印が付き、クライアント runtime は重複した subtree を
 mount せず hydrate できます。そのフックはアダプタ側に置きます。コア
-レンダラーは `react-dom/server`、`svelte/server`、`solid-js/web` を import しません。
+レンダラーは `react-dom/server`、`svelte/server`、`@solidjs/web` を import しません。
 
 ## Markdown でコンポーネントを書く
 

--- a/docs/content/mdx.md
+++ b/docs/content/mdx.md
@@ -96,8 +96,8 @@ Vue, Svelte, and Solid work the same way via `@ox-content/vite-plugin-vue`
 `@ox-content/vite-plugin-solid` (`oxContentSolid`). When `components` is a glob,
 the component name is the PascalCased file name.
 
-The Solid integration additionally has to run before `vite-plugin-solid`, which
-must be given the Markdown extensions — see
+The Solid integration additionally has to run before `@solidjs/vite-plugin`,
+which must be given the Markdown extensions — see
 [its reference page](./packages/vite-plugin-ox-content-solid.md#plugin-order-and-extensions).
 
 ## Document-local imports
@@ -132,7 +132,7 @@ that do not declare a local import. Framework plugins may also pass an optional
 at transform time. Adapter-rendered HTML is marked as server-rendered so the
 client runtime can hydrate it instead of mounting a duplicate subtree. That hook
 lives on the adapter; the core renderer does not import `react-dom/server`,
-`svelte/server`, or `solid-js/web`.
+`svelte/server`, or `@solidjs/web`.
 
 ## Authoring components in Markdown
 

--- a/docs/content/packages/vite-plugin-ox-content-solid.md
+++ b/docs/content/packages/vite-plugin-ox-content-solid.md
@@ -5,15 +5,19 @@ Solid integration for Ox Content - embed Solid components in Markdown.
 ## Installation
 
 ```bash
-vp install @ox-content/vite-plugin-solid solid-js vite-plugin-solid
+vp install @ox-content/vite-plugin-solid solid-js@next @solidjs/web@next @solidjs/vite-plugin
 ```
+
+This 3.x beta adapter targets Solid 2 and `@solidjs/vite-plugin`. It does not
+preserve the Solid 1 + `vite-plugin-solid` peer dependency path; keep the older
+adapter release if your app has to stay on Solid 1.
 
 ## Usage
 
 ```ts
 // vite.config.ts
 import { defineConfig } from "vite";
-import solid from "vite-plugin-solid";
+import solid from "@solidjs/vite-plugin";
 import { oxContentSolid } from "@ox-content/vite-plugin-solid";
 
 export default defineConfig({
@@ -23,7 +27,7 @@ export default defineConfig({
       // Auto-discover components with glob pattern
       components: "./src/components/*.tsx",
     }),
-    solid({ extensions: [".md", ".markdown", ".mdx"] }),
+    solid({ extensions: [".md", ".markdown", ".mdx"], compiler: "native" }),
   ],
 });
 ```
@@ -34,15 +38,16 @@ Unlike the Vue, React, and Svelte integrations, this plugin has two setup rules
 that are not optional. Both follow from the same fact: **Solid's JSX is
 compile-time only.** There is no runtime element factory like React's
 `createElement` or Vue's `h` to fall back on, so Markdown is emitted as Solid
-JSX and `vite-plugin-solid` is what turns it into DOM or SSR instructions.
+JSX and `@solidjs/vite-plugin` is what turns it into DOM or SSR instructions.
 
 1. `oxContentSolid()` must come **before** `solid()` in the `plugins` array.
    Both plugins are `enforce: "pre"`, so array order decides which one sees the
-   Markdown file first. If `solid()` runs first, Babel tries to parse raw
-   Markdown as JSX.
-2. `solid()` must be given the Markdown extensions. By default it only looks at
-   `.jsx` and `.tsx` files, so the generated modules would be handed to the
-   browser as uncompiled JSX.
+   Markdown file first. If `solid()` runs first, the Solid compiler sees raw
+   Markdown instead of the generated JSX.
+2. `solid()` must be given the Markdown extensions. Use
+   `compiler: "native"` for the Solid 2 native OXC compiler path. Without the
+   extensions, generated Markdown modules would be handed to the browser as
+   uncompiled JSX.
 
 Both mistakes are checked for you and reported with the fix — see
 [`verifySolidPlugin`](#verifysolidplugin).
@@ -92,7 +97,7 @@ first time a Markdown module comes out of the pipeline still uncompiled. Both
 throw a message naming the fix.
 
 Turn it off when Solid's JSX is compiled by something other than
-`vite-plugin-solid`.
+`@solidjs/vite-plugin`.
 
 ## Using Components in Markdown
 
@@ -124,7 +129,7 @@ import GtvChart from './gtv-chart/GtvChart.tsx'
 
 Optional `renderIsland(name, props, filePath)` can replace island inner HTML
 at transform time. The hook belongs on the Solid adapter; `@ox-content/vite-plugin`
-does not import `solid-js/web` for SSR.
+does not import `@solidjs/web` for SSR.
 
 ## Example Component
 
@@ -158,7 +163,7 @@ import components from "virtual:ox-content-solid/components";
 ```
 
 There is no `virtual:ox-content-solid/runtime` counterpart to the Svelte
-integration's: Solid mounts through `render` from `solid-js/web`, which the
+integration's: Solid mounts through `render` from `@solidjs/web`, which the
 generated modules import directly.
 
 ## Islands
@@ -166,7 +171,7 @@ generated modules import directly.
 Markdown that uses a registered or document-imported component is emitted with
 island markers and hydrated through `@ox-content/islands`, the same runtime the
 other framework integrations use. Each island is mounted with `render` from
-`solid-js/web` and disposed when the Markdown component unmounts.
+`@solidjs/web` and disposed when the Markdown component unmounts.
 
 Markdown without any registered or document-imported component skips the island
 runtime entirely and compiles to a single `innerHTML` binding.

--- a/examples/integ-solid/docs/index.md
+++ b/examples/integ-solid/docs/index.md
@@ -28,7 +28,7 @@ Components work seamlessly!
 ```ts
 // vite.config.ts
 import { defineConfig } from "vite-plus";
-import solid from "vite-plugin-solid";
+import solid from "@solidjs/vite-plugin";
 import { oxContentSolid } from "@ox-content/vite-plugin-solid";
 
 export default defineConfig({
@@ -41,7 +41,7 @@ export default defineConfig({
     }),
     // Solid's JSX is compile-time only, so Markdown extensions must be listed
     // here, and this plugin must come after oxContentSolid().
-    solid({ extensions: [".md", ".markdown", ".mdx"] }),
+    solid({ extensions: [".md", ".markdown", ".mdx"], compiler: "native" }),
   ],
 });
 ```

--- a/examples/integ-solid/package.json
+++ b/examples/integ-solid/package.json
@@ -10,12 +10,13 @@
   },
   "dependencies": {
     "@ox-content/islands": "workspace:*",
+    "@solidjs/web": "catalog:",
     "solid-js": "catalog:"
   },
   "devDependencies": {
     "@ox-content/vite-plugin-solid": "workspace:*",
+    "@solidjs/vite-plugin": "catalog:",
     "vite": "catalog:",
-    "vite-plugin-solid": "catalog:",
     "vite-plus": "catalog:"
   }
 }

--- a/examples/integ-solid/src/main.tsx
+++ b/examples/integ-solid/src/main.tsx
@@ -1,4 +1,4 @@
-import { render } from "solid-js/web";
+import { render } from "@solidjs/web";
 import App from "./App";
 import "./styles.css";
 

--- a/examples/integ-solid/vite.config.ts
+++ b/examples/integ-solid/vite.config.ts
@@ -1,12 +1,12 @@
 import { defineConfig } from "vite-plus";
-import solid from "vite-plugin-solid";
+import solid from "@solidjs/vite-plugin";
 import { oxContentSolid } from "@ox-content/vite-plugin-solid";
 
 export default defineConfig({
   plugins: [
     // Order matters: oxContentSolid() turns Markdown into Solid JSX, and
-    // vite-plugin-solid compiles that JSX. Both are `enforce: 'pre'`, so the
-    // array order is what decides which one sees the file first.
+    // @solidjs/vite-plugin compiles that JSX. Both are `enforce: 'pre'`, so
+    // the array order is what decides which one sees the file first.
     oxContentSolid({
       srcDir: "docs",
       // Auto-discover components using glob pattern
@@ -14,6 +14,6 @@ export default defineConfig({
     }),
     // Solid's JSX is compile-time only, so the Markdown extensions have to be
     // listed here for the generated modules to be compiled at all.
-    solid({ extensions: [".md", ".markdown", ".mdx"] }),
+    solid({ extensions: [".md", ".markdown", ".mdx"], compiler: "native" }),
   ],
 });

--- a/npm/vite-plugin-ox-content-solid/package.json
+++ b/npm/vite-plugin-ox-content-solid/package.json
@@ -44,17 +44,19 @@
     "@ox-content/vite-plugin": "workspace:*"
   },
   "devDependencies": {
+    "@solidjs/vite-plugin": "catalog:",
+    "@solidjs/web": "catalog:",
     "@types/node": "catalog:",
     "@typescript/native-preview": "catalog:",
     "solid-js": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",
-    "vite-plugin-solid": "catalog:",
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "solid-js": "catalog:",
-    "vite": "^0.2.8 || ^8.0.0",
-    "vite-plugin-solid": "catalog:"
+    "@solidjs/vite-plugin": "^3.0.0-next.36",
+    "@solidjs/web": "^2.0.0-rc.4",
+    "solid-js": "^2.0.0-rc.4",
+    "vite": "^8.0.0 || ^9.0.0"
   }
 }

--- a/npm/vite-plugin-ox-content-solid/src/__snapshots__/transform.test.ts.snap
+++ b/npm/vite-plugin-ox-content-solid/src/__snapshots__/transform.test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`transformMarkdownWithSolid > discovers nested, expression, and fragment islands from the MDX AST 1`] = `
 "
-import { onCleanup, onMount } from 'solid-js';
-import { render } from 'solid-js/web';
+import { createEffect, onCleanup } from 'solid-js';
+import { render } from '@solidjs/web';
 import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
 import Callout from '../src/components/Callout.tsx';
 import Badge from '../src/components/Badge.tsx';
@@ -42,7 +42,7 @@ function createSolidHydrate() {
 export default function MarkdownContent() {
   let container;
 
-  onMount(() => {
+  createEffect(() => {
     if (!container) return;
     const controller = initIslands(createSolidHydrate(), {
       selector: '.ox-content [data-ox-island]',
@@ -57,8 +57,8 @@ export default function MarkdownContent() {
 
 exports[`transformMarkdownWithSolid > discovers nested, expression, and fragment islands from the MDX AST 2`] = `
 "
-import { onCleanup, onMount } from 'solid-js';
-import { render } from 'solid-js/web';
+import { createEffect, onCleanup } from 'solid-js';
+import { render } from '@solidjs/web';
 import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
 import Alert from '../src/components/Alert.tsx';
 
@@ -95,7 +95,7 @@ function createSolidHydrate() {
 export default function MarkdownContent() {
   let container;
 
-  onMount(() => {
+  createEffect(() => {
     if (!container) return;
     const controller = initIslands(createSolidHydrate(), {
       selector: '.ox-content [data-ox-island]',
@@ -110,8 +110,8 @@ export default function MarkdownContent() {
 
 exports[`transformMarkdownWithSolid > discovers nested, expression, and fragment islands from the MDX AST 3`] = `
 "
-import { onCleanup, onMount } from 'solid-js';
-import { render } from 'solid-js/web';
+import { createEffect, onCleanup } from 'solid-js';
+import { render } from '@solidjs/web';
 import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
 import Alert from '../src/components/Alert.tsx';
 
@@ -148,7 +148,7 @@ function createSolidHydrate() {
 export default function MarkdownContent() {
   let container;
 
-  onMount(() => {
+  createEffect(() => {
     if (!container) return;
     const controller = initIslands(createSolidHydrate(), {
       selector: '.ox-content [data-ox-island]',
@@ -175,8 +175,8 @@ export default function MarkdownContent() {
 
 exports[`transformMarkdownWithSolid > turns registered components into islands and leaves fenced tags literal 1`] = `
 "
-import { onCleanup, onMount } from 'solid-js';
-import { render } from 'solid-js/web';
+import { createEffect, onCleanup } from 'solid-js';
+import { render } from '@solidjs/web';
 import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
 import Alert from '../src/components/Alert.tsx';
 
@@ -213,7 +213,7 @@ function createSolidHydrate() {
 export default function MarkdownContent() {
   let container;
 
-  onMount(() => {
+  createEffect(() => {
     if (!container) return;
     const controller = initIslands(createSolidHydrate(), {
       selector: '.ox-content [data-ox-island]',

--- a/npm/vite-plugin-ox-content-solid/src/codegen.ts
+++ b/npm/vite-plugin-ox-content-solid/src/codegen.ts
@@ -2,8 +2,8 @@
  * Generates the Solid module a Markdown file compiles to.
  *
  * The output is JSX on purpose. Solid has no runtime element factory to target
- * — `vite-plugin-solid` compiles this into DOM or SSR instructions — so unlike
- * the React and Vue integrations there is no factory-call form to emit.
+ * — the Solid Vite plugin compiles this into DOM or SSR instructions — so
+ * unlike the React and Vue integrations there is no factory-call form to emit.
  */
 
 import {
@@ -48,8 +48,8 @@ export default function MarkdownContent() {
   const componentMap = usedComponents.map((name) => `  ${name},`).join("\n");
 
   return `
-import { onCleanup, onMount } from 'solid-js';
-import { render } from 'solid-js/web';
+import { createEffect, onCleanup } from 'solid-js';
+import { render } from '@solidjs/web';
 import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
 ${imports}
 
@@ -86,7 +86,7 @@ function createSolidHydrate() {
 export default function MarkdownContent() {
   let container;
 
-  onMount(() => {
+  createEffect(() => {
     if (!container) return;
     const controller = initIslands(createSolidHydrate(), {
       selector: '.ox-content [data-ox-island]',

--- a/npm/vite-plugin-ox-content-solid/src/environment.ts
+++ b/npm/vite-plugin-ox-content-solid/src/environment.ts
@@ -25,7 +25,7 @@ export function createSolidMarkdownEnvironment(
       conditions: isSSR ? ["solid", "node", "import"] : ["solid", "browser", "import"],
     },
     optimizeDeps: {
-      include: isSSR ? [] : ["solid-js", "solid-js/web"],
+      include: isSSR ? [] : ["solid-js", "@solidjs/web"],
       exclude: ["@ox-content/vite-plugin", "@ox-content/vite-plugin-solid"],
     },
   };

--- a/npm/vite-plugin-ox-content-solid/src/index.test.ts
+++ b/npm/vite-plugin-ox-content-solid/src/index.test.ts
@@ -1,9 +1,17 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import solid from "@solidjs/vite-plugin";
 import { describe, expect, it } from "vite-plus/test";
-import type { Plugin, ResolvedConfig } from "vite";
+import { build, type Plugin, type ResolvedConfig } from "vite";
 import { oxContentSolid } from "./index";
 import type { SolidIntegrationOptions } from "./types";
+import { formatSolidPluginError } from "./verify";
 
 describe("oxContentSolid", () => {
+  const packageNodeModules = fileURLToPath(new URL("../node_modules/", import.meta.url));
+
   it("returns the transform, verify, environment and hmr plugins", () => {
     const names = pluginNames(oxContentSolid());
 
@@ -13,19 +21,19 @@ describe("oxContentSolid", () => {
     expect(names).toContain("ox-content:solid-hmr");
   });
 
-  it("accepts a config where vite-plugin-solid runs after it", async () => {
+  it("accepts a config where @solidjs/vite-plugin runs after it", async () => {
     await expect(
       resolveConfigWith({}, ["ox-content:solid-transform", "solid"]),
     ).resolves.toBeUndefined();
   });
 
-  it("rejects a config without vite-plugin-solid", async () => {
+  it("rejects a config without @solidjs/vite-plugin", async () => {
     await expect(resolveConfigWith({}, ["ox-content:solid-transform"])).rejects.toThrow(
-      /vite-plugin-solid was not found/,
+      /@solidjs\/vite-plugin was not found/,
     );
   });
 
-  it("rejects a config where vite-plugin-solid runs first", async () => {
+  it("rejects a config where @solidjs/vite-plugin runs first", async () => {
     // Solid would receive raw Markdown instead of the generated JSX.
     await expect(resolveConfigWith({}, ["solid", "ox-content:solid-transform"])).rejects.toThrow(
       /runs before oxContentSolid\(\)/,
@@ -57,11 +65,157 @@ describe("oxContentSolid", () => {
 
     expect(() =>
       runTransform('<div class="ox-content" innerHTML={rawHtml} />', "/docs/a.md"),
-    ).toThrow(/`extensions` option must list the Markdown extensions/);
+    ).toThrow(/`extensions` option must list \.md, \.markdown, and \.mdx/);
 
     // Compiled output and non-Markdown ids pass straight through.
     expect(runTransform("_$template(`<div class=ox-content>`)", "/docs/a.md")).toBeNull();
     expect(runTransform('<div class="ox-content" innerHTML={rawHtml} />', "/src/a.ts")).toBeNull();
+  });
+
+  it("formats setup diagnostics for the Solid 2 native compiler", () => {
+    const message = formatSolidPluginError("extensions");
+
+    expect(message).toContain("@solidjs/vite-plugin");
+    expect(message).toContain("compiler: 'native'");
+    expect(message).not.toContain("babel-preset-solid");
+  });
+
+  it("builds Markdown and MDX modules with Solid 2's native compiler", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "ox-solid-native-"));
+
+    try {
+      await fs.mkdir(path.join(root, "docs", "widgets"), { recursive: true });
+      await fs.mkdir(path.join(root, "src", "components"), { recursive: true });
+
+      await fs.writeFile(
+        path.join(root, "index.html"),
+        '<div id="app"></div><script type="module" src="/src/main.tsx"></script>',
+      );
+      await fs.writeFile(
+        path.join(root, "src", "main.tsx"),
+        [
+          'import { render } from "@solidjs/web";',
+          'import StaticDoc from "../docs/static.md";',
+          'import NotesDoc from "../docs/notes.markdown";',
+          'import IslandDoc from "../docs/island.mdx";',
+          "",
+          'render(() => <><StaticDoc /><NotesDoc /><IslandDoc /></>, document.getElementById("app")!);',
+        ].join("\n"),
+      );
+      await fs.writeFile(
+        path.join(root, "src", "components", "Alert.tsx"),
+        [
+          'import type { JSX } from "solid-js";',
+          "",
+          "export default function Alert(props: { tone?: string; children?: JSX.Element }) {",
+          '  return <section data-alert={props.tone ?? "info"}>{props.children}</section>;',
+          "}",
+        ].join("\n"),
+      );
+      await fs.writeFile(path.join(root, "docs", "static.md"), "# Static\n\nPlain Markdown.");
+      await fs.writeFile(path.join(root, "docs", "notes.markdown"), "# Notes\n\nMore Markdown.");
+      await fs.writeFile(
+        path.join(root, "docs", "widgets", "Badge.tsx"),
+        [
+          "export default function Badge(props: { label: string }) {",
+          "  return <span data-badge={props.label}>{props.label}</span>;",
+          "}",
+        ].join("\n"),
+      );
+      await fs.writeFile(
+        path.join(root, "docs", "island.mdx"),
+        [
+          "import Badge from './widgets/Badge.tsx'",
+          "",
+          "# Island",
+          "",
+          '<Alert tone="success">Registered island</Alert>',
+          "",
+          '<Badge label="local" />',
+        ].join("\n"),
+      );
+
+      await build({
+        root,
+        configFile: false,
+        logLevel: "silent",
+        plugins: [
+          oxContentSolid({
+            srcDir: "docs",
+            components: { Alert: "./src/components/Alert.tsx" },
+            embeds: { github: false, openGraph: false },
+          }),
+          solid({ extensions: [".md", ".markdown", ".mdx"], compiler: "native" }),
+        ],
+        resolve: {
+          alias: {
+            "@ox-content/islands": fileURLToPath(
+              new URL("../../ox-content-islands/src/index.ts", import.meta.url),
+            ),
+            "@solidjs/web": path.join(packageNodeModules, "@solidjs/web/dist/web.js"),
+            "solid-js": path.join(packageNodeModules, "solid-js/dist/solid.js"),
+          },
+        },
+        build: {
+          outDir: "dist",
+          emptyOutDir: true,
+          rollupOptions: {
+            input: path.join(root, "index.html"),
+          },
+        },
+      });
+
+      const assetDir = path.join(root, "dist", "assets");
+      const bundle = (
+        await Promise.all(
+          (await fs.readdir(assetDir))
+            .filter((file) => file.endsWith(".js"))
+            .map((file) => fs.readFile(path.join(assetDir, file), "utf8")),
+        )
+      ).join("\n");
+
+      expect(bundle).not.toContain("innerHTML={rawHtml}");
+      expect(bundle).not.toContain("<Alert");
+      expect(bundle).not.toContain("<Badge");
+      expect(bundle).toContain("data-ox-island");
+    } finally {
+      await fs.rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("invalidates Markdown modules when a registered Solid component changes", () => {
+    const hmr = findPlugin(
+      oxContentSolid({ components: { Alert: "./src/components/Alert.tsx" } }),
+      "ox-content:solid-hmr",
+    );
+    const changedModule = { file: "/repo/src/components/Alert.tsx" };
+    const markdownModule = { file: "/repo/docs/index.md" };
+    const messages: unknown[] = [];
+    const context = {
+      file: "/repo/src/components/Alert.tsx",
+      modules: [changedModule],
+      server: {
+        moduleGraph: {
+          idToModuleMap: new Map([["/repo/docs/index.md", markdownModule]]),
+        },
+        ws: {
+          send(message: unknown) {
+            messages.push(message);
+          },
+        },
+      },
+    };
+
+    const result = (hmr.handleHotUpdate as (context: unknown) => unknown)(context);
+
+    expect(result).toEqual([changedModule, markdownModule]);
+    expect(messages).toEqual([
+      {
+        type: "custom",
+        event: "ox-content:solid-update",
+        data: { file: "/repo/src/components/Alert.tsx" },
+      },
+    ]);
   });
 });
 

--- a/npm/vite-plugin-ox-content-solid/src/index.ts
+++ b/npm/vite-plugin-ox-content-solid/src/index.ts
@@ -35,16 +35,16 @@ export type {
  * Creates the Ox Content Solid integration plugin.
  *
  * Unlike the React and Svelte integrations, this plugin must be listed **before**
- * `vite-plugin-solid`, and that plugin must be told about the Markdown
+ * `@solidjs/vite-plugin`, and that plugin must be told about the Markdown
  * extensions. Markdown is turned into Solid JSX here, and Solid's JSX is
- * compile-time only — `vite-plugin-solid` is what turns it into DOM or SSR
- * instructions.
+ * compile-time only — the Solid 2 Vite plugin is what turns it into DOM or SSR
+ * instructions through its native compiler.
  *
  * @example
  * ```ts
  * // vite.config.ts
  * import { defineConfig } from 'vite';
- * import solid from 'vite-plugin-solid';
+ * import solid from '@solidjs/vite-plugin';
  * import { oxContentSolid } from '@ox-content/vite-plugin-solid';
  *
  * export default defineConfig({
@@ -55,7 +55,7 @@ export type {
  *         Counter: './src/components/Counter.tsx',
  *       },
  *     }),
- *     solid({ extensions: ['.md', '.markdown', '.mdx'] }),
+ *     solid({ extensions: ['.md', '.markdown', '.mdx'], compiler: 'native' }),
  *   ],
  * });
  * ```
@@ -106,7 +106,7 @@ export function oxContentSolid(options: SolidIntegrationOptions = {}): PluginOpt
     },
   };
 
-  // `post` so every `pre`/normal plugin — vite-plugin-solid included — has
+  // `post` so every `pre`/normal plugin — @solidjs/vite-plugin included — has
   // already had its turn at the module.
   const solidVerifyPlugin: Plugin = {
     name: "ox-content:solid-verify",

--- a/npm/vite-plugin-ox-content-solid/src/transform.test.ts
+++ b/npm/vite-plugin-ox-content-solid/src/transform.test.ts
@@ -127,8 +127,8 @@ describe("transformMarkdownWithSolid", () => {
     );
 
     // Solid has no runtime JSX factory: the generated module stays JSX and is
-    // compiled by vite-plugin-solid. The `class` (not `className`) attribute is
-    // part of that contract.
+    // compiled by @solidjs/vite-plugin. The `class` (not `className`) attribute
+    // is part of that contract.
     expect(result.code).toContain('<div class="ox-content" innerHTML={rawHtml} />');
     expect(result.code).not.toContain("createElement");
   });
@@ -147,15 +147,15 @@ describe("transformMarkdownWithSolid", () => {
     expect(result.code).toContain("title: Solid Guide");
   });
 
-  it("mounts islands through solid-js/web render", async () => {
+  it("mounts islands through @solidjs/web render", async () => {
     const result = await transformMarkdownWithSolid(
       '<Alert tone="info">Body</Alert>',
       "/repo/docs/island.md",
       createOptions(),
     );
 
-    expect(result.code).toContain(`import { render } from 'solid-js/web';`);
-    expect(result.code).toContain(`import { onCleanup, onMount } from 'solid-js';`);
+    expect(result.code).toContain(`import { render } from '@solidjs/web';`);
+    expect(result.code).toContain(`import { createEffect, onCleanup } from 'solid-js';`);
     expect(result.code).toContain("initIslands(createSolidHydrate()");
   });
 });

--- a/npm/vite-plugin-ox-content-solid/src/types.ts
+++ b/npm/vite-plugin-ox-content-solid/src/types.ts
@@ -43,7 +43,7 @@ export type ComponentsOption = ComponentsMap | string | string[];
  * still provides shared parsing, embeds, and environment setup.
  *
  * Solid has no runtime JSX factory, so the generated modules must still be
- * compiled by `vite-plugin-solid`. See {@link SolidIntegrationOptions.verifySolidPlugin}.
+ * compiled by `@solidjs/vite-plugin`. See {@link SolidIntegrationOptions.verifySolidPlugin}.
  */
 export interface SolidIntegrationOptions extends OxContentOptions {
   /**
@@ -84,25 +84,24 @@ export interface SolidIntegrationOptions extends OxContentOptions {
   codeAnnotations?: boolean | CodeAnnotationsOptions;
 
   /**
-   * Fail fast when `vite-plugin-solid` cannot compile the generated modules.
+   * Fail fast when `@solidjs/vite-plugin` cannot compile the generated modules.
    *
    * Markdown files are emitted as Solid JSX, and Solid's JSX has no runtime
-   * factory to fall back on: it only works after `babel-preset-solid` has
-   * compiled it. `vite-plugin-solid` only looks at `.jsx`/`.tsx` ids unless its
-   * own `extensions` option lists the Markdown extensions too, so a missing
-   * entry surfaces as an opaque syntax error in an unrelated file.
+   * factory to fall back on. `@solidjs/vite-plugin` only compiles Markdown ids
+   * when its `extensions` option lists the Markdown extensions too, so a
+   * missing entry surfaces as an opaque syntax error in an unrelated file.
    *
    * With this enabled the plugin checks the resolved plugin list and throws a
    * message naming the extensions that are missing. Turn it off when Solid JSX
-   * is compiled by something other than `vite-plugin-solid`.
+   * is compiled by something other than `@solidjs/vite-plugin`.
    *
    * @default true
    *
    * @example
    * ```ts
    * plugins: [
-   *   solid({ extensions: ['.md', '.markdown', '.mdx'] }),
    *   oxContentSolid({ srcDir: 'docs' }),
+   *   solid({ extensions: ['.md', '.markdown', '.mdx'], compiler: 'native' }),
    * ]
    * ```
    */

--- a/npm/vite-plugin-ox-content-solid/src/verify.ts
+++ b/npm/vite-plugin-ox-content-solid/src/verify.ts
@@ -1,5 +1,5 @@
 /**
- * Guards against the two ways `vite-plugin-solid` can fail to compile the
+ * Guards against the two ways the Solid Vite plugin can fail to compile the
  * Markdown modules this plugin emits.
  *
  * Both are configuration mistakes with silent-until-cryptic failure modes, so
@@ -14,6 +14,7 @@ import type { ResolvedConfig } from "vite";
 export const TRANSFORM_PLUGIN_NAME = "ox-content:solid-transform";
 
 const SOLID_PLUGIN_NAME = "solid";
+const SOLID_PLUGIN_PACKAGE = "@solidjs/vite-plugin";
 
 /**
  * Emitted by both generated module shapes. Solid's JSX has no runtime factory,
@@ -24,27 +25,36 @@ export const UNCOMPILED_JSX_MARKER = "innerHTML={rawHtml}";
 
 export function formatSolidPluginError(reason: "missing" | "ordering" | "extensions"): string {
   const example = [
+    "  import solid from '@solidjs/vite-plugin';",
+    "",
     "  plugins: [",
     "    oxContentSolid({ srcDir: 'docs' }),",
-    "    solid({ extensions: ['.md', '.markdown', '.mdx'] }),",
+    "    solid({ extensions: ['.md', '.markdown', '.mdx'], compiler: 'native' }),",
     "  ]",
   ].join("\n");
 
   const detail = {
-    missing:
-      "vite-plugin-solid was not found in the Vite config. Markdown files are emitted as Solid JSX, which only runs after babel-preset-solid compiles it.",
-    ordering:
-      "vite-plugin-solid runs before oxContentSolid(), so it sees raw Markdown instead of the generated JSX. Both plugins are `enforce: 'pre'`, so their order follows the `plugins` array.",
-    extensions:
-      "vite-plugin-solid did not compile the generated Markdown module. Its `extensions` option must list the Markdown extensions; by default it only looks at .jsx/.tsx files.",
-  }[reason];
+    missing: [
+      `${SOLID_PLUGIN_PACKAGE} was not found in the Vite config.`,
+      "Markdown files are emitted as Solid JSX and must be compiled by Solid's Vite plugin.",
+    ],
+    ordering: [
+      `${SOLID_PLUGIN_PACKAGE} runs before oxContentSolid(), so it sees raw Markdown instead of the generated JSX.`,
+      "Both plugins are `enforce: 'pre'`, so their order follows the `plugins` array.",
+    ],
+    extensions: [
+      `${SOLID_PLUGIN_PACKAGE} did not compile the generated Markdown module.`,
+      "Its `extensions` option must list .md, .markdown, and .mdx.",
+      "The documented Solid 2 path uses `compiler: 'native'`.",
+    ],
+  }[reason].join(" ");
 
   return `[ox-content:solid] ${detail}\n\n${example}\n`;
 }
 
 /**
- * Throws when `vite-plugin-solid` is absent, or placed where it would see raw
- * Markdown instead of the JSX this plugin generates.
+ * Throws when the Solid Vite plugin is absent, or placed where it would see
+ * raw Markdown instead of the JSX this plugin generates.
  */
 export function verifySolidPluginOrder(config: ResolvedConfig): void {
   const names = config.plugins.map((plugin) => plugin.name);

--- a/npm/vite-plugin-ox-content-solid/vite.config.ts
+++ b/npm/vite-plugin-ox-content-solid/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     clean: true,
     hash: false,
     deps: {
-      neverBundle: ["vite", "solid-js", "@ox-content/vite-plugin"],
+      neverBundle: ["vite", "solid-js", "@solidjs/web", "@ox-content/vite-plugin"],
     },
   }),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,12 @@ settings:
 
 catalogs:
   default:
+    '@solidjs/vite-plugin':
+      specifier: ^3.0.0-next.36
+      version: 3.0.0-next.36
+    '@solidjs/web':
+      specifier: ^2.0.0-rc.4
+      version: 2.0.0-rc.4
     '@sveltejs/vite-plugin-svelte':
       specifier: ^7.2.0
       version: 7.3.0
@@ -138,17 +144,14 @@ catalogs:
       specifier: ^19.0.0
       version: 19.2.8
     solid-js:
-      specifier: ^1.9.15
-      version: 1.9.15
+      specifier: ^2.0.0-rc.4
+      version: 2.0.0-rc.4
     svelte:
       specifier: ^5.56.10
       version: 5.56.10
     typescript:
       specifier: ^7.0.2
       version: 7.0.2
-    vite-plugin-solid:
-      specifier: ^2.11.14
-      version: 2.11.14
     vite-plus:
       specifier: 0.3.0
       version: 0.3.0
@@ -236,16 +239,16 @@ importers:
     dependencies:
       astro:
         specifier: ^7.2.4
-        version: 7.2.4(@astrojs/markdown-remark@7.2.4(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)
+        version: 7.2.4(@astrojs/markdown-remark@7.2.4(supports-color@10.2.2))(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)
 
   benchmarks/bundle-size/apps/astro-vue:
     dependencies:
       '@astrojs/vue':
         specifier: ^7.0.2
-        version: 7.0.2(@types/node@26.2.0)(astro@7.2.4(@astrojs/markdown-remark@7.2.4(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@1.21.7)(supports-color@10.2.2)(terser@5.49.0)(vue@3.5.41(typescript@7.0.2))(yaml@2.9.0)
+        version: 7.0.2(@types/node@26.2.0)(astro@7.2.4(@astrojs/markdown-remark@7.2.4(supports-color@10.2.2))(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@1.21.7)(supports-color@10.2.2)(terser@5.49.0)(vue@3.5.41(typescript@7.0.2))(yaml@2.9.0)
       astro:
         specifier: ^7.2.4
-        version: 7.2.4(@astrojs/markdown-remark@7.2.4(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)
+        version: 7.2.4(@astrojs/markdown-remark@7.2.4(supports-color@10.2.2))(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)
       vue:
         specifier: 'catalog:'
         version: 3.5.41(typescript@7.0.2)
@@ -479,19 +482,22 @@ importers:
       '@ox-content/islands':
         specifier: workspace:*
         version: link:../../npm/ox-content-islands
+      '@solidjs/web':
+        specifier: 'catalog:'
+        version: 2.0.0-rc.4(solid-js@2.0.0-rc.4)
       solid-js:
         specifier: 'catalog:'
-        version: 1.9.15
+        version: 2.0.0-rc.4
     devDependencies:
       '@ox-content/vite-plugin-solid':
         specifier: workspace:*
         version: link:../../npm/vite-plugin-ox-content-solid
+      '@solidjs/vite-plugin':
+        specifier: 'catalog:'
+        version: 3.0.0-next.36(@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(solid-js@2.0.0-rc.4)(supports-color@10.2.2)
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.2.8
         version: '@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)'
-      vite-plugin-solid:
-        specifier: 'catalog:'
-        version: 2.11.14(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(solid-js@1.9.15)
       vite-plus:
         specifier: 'catalog:'
         version: 0.3.0(@types/node@26.2.0)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.2)(jiti@1.21.7)(svelte@5.56.10)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)
@@ -2361,6 +2367,12 @@ importers:
         specifier: workspace:*
         version: link:../vite-plugin-ox-content
     devDependencies:
+      '@solidjs/vite-plugin':
+        specifier: 'catalog:'
+        version: 3.0.0-next.36(@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(solid-js@2.0.0-rc.4)(supports-color@10.2.2)
+      '@solidjs/web':
+        specifier: 'catalog:'
+        version: 2.0.0-rc.4(solid-js@2.0.0-rc.4)
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0
@@ -2369,16 +2381,13 @@ importers:
         version: 7.0.0-dev.20260707.2
       solid-js:
         specifier: 'catalog:'
-        version: 1.9.15
+        version: 2.0.0-rc.4
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.2.8
         version: '@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)'
-      vite-plugin-solid:
-        specifier: 'catalog:'
-        version: 2.11.14(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(solid-js@1.9.15)
       vite-plus:
         specifier: 'catalog:'
         version: 0.3.0(@types/node@26.2.0)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.2)(jiti@1.21.7)(svelte@5.56.10)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)
@@ -2560,6 +2569,10 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
@@ -2656,24 +2669,12 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.29.3':
-    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/compat-data@7.29.7':
     resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/core@7.29.7':
     resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.29.8':
@@ -2682,10 +2683,6 @@ packages:
 
   '@babel/helper-annotate-as-pure@7.29.7':
     resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-compilation-targets@7.28.6':
-    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.29.7':
@@ -2697,10 +2694,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
-
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/helper-globals@7.29.7':
     resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
@@ -2714,19 +2707,9 @@ packages:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-imports@7.28.6':
-    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-module-imports@7.29.7':
     resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-transforms@7.28.6':
-    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
 
   '@babel/helper-module-transforms@7.29.7':
     resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
@@ -2764,16 +2747,8 @@ packages:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-option@7.27.1':
-    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-validator-option@7.29.7':
     resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helpers@7.29.2':
-    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helpers@7.29.7':
@@ -2813,12 +2788,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-jsx@7.28.6':
-    resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-syntax-jsx@7.29.7':
     resolution: {integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==}
     engines: {node: '>=6.9.0'}
@@ -2841,16 +2810,8 @@ packages:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.28.6':
-    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.29.0':
-    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.29.8':
@@ -3210,6 +3171,9 @@ packages:
   '@emnapi/core@1.11.2':
     resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
 
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
+
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
@@ -3233,6 +3197,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@esbuild/aix-ppc64@0.28.2':
     resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
@@ -5154,6 +5121,68 @@ packages:
     engines: {node: '>= 8.0.0'}
     hasBin: true
 
+  '@solidjs/babel-plugin@2.0.0-rc.4':
+    resolution: {integrity: sha512-4RYR4PWAlQIz1dmIyPheaUvVb9EnSIw5KIGsEISmHod5qfT1IPVKgtb9bctyQ5FeDAuc7JcpbkFYN2heLrk6rQ==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.4':
+    resolution: {integrity: sha512-YR4T15ucsV1Vb4J6yaHxss2hakdcbZ353ye53AhX+FWNayuEhO/Cyjdtb9uS38Dfzysok/rIEQdaeZcaXt+rPA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.4':
+    resolution: {integrity: sha512-95SkVSyXP2eh7PvPWi+fTeH5aTcTwOUvRV7ubeUrutE4akW3ndq1N8cvg2WZ+LhKrf2pvDO0eSDEZ72I769CLg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.4':
+    resolution: {integrity: sha512-36Ht+EUAVUt8fAxq8zlfPS0+vZ61hfJRJDiX1HDNXvlAwZE1B7FH/ym1wfXrhG1TvrNA63Sjjj5CeccYO2H4Tg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.4':
+    resolution: {integrity: sha512-DSFOQEjfYmmRQ70pNLamRXPNQ+aP+5vyh1rMjSKwAzONt0xB2rcy9Alt02GU38gztW9YN6ZyxM4rwkYe+7MfaQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.4':
+    resolution: {integrity: sha512-zVxXS+01rbv+0yOp2vaGjIu0om5I1UhhPpzNYeE+AmfpVc2eCWxqDsPai3dIxFDGPTjaJ+npwjKJRmOTaoknRw==}
+    engines: {node: '>=14.0.0'}
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.4':
+    resolution: {integrity: sha512-DkzTHMZXzaiL/KhL76UJWN24pKkkXeLpPYtDxUqX6VaKuOCPDmp/m7GLWSDrqCdF7leuYsig2MuMJTXZRLOkbQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@solidjs/compiler@2.0.0-rc.4':
+    resolution: {integrity: sha512-lKx6Jp1KbHxqO+v+g7cRbm8I1DHx/10Lj8bKG4vmdGnCfSlFbyhCd8cPTLdLV0YVG7GGSzzF5m8NkC9NlfGN5w==}
+
+  '@solidjs/signals@2.0.0-rc.4':
+    resolution: {integrity: sha512-l7P0g8+2pnNscaIPOGDMhv0boaidGAsvR8QN66JySIWNMvVnuq2ayv7ZnvP+IR00DJC+RqCNnnTG/UCdxf+h8g==}
+
+  '@solidjs/vite-plugin@3.0.0-next.36':
+    resolution: {integrity: sha512-PMreKx9IeQwSRt6xt8LQHe58Gk79CVaB57PQMlvXUdbyL5JliaehOSg5a4W6bKoJfeWku7nryEWUvTDKyZ2PBg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@solidjs/start-devtools': ^1.0.0-next.2
+      '@solidjs/web': ^2.0.0-rc.0
+      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
+      solid-js: ^2.0.0-rc.0
+      vite: 8.0.16
+    peerDependenciesMeta:
+      '@solidjs/start-devtools':
+        optional: true
+      '@testing-library/jest-dom':
+        optional: true
+
+  '@solidjs/web@2.0.0-rc.4':
+    resolution: {integrity: sha512-acM9W0FByf0aJDMG5kMbHr0BLTjvFIg8lxwLwHzsu3ybWSmsP1FiOOs2RHNItve/AiX+MGR9CQBCazmnfPykEA==}
+    peerDependencies:
+      solid-js: ^2.0.0-rc.4
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -6334,20 +6363,6 @@ packages:
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
-
-  babel-plugin-jsx-dom-expressions@0.40.7:
-    resolution: {integrity: sha512-/O6JWUmjv03OI9lL2ry9bUjpD5S3PclM55RRJEyCdcFZ5W2SEA/59d+l2hNsk3gI6kiWRdRPdOtqZmsQzFN1pQ==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
-
-  babel-preset-solid@1.9.12:
-    resolution: {integrity: sha512-LLqnuKVDlKpyBlMPcH6qEvs/wmS9a+NczppxJ3ryS/c0O5IiSFOIBQi9GzyiGDSbcJpx4Gr87jyFTos1MyEuWg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      solid-js: ^1.9.12
-    peerDependenciesMeta:
-      solid-js:
-        optional: true
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -8846,13 +8861,8 @@ packages:
     resolution: {integrity: sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==}
     engines: {node: '>= 18'}
 
-  solid-js@1.9.15:
-    resolution: {integrity: sha512-EeiY2xfpZJqPLjXspVEKjAII4yv8NyG//NxZ3IpOFHdUNnnTyL0uJOeS9LWGvA7cFCz5y94cjFwYlmw5Luncsg==}
-
-  solid-refresh@0.6.3:
-    resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
-    peerDependencies:
-      solid-js: ^1.3
+  solid-js@2.0.0-rc.4:
+    resolution: {integrity: sha512-hSkDmtduesjFtvzjNyqLphrqiSvhSD5+njkPQUR+9YEoR60MMWtuv36SbLL4OucI0Ronof3Jc+AsUp0oWffwMg==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -9270,6 +9280,9 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
+  validate-html-nesting@1.2.4:
+    resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
+
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
@@ -9297,16 +9310,6 @@ packages:
       vite: 8.0.16
     peerDependenciesMeta:
       '@nuxt/kit':
-        optional: true
-
-  vite-plugin-solid@2.11.14:
-    resolution: {integrity: sha512-7ZVBt8rpoyqmlwin2kRIUveaHoF6/kulY7gsnD+qFh4nS29V4OPAnw+ojoAspXIjObiL9o1xh9a/nTuYHm02Rw==}
-    peerDependencies:
-      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.0.0 || ^7.0.0
-      solid-js: ^1.7.2
-      vite: 8.0.16
-    peerDependenciesMeta:
-      '@testing-library/jest-dom':
         optional: true
 
   vite-plugin-vue-devtools@8.2.1:
@@ -9765,6 +9768,11 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.8.0
@@ -9788,9 +9796,9 @@ snapshots:
   '@astrojs/compiler-binding-linux-x64-musl@0.3.2':
     optional: true
 
-  '@astrojs/compiler-binding-wasm32-wasi@0.3.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)':
+  '@astrojs/compiler-binding-wasm32-wasi@0.3.2(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -9802,7 +9810,7 @@ snapshots:
   '@astrojs/compiler-binding-win32-x64-msvc@0.3.2':
     optional: true
 
-  '@astrojs/compiler-binding@0.3.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)':
+  '@astrojs/compiler-binding@0.3.2(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     optionalDependencies:
       '@astrojs/compiler-binding-darwin-arm64': 0.3.2
       '@astrojs/compiler-binding-darwin-x64': 0.3.2
@@ -9810,16 +9818,16 @@ snapshots:
       '@astrojs/compiler-binding-linux-arm64-musl': 0.3.2
       '@astrojs/compiler-binding-linux-x64-gnu': 0.3.2
       '@astrojs/compiler-binding-linux-x64-musl': 0.3.2
-      '@astrojs/compiler-binding-wasm32-wasi': 0.3.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)
+      '@astrojs/compiler-binding-wasm32-wasi': 0.3.2(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
       '@astrojs/compiler-binding-win32-arm64-msvc': 0.3.2
       '@astrojs/compiler-binding-win32-x64-msvc': 0.3.2
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@astrojs/compiler-rs@0.3.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)':
+  '@astrojs/compiler-rs@0.3.2(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@astrojs/compiler-binding': 0.3.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)
+      '@astrojs/compiler-binding': 0.3.2(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -9875,12 +9883,12 @@ snapshots:
       is-docker: 4.0.0
       package-manager-detector: 1.8.0
 
-  '@astrojs/vue@7.0.2(@types/node@26.2.0)(astro@7.2.4(@astrojs/markdown-remark@7.2.4(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@1.21.7)(supports-color@10.2.2)(terser@5.49.0)(vue@3.5.41(typescript@7.0.2))(yaml@2.9.0)':
+  '@astrojs/vue@7.0.2(@types/node@26.2.0)(astro@7.2.4(@astrojs/markdown-remark@7.2.4(supports-color@10.2.2))(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@1.21.7)(supports-color@10.2.2)(terser@5.49.0)(vue@3.5.41(typescript@7.0.2))(yaml@2.9.0)':
     dependencies:
       '@vitejs/plugin-vue': 6.0.8(vite@8.0.16(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))
       '@vitejs/plugin-vue-jsx': 5.1.6(supports-color@10.2.2)(vite@8.0.16(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))
       '@vue/compiler-sfc': 3.5.41
-      astro: 7.2.4(@astrojs/markdown-remark@7.2.4(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)
+      astro: 7.2.4(@astrojs/markdown-remark@7.2.4(supports-color@10.2.2))(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)
       vite: 8.0.16(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)
       vite-plugin-vue-devtools: 8.2.1(supports-color@10.2.2)(vite@8.0.16(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))
       vue: 3.5.41(typescript@7.0.2)
@@ -9906,29 +9914,7 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.29.3': {}
-
   '@babel/compat-data@7.29.7': {}
-
-  '@babel/core@7.29.0':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.1
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.8
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.8
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/core@7.29.7(supports-color@10.2.2)':
     dependencies:
@@ -9950,14 +9936,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.29.1':
-    dependencies:
-      '@babel/parser': 7.29.8
-      '@babel/types': 7.29.8
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
-
   '@babel/generator@7.29.8':
     dependencies:
       '@babel/parser': 7.29.8
@@ -9969,14 +9947,6 @@ snapshots:
   '@babel/helper-annotate-as-pure@7.29.7':
     dependencies:
       '@babel/types': 7.29.8
-
-  '@babel/helper-compilation-targets@7.28.6':
-    dependencies:
-      '@babel/compat-data': 7.29.3
-      '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.7
-      lru-cache: 5.1.1
-      semver: 6.3.1
 
   '@babel/helper-compilation-targets@7.29.7':
     dependencies:
@@ -9999,8 +9969,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-globals@7.28.0': {}
-
   '@babel/helper-globals@7.29.7': {}
 
   '@babel/helper-member-expression-to-functions@7.29.7(supports-color@10.2.2)':
@@ -10014,26 +9982,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.8
 
-  '@babel/helper-module-imports@7.28.6':
-    dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-module-imports@7.29.7(supports-color@10.2.2)':
     dependencies:
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
       '@babel/types': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10074,14 +10026,7 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/helper-validator-option@7.27.1': {}
-
   '@babel/helper-validator-option@7.29.7': {}
-
-  '@babel/helpers@7.29.2':
-    dependencies:
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.8
 
   '@babel/helpers@7.29.7':
     dependencies:
@@ -10120,11 +10065,6 @@ snapshots:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
@@ -10148,29 +10088,11 @@ snapshots:
 
   '@babel/runtime@7.29.7': {}
 
-  '@babel/template@7.28.6':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/parser': 7.29.8
-      '@babel/types': 7.29.8
-
   '@babel/template@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
-
-  '@babel/traverse@7.29.0':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.1
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.8
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.8
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/traverse@7.29.8(supports-color@10.2.2)':
     dependencies:
@@ -10513,6 +10435,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.11.3':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.3
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.9.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -10550,6 +10478,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -11270,9 +11203,9 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)':
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.11.2
+      '@emnapi/core': 1.11.3
       '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
@@ -11932,6 +11865,70 @@ snapshots:
     dependencies:
       fflate: 0.7.3
       string.prototype.codepointat: 0.2.1
+
+  '@solidjs/babel-plugin@2.0.0-rc.4(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/types': 7.29.8
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.4':
+    optional: true
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.4':
+    optional: true
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.4':
+    optional: true
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.4':
+    optional: true
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.4':
+    dependencies:
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.4':
+    optional: true
+
+  '@solidjs/compiler@2.0.0-rc.4':
+    optionalDependencies:
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.4
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.4
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.4
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.4
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.4
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.4
+
+  '@solidjs/signals@2.0.0-rc.4': {}
+
+  '@solidjs/vite-plugin@3.0.0-next.36(@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(solid-js@2.0.0-rc.4)(supports-color@10.2.2)':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@solidjs/babel-plugin': 2.0.0-rc.4(@babel/core@7.29.7(supports-color@10.2.2))
+      '@solidjs/compiler': 2.0.0-rc.4
+      '@solidjs/web': 2.0.0-rc.4(solid-js@2.0.0-rc.4)
+      '@types/babel__core': 7.20.5
+      merge-anything: 5.1.7
+      solid-js: 2.0.0-rc.4
+      vite: '@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)'
+      vitefu: 1.1.3(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4)':
+    dependencies:
+      seroval: 1.5.6
+      seroval-plugins: 1.5.6(seroval@1.5.6)
+      solid-js: 2.0.0-rc.4
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -13055,9 +13052,9 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  astro@7.2.4(@astrojs/markdown-remark@7.2.4(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0):
+  astro@7.2.4(@astrojs/markdown-remark@7.2.4(supports-color@10.2.2))(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0):
     dependencies:
-      '@astrojs/compiler-rs': 0.3.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)
+      '@astrojs/compiler-rs': 0.3.2(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
       '@astrojs/internal-helpers': 0.10.4
       '@astrojs/markdown-satteri': 0.3.7
       '@astrojs/telemetry': 3.3.3
@@ -13148,22 +13145,6 @@ snapshots:
       - yaml
 
   axobject-query@4.1.0: {}
-
-  babel-plugin-jsx-dom-expressions@0.40.7(@babel/core@7.29.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/types': 7.29.8
-      html-entities: 2.3.3
-      parse5: 7.3.0
-
-  babel-preset-solid@1.9.12(@babel/core@7.29.0)(solid-js@1.9.15):
-    dependencies:
-      '@babel/core': 7.29.0
-      babel-plugin-jsx-dom-expressions: 0.40.7(@babel/core@7.29.0)
-    optionalDependencies:
-      solid-js: 1.9.15
 
   bail@2.0.2: {}
 
@@ -16170,20 +16151,12 @@ snapshots:
 
   smol-toml@1.7.1: {}
 
-  solid-js@1.9.15:
+  solid-js@2.0.0-rc.4:
     dependencies:
+      '@solidjs/signals': 2.0.0-rc.4
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-
-  solid-refresh@0.6.3(solid-js@1.9.15):
-    dependencies:
-      '@babel/generator': 7.29.1
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/types': 7.29.8
-      solid-js: 1.9.15
-    transitivePeerDependencies:
-      - supports-color
 
   source-map-js@1.2.1: {}
 
@@ -16575,6 +16548,8 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
+  validate-html-nesting@1.2.4: {}
+
   vfile-location@5.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -16612,19 +16587,6 @@ snapshots:
       unplugin-utils: 0.3.2
       vite: 8.0.16(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)
       vite-dev-rpc: 2.0.0(vite@8.0.16(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
-
-  vite-plugin-solid@2.11.14(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(solid-js@1.9.15):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@1.9.15)
-      merge-anything: 5.1.7
-      solid-js: 1.9.15
-      solid-refresh: 0.6.3(solid-js@1.9.15)
-      vite: '@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)'
-      vitefu: 1.1.3(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - supports-color
 
   vite-plugin-vue-devtools@8.2.1(supports-color@10.2.2)(vite@8.0.16(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,8 @@ packages:
   - benchmarks/bundle-size/apps/*
 
 catalog:
+  "@solidjs/vite-plugin": ^3.0.0-next.36
+  "@solidjs/web": ^2.0.0-rc.4
   "@sveltejs/vite-plugin-svelte": ^7.2.0
   "@types/node": ^26.2.0
   "@types/react": ^19.2.18
@@ -21,10 +23,9 @@ catalog:
   esbuild: ^0.28.1
   react: ^19.0.0
   react-dom: ^19.0.0
-  solid-js: ^1.9.15
+  solid-js: ^2.0.0-rc.4
   svelte: ^5.56.10
   typescript: ^7.0.2
-  vite-plugin-solid: ^2.11.14
   vite: npm:@voidzero-dev/vite-plus-core@0.2.8
   vitest: 4.1.11
   vue: ^3.5.41

--- a/scripts/package-dry-run.mjs
+++ b/scripts/package-dry-run.mjs
@@ -34,7 +34,10 @@ const packages = [
 ];
 const packDir = mkdtempSync(join(tmpdir(), "ox-content-pack-"));
 const failures = [];
-const publicVitePeerRange = "^0.2.8 || ^8.0.0";
+const publicVitePeerRanges = new Map([
+  ["@ox-content/vite-plugin-solid", "^8.0.0 || ^9.0.0"],
+]);
+const defaultPublicVitePeerRange = "^0.2.8 || ^8.0.0";
 
 try {
   for (const packageDir of packages) {
@@ -122,9 +125,10 @@ function checkVitePeerDependency(pkg) {
     return;
   }
 
-  if (pkg.peerDependencies.vite !== publicVitePeerRange) {
+  const expectedRange = publicVitePeerRanges.get(pkg.name) ?? defaultPublicVitePeerRange;
+  if (pkg.peerDependencies.vite !== expectedRange) {
     failures.push(
-      `${pkg.name} publishes vite peer ${pkg.peerDependencies.vite}; expected ${publicVitePeerRange}`,
+      `${pkg.name} publishes vite peer ${pkg.peerDependencies.vite}; expected ${expectedRange}`,
     );
   }
 }

--- a/scripts/package-dry-run.mjs
+++ b/scripts/package-dry-run.mjs
@@ -34,9 +34,7 @@ const packages = [
 ];
 const packDir = mkdtempSync(join(tmpdir(), "ox-content-pack-"));
 const failures = [];
-const publicVitePeerRanges = new Map([
-  ["@ox-content/vite-plugin-solid", "^8.0.0 || ^9.0.0"],
-]);
+const publicVitePeerRanges = new Map([["@ox-content/vite-plugin-solid", "^8.0.0 || ^9.0.0"]]);
 const defaultPublicVitePeerRange = "^0.2.8 || ^8.0.0";
 
 try {


### PR DESCRIPTION
## Summary
- move the Solid adapter and example to Solid 2 with `@solidjs/vite-plugin`, `@solidjs/web`, and the native compiler path
- generate Solid 2-compatible island modules with `@solidjs/web` rendering and `createEffect` cleanup lifecycle
- make setup diagnostics compiler-neutral and add native compiler/HMR regression coverage
- update the Solid adapter docs and examples, documenting this as the Solid 2 beta path

Closes #1238

## Validation
- `vp run test:framework-solid`
- `pnpm --filter @ox-content/vite-plugin-solid exec vp test src`
- `pnpm --filter @ox-content/vite-plugin-solid exec tsgo --noEmit`
- `pnpm --filter @ox-content/vite-plugin-solid run build`
- `pnpm --filter @ox-content/islands run build`
- `pnpm --filter ./examples/integ-solid build`
- `vp fmt npm/vite-plugin-ox-content-solid examples/integ-solid docs/content/packages/vite-plugin-ox-content-solid.md docs/content/examples/integ-solid.md docs/content/examples/index.md docs/content/ja/examples/index.md docs/content/getting-started.md docs/content/ja/getting-started.md docs/content/mdx.md docs/content/ja/mdx.md README.md pnpm-workspace.yaml --check`
- `vp run check:ts` (exit 0; existing unrelated warnings remain)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->