### PR TITLE
fix(cli): run oxct lsp from bundled native binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,6 +1619,7 @@ dependencies = [
  "ox_content_i18n_checker",
  "ox_content_incremental",
  "ox_content_link_checker",
+ "ox_content_lsp",
  "ox_content_markdown_lint",
  "ox_content_mdast",
  "ox_content_mdc_checker",
@@ -1632,6 +1633,7 @@ dependencies = [
  "oxc_span 0.147.0",
  "rustc-hash",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ ox_content_ssg = { version = "3.0.0-beta.2", path = "crates/ox_content_ssg" }
 ox_content_transform = { version = "3.0.0-beta.2", path = "crates/ox_content_transform" }
 ox_content_i18n = { version = "3.0.0-beta.2", path = "crates/ox_content_i18n" }
 ox_content_i18n_checker = { version = "3.0.0-beta.2", path = "crates/ox_content_i18n_checker" }
+ox_content_lsp = { version = "3.0.0-beta.2", path = "crates/ox_content_lsp" }
 ox_content_markdown_lint = { version = "3.0.0-beta.2", path = "crates/ox_content_markdown_lint" }
 ox_content_mdc_checker = { version = "3.0.0-beta.2", path = "crates/ox_content_mdc_checker" }
 ox_content_mermaid = { version = "3.0.0-beta.2", path = "crates/ox_content_mermaid" }

--- a/crates/ox_content_lsp/src/lib.rs
+++ b/crates/ox_content_lsp/src/lib.rs
@@ -1,0 +1,41 @@
+//! # ox-content-lsp
+//!
+//! Unified Language Server Protocol server for Ox Content authoring.
+//!
+//! Provides:
+//! - schema-aware frontmatter completion and diagnostics
+//! - fast Markdown snippet completions
+//! - editor-triggered insertion commands
+//! - preview HTML generation via `workspace/executeCommand`
+//! - heading symbols for document outline navigation
+//! - folding ranges for headings, code blocks, and frontmatter
+//! - document links for Markdown links and images
+//! - document highlights for matching link/image targets
+//! - smart selection ranges for expand-selection
+//! - half-width/full-width spacing diagnostics and fixes
+
+mod backend;
+mod config;
+mod document;
+mod document_highlight;
+mod document_link;
+mod folding;
+mod frontmatter;
+mod i18n;
+mod preview;
+mod selection_range;
+mod session;
+mod spacing;
+mod state;
+mod textlint;
+
+use tower_lsp::{LspService, Server};
+
+/// Run the Ox Content language server over process stdio.
+pub async fn run_stdio() {
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+    let (service, socket) = LspService::new(backend::Backend::new);
+
+    Server::new(stdin, stdout, socket).serve(service).await;
+}

--- a/crates/ox_content_lsp/src/main.rs
+++ b/crates/ox_content_lsp/src/main.rs
@@ -1,42 +1,4 @@
-//! # ox-content-lsp
-//!
-//! Unified Language Server Protocol server for Ox Content authoring.
-//!
-//! Provides:
-//! - schema-aware frontmatter completion and diagnostics
-//! - fast Markdown snippet completions
-//! - editor-triggered insertion commands
-//! - preview HTML generation via `workspace/executeCommand`
-//! - heading symbols for document outline navigation
-//! - folding ranges for headings, code blocks, and frontmatter
-//! - document links for Markdown links and images
-//! - document highlights for matching link/image targets
-//! - smart selection ranges for expand-selection
-//! - half-width/full-width spacing diagnostics and fixes
-
-mod backend;
-mod config;
-mod document;
-mod document_highlight;
-mod document_link;
-mod folding;
-mod frontmatter;
-mod i18n;
-mod preview;
-mod selection_range;
-mod session;
-mod spacing;
-mod state;
-mod textlint;
-
-use tower_lsp::{LspService, Server};
-
 #[tokio::main]
 async fn main() {
-    let stdin = tokio::io::stdin();
-    let stdout = tokio::io::stdout();
-
-    let (service, socket) = LspService::new(backend::Backend::new);
-
-    Server::new(stdin, stdout, socket).serve(service).await;
+    ox_content_lsp::run_stdio().await;
 }

--- a/crates/ox_content_napi/Cargo.toml
+++ b/crates/ox_content_napi/Cargo.toml
@@ -35,6 +35,7 @@ ox_content_transform = { workspace = true }
 ox_content_i18n = { workspace = true }
 ox_content_i18n_checker = { workspace = true }
 ox_content_link_checker = { workspace = true }
+ox_content_lsp = { workspace = true }
 ox_content_mdc_checker = { workspace = true }
 memchr = { workspace = true }
 oxc_span = { workspace = true }
@@ -42,6 +43,7 @@ napi = { workspace = true }
 napi-derive = { workspace = true }
 rustc-hash = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -3314,6 +3314,8 @@ export declare function resolveSsgPageRoutes(pages: Array<JsSsgRoutePageInput>, 
 /** Resolves all output and public route paths for an SSG page. */
 export declare function resolveSsgRoutePaths(inputPath: string, srcDir: string, outDir: string, base: string, extension: string, siteUrl?: string | undefined | null): JsSsgRoutePaths
 
+export declare function runLspStdio(): void
+
 /** Sanitize an HTML string with safe defaults or an explicit allow-list. */
 export declare function sanitizeHtml(html: string, options?: JsSanitizeOptions | undefined | null): string
 

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -250,6 +250,7 @@ module.exports.validateMf2 = binding.validateMf2;
 module.exports.checkI18n = binding.checkI18n;
 module.exports.checkI18nProject = binding.checkI18nProject;
 module.exports.checkLinks = binding.checkLinks;
+module.exports.runLspStdio = binding.runLspStdio;
 module.exports.checkMdc = binding.checkMdc;
 module.exports.extractTranslationKeys = binding.extractTranslationKeys;
 module.exports.renderFrameworkComponentCode = binding.renderFrameworkComponentCode;

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -32,6 +32,7 @@ mod incremental;
 mod incremental_result;
 mod incremental_types;
 mod lint;
+mod lsp_bindings;
 mod mermaid_bindings;
 mod og_image_bindings;
 mod parse_bindings;
@@ -72,6 +73,7 @@ pub use incremental_types::{
     JsIncrementalRenderOptions,
 };
 pub use lint::*;
+pub use lsp_bindings::*;
 pub use mermaid_bindings::*;
 pub use og_image_bindings::*;
 pub use parse_bindings::*;

--- a/crates/ox_content_napi/src/lsp_bindings.rs
+++ b/crates/ox_content_napi/src/lsp_bindings.rs
@@ -1,0 +1,12 @@
+use napi_derive::napi;
+
+#[napi(js_name = "runLspStdio")]
+pub fn run_lsp_stdio() -> napi::Result<()> {
+    let runtime =
+        tokio::runtime::Builder::new_multi_thread().enable_all().build().map_err(|error| {
+            napi::Error::from_reason(format!("Failed to start ox-content-lsp runtime: {error}"))
+        })?;
+
+    runtime.block_on(ox_content_lsp::run_stdio());
+    Ok(())
+}

--- a/crates/ox_content_napi/src/tests/runtime_features.rs
+++ b/crates/ox_content_napi/src/tests/runtime_features.rs
@@ -104,6 +104,7 @@ fn javascript_wrapper_and_declarations_cover_expected_exports() {
         "resolveSsgNavigationGroups",
         "resolveSsgPageRoutes",
         "resolveSsgRoutePaths",
+        "runLspStdio",
         "sanitizeHtml",
         "searchIndex",
         "transform",

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -3318,6 +3318,8 @@ export declare function resolveSsgPageRoutes(pages: Array<JsSsgRoutePageInput>, 
 /** Resolves all output and public route paths for an SSG page. */
 export declare function resolveSsgRoutePaths(inputPath: string, srcDir: string, outDir: string, base: string, extension: string, siteUrl?: string | undefined | null): JsSsgRoutePaths
 
+export declare function runLspStdio(): void
+
 /** Sanitize an HTML string with safe defaults or an explicit allow-list. */
 export declare function sanitizeHtml(html: string, options?: JsSanitizeOptions | undefined | null): string
 

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_expected_exports.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_expected_exports.snap
@@ -85,6 +85,7 @@ renderSsgSectionIndex
 resolveSsgNavigationGroups
 resolveSsgPageRoutes
 resolveSsgRoutePaths
+runLspStdio
 sanitizeHtml
 searchIndex
 transform

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
@@ -254,6 +254,7 @@ module.exports.validateMf2 = binding.validateMf2;
 module.exports.checkI18n = binding.checkI18n;
 module.exports.checkI18nProject = binding.checkI18nProject;
 module.exports.checkLinks = binding.checkLinks;
+module.exports.runLspStdio = binding.runLspStdio;
 module.exports.checkMdc = binding.checkMdc;
 module.exports.extractTranslationKeys = binding.extractTranslationKeys;
 module.exports.renderFrameworkComponentCode = binding.renderFrameworkComponentCode;

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
@@ -254,6 +254,7 @@ module.exports.validateMf2 = binding.validateMf2;
 module.exports.checkI18n = binding.checkI18n;
 module.exports.checkI18nProject = binding.checkI18nProject;
 module.exports.checkLinks = binding.checkLinks;
+module.exports.runLspStdio = binding.runLspStdio;
 module.exports.checkMdc = binding.checkMdc;
 module.exports.extractTranslationKeys = binding.extractTranslationKeys;
 module.exports.renderFrameworkComponentCode = binding.renderFrameworkComponentCode;

--- a/npm/vite-plugin-ox-content/bin/oxct-runtime.mjs
+++ b/npm/vite-plugin-ox-content/bin/oxct-runtime.mjs
@@ -4,6 +4,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runLinkCheck, runMdcCheck } from "./oxct-checkers.mjs";
 import { runI18n } from "./oxct-i18n.mjs";
+import { loadNapi } from "./oxct-napi.mjs";
 import { runOgPreview } from "./oxct-og-preview.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -48,10 +49,21 @@ export function main(args) {
 }
 
 function runLsp(args) {
-  if (isHelp(args)) {
+  if (isExplicitHelp(args)) {
     printLspHelp();
     return;
   }
+
+  if (args.length > 0) {
+    throw new Error(`Unknown lsp option: ${args[0]}`);
+  }
+
+  const napi = tryLoadNapi();
+  if (typeof napi?.runLspStdio === "function") {
+    napi.runLspStdio();
+    return;
+  }
+
   runRustCli({
     binary: "ox-content-lsp",
     crate: "ox_content_lsp",
@@ -103,6 +115,14 @@ function runCommand(command, args, options) {
   setExitCodeFromCommand(spawnSync(command, args, options), command);
 }
 
+function tryLoadNapi() {
+  try {
+    return loadNapi();
+  } catch {
+    return undefined;
+  }
+}
+
 function setExitCodeFromCommand(result, command) {
   if (result.error) {
     throw new Error(`Failed to run ${command}: ${result.error.message}`);
@@ -133,7 +153,11 @@ function findCargoWorkspaceRoot(start) {
 }
 
 function isHelp(args) {
-  return args.length === 0 || args[0] === "--help" || args[0] === "-h";
+  return args.length === 0 || isExplicitHelp(args);
+}
+
+function isExplicitHelp(args) {
+  return args[0] === "--help" || args[0] === "-h";
 }
 
 function printHelp() {
@@ -157,7 +181,7 @@ function printLspHelp() {
 Usage:
   oxct lsp
 
-Runs ox-content-lsp over stdio. oxct uses an ox-content-lsp binary from PATH, or Cargo when run inside the ox-content repository.`);
+Runs the bundled Ox Content language server over stdio. Source checkouts can fall back to an ox-content-lsp binary from PATH or Cargo when the native binding is unavailable.`);
 }
 
 function printMigrateHelp() {


### PR DESCRIPTION
## Summary
- expose the Ox Content LSP stdio server through @ox-content/napi as runLspStdio
- make oxct lsp use the bundled native binding before falling back to PATH/Cargo in source checkouts
- update generated N-API declarations and wrapper export snapshots

## Verification
- rtk vp run check
- rtk vp run test
- rtk node tools/scripts/package-dry-run.mjs npm/vite-plugin-ox-content
- rtk node npm/vite-plugin-ox-content/bin/oxct.mjs lsp

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790841882&installation_model_id=422833&pr_number=1251&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1251&signature=52c358bf5f1f5c0524cab1e69992857692a8d2d86ed8ff7c753862b399005cfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->