### PR TITLE
fix(ci): run PR benchmarks from legacy checkout roots

### DIFF
--- a/.github/scripts/run-pr-benchmark.mjs
+++ b/.github/scripts/run-pr-benchmark.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
-import { copyFileSync, existsSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { cpus, totalmem } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
@@ -15,36 +15,39 @@ if (options.skipRuntime && options.skipBundle) {
 }
 
 const sourceRoot = resolve(options.source ?? requiredEnv("GITHUB_WORKSPACE"));
+const sourceBenchmarkRoot = "tools/benchmarks";
+const checkoutBenchmarkRoot = detectBenchmarkRoot(checkoutRoot);
+const benchmarkPath = (path) => join(checkoutBenchmarkRoot, path);
 
 for (const file of [
-  "tools/benchmarks/mizchi-markdown-native.mjs",
-  "tools/benchmarks/mizchi-markdown-native-template.mjs",
-  "tools/benchmarks/bundle-size/parse-benchmark.mjs",
-  "tools/benchmarks/bundle-size/parse-benchmark-bun.mjs",
-  "tools/benchmarks/bundle-size/measure.mjs",
-  "tools/benchmarks/bundle-size/measure-artifacts.mjs",
-  "tools/benchmarks/native-competitors/Cargo.toml",
-  "tools/benchmarks/native-competitors/Cargo.lock",
-  "tools/benchmarks/native-competitors/src/bench.rs",
-  "tools/benchmarks/native-competitors/src/cli.rs",
-  "tools/benchmarks/native-competitors/src/conformance.rs",
-  "tools/benchmarks/native-competitors/src/json.rs",
-  "tools/benchmarks/native-competitors/src/main.rs",
+  "mizchi-markdown-native.mjs",
+  "mizchi-markdown-native-template.mjs",
+  "bundle-size/package.json",
+  "bundle-size/parse-benchmark.mjs",
+  "bundle-size/parse-benchmark-bun.mjs",
+  "bundle-size/measure.mjs",
+  "bundle-size/measure-artifacts.mjs",
+  "native-competitors/Cargo.toml",
+  "native-competitors/Cargo.lock",
+  "native-competitors/src/bench.rs",
+  "native-competitors/src/cli.rs",
+  "native-competitors/src/conformance.rs",
+  "native-competitors/src/json.rs",
+  "native-competitors/src/main.rs",
 ]) {
-  const from = join(sourceRoot, file);
-  const to = join(checkoutRoot, file);
+  const from = join(sourceRoot, sourceBenchmarkRoot, file);
+  const to = join(checkoutRoot, checkoutBenchmarkRoot, file);
   mkdirSync(dirname(to), { recursive: true });
   copyFileSync(from, to);
 }
 
 run("vp", ["install"]);
-linkLegacyBenchmarkDependencies();
 run("vp", ["run", "build:npm"]);
 if (options.skipRuntime) {
   writeSkippedRuntimeReport(options.runtimeJson);
 } else {
   run("node", [
-    "tools/benchmarks/bundle-size/parse-benchmark.mjs",
+    benchmarkPath("bundle-size/parse-benchmark.mjs"),
     "--runs",
     options.runs,
     "--json",
@@ -55,7 +58,7 @@ if (options.skipBundle) {
   writeSkippedBundleReport(options.bundleJson);
 } else {
   run("node", [
-    "tools/benchmarks/bundle-size/measure.mjs",
+    benchmarkPath("bundle-size/measure.mjs"),
     "--skip-install",
     "--json",
     options.bundleJson,
@@ -67,7 +70,7 @@ if (options.skipBundle) {
 // ask for it simply gets no artifact section in the report.
 if (options.artifactsJson) {
   run("node", [
-    "tools/benchmarks/bundle-size/measure-artifacts.mjs",
+    benchmarkPath("bundle-size/measure-artifacts.mjs"),
     "--json",
     options.artifactsJson,
   ]);
@@ -192,14 +195,19 @@ function requiredEnv(name) {
   return value;
 }
 
-function linkLegacyBenchmarkDependencies() {
-  const benchmarkNodeModules = join(checkoutRoot, "tools/benchmarks/bundle-size/node_modules");
-  const legacyNodeModules = join(checkoutRoot, "benchmarks/bundle-size/node_modules");
-
-  if (!existsSync(benchmarkNodeModules) && existsSync(legacyNodeModules)) {
-    mkdirSync(dirname(benchmarkNodeModules), { recursive: true });
-    symlinkSync(legacyNodeModules, benchmarkNodeModules, "dir");
+/**
+ * @param {string} root
+ * @returns {"tools/benchmarks" | "benchmarks"}
+ */
+function detectBenchmarkRoot(root) {
+  if (existsSync(join(root, "tools/benchmarks/bundle-size/package.json"))) {
+    return "tools/benchmarks";
   }
+  if (existsSync(join(root, "benchmarks/bundle-size/package.json"))) {
+    return "benchmarks";
+  }
+
+  return "tools/benchmarks";
 }
 
 /**

--- a/tools/benchmarks/bundle-size/run-pr-benchmark.test.ts
+++ b/tools/benchmarks/bundle-size/run-pr-benchmark.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { delimiter, dirname, join, resolve } from "node:path";
 import { describe, expect, it } from "vite-plus/test";
 import {
   packageBuildConcurrencyEnvName,
@@ -61,4 +61,104 @@ describe("run-pr-benchmark", () => {
       `${packageBuildConcurrencyEnvName} must be a positive integer`,
     );
   });
+
+  it("runs copied benchmark scripts from the checkout's legacy benchmark workspace", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const root = mkdtempSync(join(tmpdir(), "ox-pr-benchmark-layout-"));
+    const source = join(root, "source");
+    const checkout = join(root, "checkout");
+    const bin = join(root, "bin");
+    const runtimeJson = join(root, "runtime.json");
+    const bundleJson = join(root, "bundle.json");
+    const artifactsJson = join(root, "artifacts.json");
+
+    mkdirSync(bin, { recursive: true });
+    writeExecutable(join(bin, "vp"), "#!/bin/sh\nexit 0\n");
+    writeExecutable(join(bin, "node"), `#!/bin/sh\nexec '${escapeShell(process.execPath)}' "$@"\n`);
+
+    writeFile(
+      join(source, "tools/benchmarks/bundle-size/parse-benchmark.mjs"),
+      writesInvokedScriptJson,
+    );
+    writeFile(join(source, "tools/benchmarks/bundle-size/measure.mjs"), writesInvokedScriptJson);
+    writeFile(
+      join(source, "tools/benchmarks/bundle-size/measure-artifacts.mjs"),
+      writesInvokedScriptJson,
+    );
+    writeFile(join(source, "tools/benchmarks/bundle-size/package.json"), '{"type":"module"}\n');
+
+    for (const file of [
+      "mizchi-markdown-native.mjs",
+      "mizchi-markdown-native-template.mjs",
+      "bundle-size/parse-benchmark-bun.mjs",
+      "native-competitors/Cargo.toml",
+      "native-competitors/Cargo.lock",
+      "native-competitors/src/bench.rs",
+      "native-competitors/src/cli.rs",
+      "native-competitors/src/conformance.rs",
+      "native-competitors/src/json.rs",
+      "native-competitors/src/main.rs",
+    ]) {
+      writeFile(join(source, "tools/benchmarks", file), "");
+    }
+
+    writeFile(join(checkout, "benchmarks/bundle-size/package.json"), '{"type":"module"}\n');
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        script,
+        "--source",
+        source,
+        "--runtime-json",
+        runtimeJson,
+        "--bundle-json",
+        bundleJson,
+        "--artifacts-json",
+        artifactsJson,
+      ],
+      {
+        cwd: checkout,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`,
+        },
+      },
+    );
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expectBenchmarkScript(runtimeJson, join("benchmarks", "bundle-size", "parse-benchmark.mjs"));
+    expectBenchmarkScript(bundleJson, join("benchmarks", "bundle-size", "measure.mjs"));
+    expectBenchmarkScript(
+      artifactsJson,
+      join("benchmarks", "bundle-size", "measure-artifacts.mjs"),
+    );
+  });
 });
+
+const writesInvokedScriptJson = `import { writeFileSync } from "node:fs";
+const jsonIndex = process.argv.indexOf("--json");
+writeFileSync(process.argv[jsonIndex + 1], JSON.stringify({ script: process.argv[1] }) + "\\n");
+`;
+
+const writeFile = (path: string, content: string) => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+const writeExecutable = (path: string, content: string) => {
+  writeFile(path, content);
+  chmodSync(path, 0o755);
+};
+
+const escapeShell = (value: string) => value.replaceAll("'", "'\\''");
+
+const expectBenchmarkScript = (path: string, expectedSuffix: string) => {
+  const { script } = JSON.parse(readFileSync(path, "utf8")) as { script: string };
+  expect(script).toContain(expectedSuffix);
+  expect(script).not.toContain(join("tools", "benchmarks"));
+};


### PR DESCRIPTION
## Summary
- run copied PR benchmark scripts from the checkout benchmark root, including legacy base checkouts
- copy the bundle-size package manifest so benchmark-only dependencies resolve after the tools layout move
- add a regression test for legacy benchmark workspace execution

## Verification
- rtk vp test tools/benchmarks/bundle-size/run-pr-benchmark.test.ts
- rtk node tools/scripts/check-file-lines.ts --base origin/main
- rtk vp test tools/scripts/pr-preview-scope.test.ts tools/scripts/rust-doc-scope.test.ts tools/scripts/verify-publish-targets.test.ts tools/scripts/publish-editor-extensions.test.ts tools/benchmarks/bundle-size/pr-benchmark-scope.test.ts tools/benchmarks/bundle-size/run-pr-benchmark.test.ts tools/benchmarks/bundle-size/check-budgets.test.ts tools/benchmarks/bundle-size/compare-pr-benchmark.test.ts tools/benchmarks/bundle-size/artifact-size-report.test.ts
- rtk vp run check:ts
- rtk vp fmt
- rtk git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark execution across both current and legacy workspace layouts.
  * Fixed benchmark file discovery and copying, including bundle-size configuration.
  * Ensured generated reports reference the correct benchmark scripts.

* **Tests**
  * Added regression coverage for running benchmarks from legacy checkout layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->