### PR TITLE
fix(cli): bundle lsp through native binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,6 +1619,7 @@ dependencies = [
  "ox_content_i18n_checker",
  "ox_content_incremental",
  "ox_content_link_checker",
+ "ox_content_lsp",
  "ox_content_markdown_lint",
  "ox_content_mdast",
  "ox_content_mdc_checker",
@@ -1632,6 +1633,7 @@ dependencies = [
  "oxc_span 0.147.0",
  "rustc-hash",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ ox_content_markdown_lint = { version = "3.0.0-beta.2", path = "crates/ox_content
 ox_content_mdc_checker = { version = "3.0.0-beta.2", path = "crates/ox_content_mdc_checker" }
 ox_content_mermaid = { version = "3.0.0-beta.2", path = "crates/ox_content_mermaid" }
 ox_content_link_checker = { version = "3.0.0-beta.2", path = "crates/ox_content_link_checker" }
+ox_content_lsp = { version = "3.0.0-beta.2", path = "crates/ox_content_lsp" }
 ox_content_component_resolver = { version = "3.0.0-beta.2", path = "crates/ox_content_component_resolver" }
 ox_content_profiler = { version = "3.0.0-beta.2", path = "crates/ox_content_profiler" }
 ox_jsdoc = "0.0.19"

--- a/crates/ox_content_lsp/src/lib.rs
+++ b/crates/ox_content_lsp/src/lib.rs
@@ -1,0 +1,28 @@
+//! Unified Language Server Protocol server for Ox Content authoring.
+
+mod backend;
+mod config;
+mod document;
+mod document_highlight;
+mod document_link;
+mod folding;
+mod frontmatter;
+mod i18n;
+mod preview;
+mod selection_range;
+mod session;
+mod spacing;
+mod state;
+mod textlint;
+
+use tower_lsp::{LspService, Server};
+
+/// Runs the Ox Content language server over standard input and output.
+pub async fn run() {
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+
+    let (service, socket) = LspService::new(backend::Backend::new);
+
+    Server::new(stdin, stdout, socket).serve(service).await;
+}

--- a/crates/ox_content_lsp/src/main.rs
+++ b/crates/ox_content_lsp/src/main.rs
@@ -14,29 +14,7 @@
 //! - smart selection ranges for expand-selection
 //! - half-width/full-width spacing diagnostics and fixes
 
-mod backend;
-mod config;
-mod document;
-mod document_highlight;
-mod document_link;
-mod folding;
-mod frontmatter;
-mod i18n;
-mod preview;
-mod selection_range;
-mod session;
-mod spacing;
-mod state;
-mod textlint;
-
-use tower_lsp::{LspService, Server};
-
 #[tokio::main]
 async fn main() {
-    let stdin = tokio::io::stdin();
-    let stdout = tokio::io::stdout();
-
-    let (service, socket) = LspService::new(backend::Backend::new);
-
-    Server::new(stdin, stdout, socket).serve(service).await;
+    ox_content_lsp::run().await;
 }

--- a/crates/ox_content_napi/Cargo.toml
+++ b/crates/ox_content_napi/Cargo.toml
@@ -35,8 +35,10 @@ ox_content_transform = { workspace = true }
 ox_content_i18n = { workspace = true }
 ox_content_i18n_checker = { workspace = true }
 ox_content_link_checker = { workspace = true }
+ox_content_lsp = { workspace = true }
 ox_content_mdc_checker = { workspace = true }
 memchr = { workspace = true }
+tokio = { workspace = true }
 oxc_span = { workspace = true }
 napi = { workspace = true }
 napi-derive = { workspace = true }

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -105,6 +105,9 @@ export declare function checkLinks(files: Array<string>, options?: JsLinkCheckOp
 /** Checks MDC component syntax from Node.js. */
 export declare function checkMdc(files: Array<string>): JsMdcCheckResult
 
+/** Runs the Ox Content language server over standard input and output. */
+export declare function runLsp(): void
+
 /** Classifies already-parsed frontmatter JSON against publish-state options. */
 export declare function classifyPublishState(frontmatterJson: string, options?: JsPublishStateOptions | undefined | null): JsPublishDecision
 

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -251,6 +251,7 @@ module.exports.checkI18n = binding.checkI18n;
 module.exports.checkI18nProject = binding.checkI18nProject;
 module.exports.checkLinks = binding.checkLinks;
 module.exports.checkMdc = binding.checkMdc;
+module.exports.runLsp = binding.runLsp;
 module.exports.extractTranslationKeys = binding.extractTranslationKeys;
 module.exports.renderFrameworkComponentCode = binding.renderFrameworkComponentCode;
 module.exports.renderSsgSectionIndex = binding.renderSsgSectionIndex;

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -32,6 +32,7 @@ mod incremental;
 mod incremental_result;
 mod incremental_types;
 mod lint;
+mod lsp_bindings;
 mod mermaid_bindings;
 mod og_image_bindings;
 mod parse_bindings;
@@ -72,6 +73,7 @@ pub use incremental_types::{
     JsIncrementalRenderOptions,
 };
 pub use lint::*;
+pub use lsp_bindings::*;
 pub use mermaid_bindings::*;
 pub use og_image_bindings::*;
 pub use parse_bindings::*;

--- a/crates/ox_content_napi/src/lsp_bindings.rs
+++ b/crates/ox_content_napi/src/lsp_bindings.rs
@@ -1,0 +1,9 @@
+use napi_derive::napi;
+
+#[napi]
+pub fn run_lsp() -> napi::Result<()> {
+    let runtime = tokio::runtime::Runtime::new()
+        .map_err(|error| napi::Error::from_reason(format!("failed to start LSP runtime: {error}")))?;
+    runtime.block_on(ox_content_lsp::run());
+    Ok(())
+}

--- a/crates/ox_content_napi/src/tests/runtime_features.rs
+++ b/crates/ox_content_napi/src/tests/runtime_features.rs
@@ -101,6 +101,7 @@ fn javascript_wrapper_and_declarations_cover_expected_exports() {
         "renderHead",
         "renderRedirectHtml",
         "renderSsgSectionIndex",
+        "runLsp",
         "resolveSsgNavigationGroups",
         "resolveSsgPageRoutes",
         "resolveSsgRoutePaths",

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -109,6 +109,9 @@ export declare function checkLinks(files: Array<string>, options?: JsLinkCheckOp
 /** Checks MDC component syntax from Node.js. */
 export declare function checkMdc(files: Array<string>): JsMdcCheckResult
 
+/** Runs the Ox Content language server over standard input and output. */
+export declare function runLsp(): void
+
 /** Classifies already-parsed frontmatter JSON against publish-state options. */
 export declare function classifyPublishState(frontmatterJson: string, options?: JsPublishStateOptions | undefined | null): JsPublishDecision
 

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_expected_exports.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_expected_exports.snap
@@ -82,6 +82,7 @@ renderFrameworkComponentCode
 renderHead
 renderRedirectHtml
 renderSsgSectionIndex
+runLsp
 resolveSsgNavigationGroups
 resolveSsgPageRoutes
 resolveSsgRoutePaths

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
@@ -255,6 +255,7 @@ module.exports.checkI18n = binding.checkI18n;
 module.exports.checkI18nProject = binding.checkI18nProject;
 module.exports.checkLinks = binding.checkLinks;
 module.exports.checkMdc = binding.checkMdc;
+module.exports.runLsp = binding.runLsp;
 module.exports.extractTranslationKeys = binding.extractTranslationKeys;
 module.exports.renderFrameworkComponentCode = binding.renderFrameworkComponentCode;
 module.exports.renderSsgSectionIndex = binding.renderSsgSectionIndex;

--- a/npm/vite-plugin-ox-content/bin/oxct-runtime.mjs
+++ b/npm/vite-plugin-ox-content/bin/oxct-runtime.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { runLinkCheck, runMdcCheck } from "./oxct-checkers.mjs";
 import { runI18n } from "./oxct-i18n.mjs";
 import { runOgPreview } from "./oxct-og-preview.mjs";
+import { loadNapi } from "./oxct-napi.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 
@@ -52,11 +53,10 @@ function runLsp(args) {
     printLspHelp();
     return;
   }
-  runRustCli({
-    binary: "ox-content-lsp",
-    crate: "ox_content_lsp",
-    args,
-  });
+  if (args.length > 0) {
+    throw new Error(`Unknown lsp option: ${args[0]}`);
+  }
+  loadNapi().runLsp();
 }
 
 function runMigrate(args) {
@@ -157,7 +157,7 @@ function printLspHelp() {
 Usage:
   oxct lsp
 
-Runs ox-content-lsp over stdio. oxct uses an ox-content-lsp binary from PATH, or Cargo when run inside the ox-content repository.`);
+Runs the bundled Ox Content language server over stdio.`);
 }
 
 function printMigrateHelp() {


### PR DESCRIPTION
Makes `oxct lsp` work from the installed `@ox-content/vite-plugin` package instead of requiring a separately installed `ox-content-lsp` executable or a repository-only Cargo fallback. The existing language server entry point is shared with a NAPI export, and the CLI invokes that bundled implementation:

```js
if (args.length > 0) {
  throw new Error(`Unknown lsp option: ${args[0]}`);
}
loadNapi().runLsp();
```

This keeps the standalone Rust binary intact for editor packaging while ensuring npm consumers have the LSP implementation through the plugin's existing `@ox-content/napi` dependency.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a bundled Ox Content language server accessible through the JavaScript API.
  * Added the `runLsp` command for starting the language server over standard input and output.
* **Bug Fixes**
  * Improved handling of unsupported language-server command options with clear errors.
  * Updated language-server help text to reflect the bundled implementation.
* **Tests**
  * Updated runtime feature checks to include the new `runLsp` export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->