### PR TITLE
fix(ci): correct moved benchmark workspace links

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,8 +189,6 @@ importers:
         specifier: ^3.8.6
         version: 3.8.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@26.2.0)
 
-  crates/ox_content_wasm/pkg: {}
-
   docs:
     devDependencies:
       '@ox-content/code-play':
@@ -2309,7 +2307,7 @@ importers:
         version: 0.8.3
       '@ox-content/napi':
         specifier: workspace:*
-        version: link:../../crates/ox_content_napi
+        version: link:../../../crates/ox_content_napi
       '@tanstack/markdown':
         specifier: ^0.0.13
         version: 0.0.13(react@19.2.8)
@@ -2373,7 +2371,7 @@ importers:
     dependencies:
       '@ox-content/vite-plugin':
         specifier: workspace:*
-        version: link:../../../../npm/vite-plugin-ox-content
+        version: link:../../../../../npm/vite-plugin-ox-content
     devDependencies:
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.2.8
@@ -2386,7 +2384,7 @@ importers:
     dependencies:
       '@ox-content/vite-plugin':
         specifier: workspace:*
-        version: link:../../../../npm/vite-plugin-ox-content
+        version: link:../../../../../npm/vite-plugin-ox-content
     devDependencies:
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.2.8
@@ -2399,10 +2397,10 @@ importers:
     dependencies:
       '@ox-content/vite-plugin':
         specifier: workspace:*
-        version: link:../../../../npm/vite-plugin-ox-content
+        version: link:../../../../../npm/vite-plugin-ox-content
       '@ox-content/vite-plugin-vue':
         specifier: workspace:*
-        version: link:../../../../npm/vite-plugin-ox-content-vue
+        version: link:../../../../../npm/vite-plugin-ox-content-vue
       vue:
         specifier: 'catalog:'
         version: 3.5.41(typescript@7.0.2)
@@ -2439,7 +2437,7 @@ importers:
         version: 0.8.3
       '@ox-content/napi':
         specifier: workspace:*
-        version: link:../../crates/ox_content_napi
+        version: link:../../../crates/ox_content_napi
       '@tanstack/markdown':
         specifier: ^0.0.13
         version: 0.0.13(react@19.2.8)
@@ -2478,7 +2476,7 @@ importers:
     dependencies:
       '@ox-content/vite-plugin':
         specifier: workspace:*
-        version: link:../../npm/vite-plugin-ox-content
+        version: link:../../../npm/vite-plugin-ox-content
     devDependencies:
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.2.8

--- a/tools/benchmarks/bundle-size/run-pr-benchmark.test.ts
+++ b/tools/benchmarks/bundle-size/run-pr-benchmark.test.ts
@@ -218,8 +218,9 @@ const expectWorkspaceLink = (
 ) => {
   const importerBlock = importerLockfileBlock(lockfile, importer);
   const expected = relative(importer, target).split(sep).join("/");
-  expect(importerBlock).toContain(`      '${dependency}':\n        specifier: workspace:*`);
-  expect(importerBlock).toContain(`version: link:${expected}`);
+  expect(importerBlock).toContain(
+    `      '${dependency}':\n        specifier: workspace:*\n        version: link:${expected}`,
+  );
 };
 
 const importerLockfileBlock = (lockfile: string, importer: string) => {

--- a/tools/benchmarks/bundle-size/run-pr-benchmark.test.ts
+++ b/tools/benchmarks/bundle-size/run-pr-benchmark.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { delimiter, dirname, join, resolve } from "node:path";
+import { delimiter, dirname, join, relative, resolve, sep } from "node:path";
 import { describe, expect, it } from "vite-plus/test";
 import {
   packageBuildConcurrencyEnvName,
@@ -138,6 +138,53 @@ describe("run-pr-benchmark", () => {
       join("benchmarks", "bundle-size", "measure-artifacts.mjs"),
     );
   });
+
+  it("keeps benchmark app workspace links relative to the moved benchmark root", () => {
+    const lockfile = readFileSync(resolve("pnpm-lock.yaml"), "utf8");
+
+    expectWorkspaceLink(
+      lockfile,
+      "tools/benchmarks/bundle-size",
+      "@ox-content/napi",
+      "crates/ox_content_napi",
+    );
+    expectWorkspaceLink(
+      lockfile,
+      "tools/benchmarks/bundle-size/apps/ox-content",
+      "@ox-content/vite-plugin",
+      "npm/vite-plugin-ox-content",
+    );
+    expectWorkspaceLink(
+      lockfile,
+      "tools/benchmarks/bundle-size/apps/ox-content-bare",
+      "@ox-content/vite-plugin",
+      "npm/vite-plugin-ox-content",
+    );
+    expectWorkspaceLink(
+      lockfile,
+      "tools/benchmarks/bundle-size/apps/ox-content-vue",
+      "@ox-content/vite-plugin",
+      "npm/vite-plugin-ox-content",
+    );
+    expectWorkspaceLink(
+      lockfile,
+      "tools/benchmarks/bundle-size/apps/ox-content-vue",
+      "@ox-content/vite-plugin-vue",
+      "npm/vite-plugin-ox-content-vue",
+    );
+    expectWorkspaceLink(
+      lockfile,
+      "tools/benchmarks/commonmark-conformance",
+      "@ox-content/napi",
+      "crates/ox_content_napi",
+    );
+    expectWorkspaceLink(
+      lockfile,
+      "tools/benchmarks/scale",
+      "@ox-content/vite-plugin",
+      "npm/vite-plugin-ox-content",
+    );
+  });
 });
 
 const writesInvokedScriptJson = `import { writeFileSync } from "node:fs";
@@ -161,4 +208,25 @@ const expectBenchmarkScript = (path: string, expectedSuffix: string) => {
   const { script } = JSON.parse(readFileSync(path, "utf8")) as { script: string };
   expect(script).toContain(expectedSuffix);
   expect(script).not.toContain(join("tools", "benchmarks"));
+};
+
+const expectWorkspaceLink = (
+  lockfile: string,
+  importer: string,
+  dependency: string,
+  target: string,
+) => {
+  const importerBlock = importerLockfileBlock(lockfile, importer);
+  const expected = relative(importer, target).split(sep).join("/");
+  expect(importerBlock).toContain(`      '${dependency}':\n        specifier: workspace:*`);
+  expect(importerBlock).toContain(`version: link:${expected}`);
+};
+
+const importerLockfileBlock = (lockfile: string, importer: string) => {
+  const start = lockfile.indexOf(`  ${importer}:\n`);
+  expect(start).toBeGreaterThanOrEqual(0);
+
+  const rest = lockfile.slice(start + 1);
+  const next = rest.search(/\n  \S[^:\n]*:\n/);
+  return next === -1 ? rest : rest.slice(0, next);
 };


### PR DESCRIPTION
## Summary
- correct pnpm lockfile links for moved benchmark workspaces under tools/benchmarks
- add a regression test that validates benchmark workspace link depths against path.relative
- verify app and runtime benchmark package imports resolve from the moved benchmark root

## Checks
- vp install
- vp test tools/benchmarks/bundle-size/run-pr-benchmark.test.ts
- node --input-type=module -e 'console.log(await import.meta.resolve("@ox-content/vite-plugin"))' from tools/benchmarks/bundle-size/apps/ox-content-bare
- node --input-type=module -e 'console.log(await import.meta.resolve("@ox-content/napi"))' from tools/benchmarks/bundle-size

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify benchmark workspace links in the package lockfile resolve to the correct relative locations.
  * Improved validation of workspace package references and lockfile importer entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->