### PR TITLE
docs(code-play): add Rust and Go playground samples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,21 +1356,21 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "ox_content_allocator"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "bumpalo",
 ]
 
 [[package]]
 name = "ox_content_ast"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "ox_content_allocator",
 ]
 
 [[package]]
 name = "ox_content_component_resolver"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "corsa_client",
  "insta",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_docs"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "criterion",
  "insta",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_highlight"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "tree-sitter",
  "tree-sitter-bash",
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_i18n"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "insta",
  "miette",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_i18n_checker"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "insta",
  "miette",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_i18n_cli"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "clap",
  "miette",
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_i18n_lsp"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "ox_content_i18n",
  "ox_content_i18n_checker",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_incremental"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "compact_str 0.10.0",
  "criterion",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_link_checker"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "clap",
  "insta",
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_lsp"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "compact_str 0.10.0",
  "insta",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_markdown_lint"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "compact_str 0.10.0",
  "ox_content_allocator",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_mdast"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "ox_content_allocator",
  "ox_content_ast",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_mdc_checker"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "clap",
  "insta",
@@ -1600,11 +1600,11 @@ dependencies = [
 
 [[package]]
 name = "ox_content_mermaid"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 
 [[package]]
 name = "ox_content_napi"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "criterion",
  "insta",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_og_image"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "insta",
  "serde",
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_parser"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "compact_str 0.10.0",
  "criterion",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_profile_cli"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "clap",
  "ox_content_allocator",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_profiler"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "insta",
  "serde",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_renderer"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "compact_str 0.10.0",
  "criterion",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_search"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "compact_str 0.10.0",
  "insta",
@@ -1719,7 +1719,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_ssg"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "askama",
  "insta",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_theme_generator"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "regex",
  "serde",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_transform"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "compact_str 0.10.0",
  "insta",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_vite"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "insta",
  "ox_content_allocator",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_wasm"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "js-sys",
  "ox_content_allocator",

--- a/docs/content/examples/code-play.md
+++ b/docs/content/examples/code-play.md
@@ -5,11 +5,11 @@ description: Opt-in on-demand sample execution with stdio, stderr, config, prove
 
 # Code Play
 
-This page uses `@ox-content/code-play` with **JavaScript** and **TypeScript**
-enabled. Other languages stay ordinary fences until a site opts them in. The
-standalone `examples/code-play` app also opts into Rust and Go, and renders
-Python with an explicit remote executor when `OX_CODE_PLAY_PYTHON_ENDPOINT` is
-set.
+This page uses `@ox-content/code-play` with **JavaScript**, **TypeScript**,
+**Rust**, and **Go** enabled. Other languages stay ordinary fences until a site
+opts them in. The standalone `examples/code-play` app uses the same Rust and Go
+playground adapters, and renders Python with an explicit remote executor when
+`OX_CODE_PLAY_PYTHON_ENDPOINT` is set.
 Routes without a `play` fence stay ordinary docs pages and do not load
 `ox-code-play.js`.
 
@@ -77,6 +77,158 @@ function add(left, right) {
 console.log(add(2, 40));
 ```
 
+## Live Rust sample
+
+This sample uses the official Rust playground adapter. It slugifies headings
+from a small Markdown document and asserts the result before printing the
+navigation targets.
+
+```rust play typecheck play-title="Rust heading slugs" play-mode=release play-edition=2024
+#[derive(Debug, PartialEq, Eq)]
+struct Heading {
+    level: usize,
+    text: String,
+    slug: String,
+}
+
+fn collect_headings(markdown: &str) -> Vec<Heading> {
+    markdown
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim_start();
+            let level = trimmed.chars().take_while(|&ch| ch == '#').count();
+            if level == 0
+                || level > 6
+                || !trimmed
+                    .as_bytes()
+                    .get(level)
+                    .is_some_and(|byte| byte.is_ascii_whitespace())
+            {
+                return None;
+            }
+            let text = trimmed[level..].trim();
+            Some(Heading {
+                level,
+                text: text.to_string(),
+                slug: slugify(text),
+            })
+        })
+        .collect()
+}
+
+fn slugify(text: &str) -> String {
+    let mut slug = String::new();
+    let mut pending_dash = false;
+
+    for ch in text.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            if pending_dash && !slug.is_empty() {
+                slug.push('-');
+            }
+            slug.push(ch);
+            pending_dash = false;
+        } else if ch.is_whitespace() || matches!(ch, '-' | '_' | ':' | '/') {
+            pending_dash = true;
+        }
+    }
+
+    if slug.is_empty() {
+        "section".to_string()
+    } else {
+        slug
+    }
+}
+
+fn main() {
+    let markdown = "# Code Play\n\n## Rust Runner\n\n### Stdio & Timing";
+    let headings = collect_headings(markdown);
+    assert_eq!(
+        headings.iter().map(|heading| heading.slug.as_str()).collect::<Vec<_>>(),
+        ["code-play", "rust-runner", "stdio-timing"]
+    );
+
+    for heading in &headings {
+        println!("h{} {} -> #{}", heading.level, heading.text, heading.slug);
+    }
+}
+```
+
+## Live Go sample
+
+The Go sample uses the Go playground adapter with vet enabled. It counts fenced
+code blocks by language, sorts the result, and prints a small summary.
+
+````go play typecheck play-title="Go fence summary"
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type Fence struct {
+	Language string
+	Lines    int
+}
+
+func collectFences(markdown string) []Fence {
+	var fences []Fence
+	inFence := false
+	current := Fence{Language: "text"}
+
+	for _, line := range strings.Split(markdown, "\n") {
+		if strings.HasPrefix(line, "```") {
+			if inFence {
+				fences = append(fences, current)
+				inFence = false
+				current = Fence{Language: "text"}
+				continue
+			}
+			language := strings.TrimSpace(strings.TrimPrefix(line, "```"))
+			if language == "" {
+				language = "text"
+			}
+			current = Fence{Language: language}
+			inFence = true
+			continue
+		}
+		if inFence {
+			current.Lines++
+		}
+	}
+
+	return fences
+}
+
+func main() {
+	markdown := strings.Join([]string{
+		"# Samples",
+		"",
+		"```go",
+		`fmt.Println("ok")`,
+		"```",
+		"",
+		"```rust",
+		`println!("ok");`,
+		"```",
+	}, "\n")
+
+	fences := collectFences(markdown)
+	sort.Slice(fences, func(i, j int) bool {
+		return fences[i].Language < fences[j].Language
+	})
+
+	if len(fences) != 2 {
+		panic("expected two fenced code blocks")
+	}
+
+	for _, fence := range fences {
+		fmt.Printf("%s: %d line(s)\n", fence.Language, fence.Lines)
+	}
+}
+````
+
 ## Typecheck failure
 
 During `vite dev`, **Typecheck** should fail on this sample. On a published
@@ -131,22 +283,6 @@ payloads use the Vite dev proxy by default; production builds embed
 needs a Piston-compatible `languages.python.endpoint`.
 
 ````md
-```rust play typecheck play-title="Rust playground"
-fn main() {
-    println!("ok");
-}
-```
-
-```go play typecheck play-title="Go playground" play-withVet=false
-package main
-
-import "fmt"
-
-func main() {
-    fmt.Println("ok")
-}
-```
-
 ```python play play-title="Python via Piston"
 print("ok")
 ```

--- a/docs/content/ja/examples/code-play.md
+++ b/docs/content/ja/examples/code-play.md
@@ -5,8 +5,10 @@ description: stdio、stderr、config、provenance、timing ビューアー付き
 
 # Code Play
 
-このページは `@ox-content/code-play` で **JavaScript** と **TypeScript** だけを有効にします。
-Code Play がないページは通常の docs ページのままで、`ox-code-play.js` を読み込みません。
+このページは `@ox-content/code-play` で **JavaScript**、**TypeScript**、**Rust**、
+**Go** を有効にします。それ以外の言語は、サイト側で opt-in するまで通常の
+code fence のままです。Code Play がないページは通常の docs ページのままで、
+`ox-code-play.js` を読み込みません。
 
 ## プラグインを有効にする
 
@@ -21,6 +23,8 @@ export default {
       languages: {
         javascript: true,
         typescript: { execute: true, typecheck: true },
+        rust: true,
+        go: true,
       },
       ui: "default",
       viewers: { config: true, stdio: true, stderr: true, provenance: true, timing: true },
@@ -45,6 +49,157 @@ console.warn("this warning is a stderr chunk");
 const label = "works without an explicit type annotation";
 console.log(label.toUpperCase());
 ```
+
+## Rust サンプル
+
+公式 Rust playground adapter で動きます。小さな Markdown 文字列から見出しを集め、
+slug を検証してからナビゲーション先を出力します。
+
+```rust play typecheck play-title="Rust heading slugs" play-mode=release play-edition=2024
+#[derive(Debug, PartialEq, Eq)]
+struct Heading {
+    level: usize,
+    text: String,
+    slug: String,
+}
+
+fn collect_headings(markdown: &str) -> Vec<Heading> {
+    markdown
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim_start();
+            let level = trimmed.chars().take_while(|&ch| ch == '#').count();
+            if level == 0
+                || level > 6
+                || !trimmed
+                    .as_bytes()
+                    .get(level)
+                    .is_some_and(|byte| byte.is_ascii_whitespace())
+            {
+                return None;
+            }
+            let text = trimmed[level..].trim();
+            Some(Heading {
+                level,
+                text: text.to_string(),
+                slug: slugify(text),
+            })
+        })
+        .collect()
+}
+
+fn slugify(text: &str) -> String {
+    let mut slug = String::new();
+    let mut pending_dash = false;
+
+    for ch in text.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            if pending_dash && !slug.is_empty() {
+                slug.push('-');
+            }
+            slug.push(ch);
+            pending_dash = false;
+        } else if ch.is_whitespace() || matches!(ch, '-' | '_' | ':' | '/') {
+            pending_dash = true;
+        }
+    }
+
+    if slug.is_empty() {
+        "section".to_string()
+    } else {
+        slug
+    }
+}
+
+fn main() {
+    let markdown = "# Code Play\n\n## Rust Runner\n\n### Stdio & Timing";
+    let headings = collect_headings(markdown);
+    assert_eq!(
+        headings.iter().map(|heading| heading.slug.as_str()).collect::<Vec<_>>(),
+        ["code-play", "rust-runner", "stdio-timing"]
+    );
+
+    for heading in &headings {
+        println!("h{} {} -> #{}", heading.level, heading.text, heading.slug);
+    }
+}
+```
+
+## Go サンプル
+
+Go playground adapter で vet も有効にして動きます。fenced code block を言語ごとに
+集計し、ソートした結果を出力します。
+
+````go play typecheck play-title="Go fence summary"
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type Fence struct {
+	Language string
+	Lines    int
+}
+
+func collectFences(markdown string) []Fence {
+	var fences []Fence
+	inFence := false
+	current := Fence{Language: "text"}
+
+	for _, line := range strings.Split(markdown, "\n") {
+		if strings.HasPrefix(line, "```") {
+			if inFence {
+				fences = append(fences, current)
+				inFence = false
+				current = Fence{Language: "text"}
+				continue
+			}
+			language := strings.TrimSpace(strings.TrimPrefix(line, "```"))
+			if language == "" {
+				language = "text"
+			}
+			current = Fence{Language: language}
+			inFence = true
+			continue
+		}
+		if inFence {
+			current.Lines++
+		}
+	}
+
+	return fences
+}
+
+func main() {
+	markdown := strings.Join([]string{
+		"# Samples",
+		"",
+		"```go",
+		`fmt.Println("ok")`,
+		"```",
+		"",
+		"```rust",
+		`println!("ok");`,
+		"```",
+	}, "\n")
+
+	fences := collectFences(markdown)
+	sort.Slice(fences, func(i, j int) bool {
+		return fences[i].Language < fences[j].Language
+	})
+
+	if len(fences) != 2 {
+		panic("expected two fenced code blocks")
+	}
+
+	for _, fence := range fences {
+		fmt.Printf("%s: %d line(s)\n", fence.Language, fence.Lines)
+	}
+}
+````
 
 ## 実行時エラー
 

--- a/docs/content/ja/packages/code-play.md
+++ b/docs/content/ja/packages/code-play.md
@@ -11,12 +11,12 @@ Code Play は、ドキュメントのサンプルをオンデマンドで実行�
 
 このサイトの [ドキュメント例](/examples/code-play.md) とスタンドアロンの
 [`examples/code-play`](https://github.com/ubugeeei-prod/ox-content/tree/main/examples/code-play)
-アプリは、JavaScript と TypeScript だけを有効にしています。Rust、Go、リモート言語は
-オプトインするまでオフです。
+アプリは、JavaScript、TypeScript、Rust、Go を有効にしています。Rust、Go、
+リモート言語はオプトインするまでオフです。
 
 ## インストール
 
-<pm>npm install @ox-content/code-play</pm>
+<pm>npm install @ox-content/code-play@beta</pm>
 
 ```ts
 import { oxContent } from "@ox-content/vite-plugin";
@@ -29,6 +29,8 @@ export default {
       languages: {
         typescript: { execute: true, typecheck: true },
         javascript: true,
+        rust: true,
+        go: true,
       },
       ui: "default",
       viewers: { config: true, stdio: true, stderr: true, provenance: true, timing: true },
@@ -74,6 +76,16 @@ console.log(n);
 ```rust play typecheck play-title="Release-mode Rust" play-mode=release
 fn main() {
     println!("ok");
+}
+```
+
+```go play typecheck play-title="Go vet on"
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("ok")
 }
 ```
 ````
@@ -206,8 +218,9 @@ dev ミドルウェアが不要なら `proxy: false` にしてください。
 **Typecheck** ボタンは省かれます。Vite プロキシ経路は `vite dev` のあいだだけ使います。
 
 公開ページ上の Rust と Go は、ブラウザから直接 `endpoints.rust` / `endpoints.go`
-を呼びます。公式プレイグラウンドは CORS で拒否することがあります。
-ローカル docs では Vite プロキシを使い続けるか、`endpoints` を自分で制御する実行器へ向けてください。
+を呼びます。公式プレイグラウンドが既定です。より厳密な分離、監査、または上流の
+ブラウザポリシー変更への fallback が必要な場合は、`endpoints` を自分で制御する
+実行器へ向けてください。
 
 ## セキュリティ
 

--- a/docs/content/packages/code-play.md
+++ b/docs/content/packages/code-play.md
@@ -11,14 +11,14 @@ nothing until you list languages.
 
 The [docs example](../examples/code-play.md) on this site and the standalone
 [`examples/code-play`](https://github.com/ubugeeei-prod/ox-content/tree/main/examples/code-play)
-app demonstrate the browser UI. The docs site keeps JavaScript and TypeScript
-enabled; the standalone app also enables Rust and Go, and renders Python with
-an explicit Piston-compatible endpoint when one is configured. Rust, Go, and
-remote languages stay off unless you opt in.
+app demonstrate the browser UI. Both enable JavaScript, TypeScript, Rust, and
+Go; the standalone app also renders Python with an explicit Piston-compatible
+endpoint when one is configured. Rust, Go, and remote languages stay off unless
+you opt in.
 
 ## Install
 
-<pm>npm install @ox-content/code-play@alpha</pm>
+<pm>npm install @ox-content/code-play@beta</pm>
 
 ```ts
 import { oxContent } from "@ox-content/vite-plugin";
@@ -83,7 +83,7 @@ fn main() {
 }
 ```
 
-```go play typecheck play-title="Go vet off" play-withVet=false
+```go play typecheck play-title="Go vet on"
 package main
 
 import "fmt"
@@ -231,9 +231,9 @@ reachable `endpoints.typecheck`. The Vite proxy path is used only during
 `vite dev`.
 
 Rust and Go on a published page call `endpoints.rust` / `endpoints.go`
-directly from the browser. Official playgrounds may reject that as CORS;
-keep the Vite proxy for local docs, or point `endpoints` at an executor you
-control.
+directly from the browser. The official playgrounds are the defaults; point
+`endpoints` at an executor you control when you need stricter isolation,
+auditing, or a fallback if an upstream playground changes its browser policy.
 
 During `vite dev`, Code Play payloads use `/__ox-code-play/rust` and
 `/__ox-code-play/go` by default when `proxy` is enabled. Explicit

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -323,6 +323,8 @@ export default defineConfig(({ mode }) => {
         languages: {
           javascript: true,
           typescript: { execute: true, typecheck: true },
+          rust: true,
+          go: true,
         },
         srcDir: "content",
         outDir: "dist/docs",

--- a/examples/code-play/content/index.md
+++ b/examples/code-play/content/index.md
@@ -28,21 +28,146 @@ console.log(label);
 console.log(2 + 40);
 ```
 
-```rust play typecheck play-title="Rust playground" play-mode=release
+```rust play typecheck play-title="Rust heading slugs" play-mode=release play-edition=2024
+#[derive(Debug, PartialEq, Eq)]
+struct Heading {
+    level: usize,
+    text: String,
+    slug: String,
+}
+
+fn collect_headings(markdown: &str) -> Vec<Heading> {
+    markdown
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim_start();
+            let level = trimmed.chars().take_while(|&ch| ch == '#').count();
+            if level == 0
+                || level > 6
+                || !trimmed
+                    .as_bytes()
+                    .get(level)
+                    .is_some_and(|byte| byte.is_ascii_whitespace())
+            {
+                return None;
+            }
+            let text = trimmed[level..].trim();
+            Some(Heading {
+                level,
+                text: text.to_string(),
+                slug: slugify(text),
+            })
+        })
+        .collect()
+}
+
+fn slugify(text: &str) -> String {
+    let mut slug = String::new();
+    let mut pending_dash = false;
+
+    for ch in text.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            if pending_dash && !slug.is_empty() {
+                slug.push('-');
+            }
+            slug.push(ch);
+            pending_dash = false;
+        } else if ch.is_whitespace() || matches!(ch, '-' | '_' | ':' | '/') {
+            pending_dash = true;
+        }
+    }
+
+    if slug.is_empty() {
+        "section".to_string()
+    } else {
+        slug
+    }
+}
+
 fn main() {
-    println!("hello from Rust Code Play");
+    let markdown = "# Code Play\n\n## Rust Runner\n\n### Stdio & Timing";
+    let headings = collect_headings(markdown);
+    assert_eq!(
+        headings.iter().map(|heading| heading.slug.as_str()).collect::<Vec<_>>(),
+        ["code-play", "rust-runner", "stdio-timing"]
+    );
+
+    for heading in &headings {
+        println!("h{} {} -> #{}", heading.level, heading.text, heading.slug);
+    }
 }
 ```
 
-```go play typecheck play-title="Go playground" play-withVet=false
+````go play typecheck play-title="Go fence summary"
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type Fence struct {
+	Language string
+	Lines    int
+}
+
+func collectFences(markdown string) []Fence {
+	var fences []Fence
+	inFence := false
+	current := Fence{Language: "text"}
+
+	for _, line := range strings.Split(markdown, "\n") {
+		if strings.HasPrefix(line, "```") {
+			if inFence {
+				fences = append(fences, current)
+				inFence = false
+				current = Fence{Language: "text"}
+				continue
+			}
+			language := strings.TrimSpace(strings.TrimPrefix(line, "```"))
+			if language == "" {
+				language = "text"
+			}
+			current = Fence{Language: language}
+			inFence = true
+			continue
+		}
+		if inFence {
+			current.Lines++
+		}
+	}
+
+	return fences
+}
 
 func main() {
-    fmt.Println("hello from Go Code Play")
+	markdown := strings.Join([]string{
+		"# Samples",
+		"",
+		"```go",
+		`fmt.Println("ok")`,
+		"```",
+		"",
+		"```rust",
+		`println!("ok");`,
+		"```",
+	}, "\n")
+
+	fences := collectFences(markdown)
+	sort.Slice(fences, func(i, j int) bool {
+		return fences[i].Language < fences[j].Language
+	})
+
+	if len(fences) != 2 {
+		panic("expected two fenced code blocks")
+	}
+
+	for _, fence := range fences {
+		fmt.Printf("%s: %d line(s)\n", fence.Language, fence.Lines)
+	}
 }
-```
+````
 
 ```python play play-title="Python remote executor"
 print("hello from Python Code Play")

--- a/npm/ox-content-code-play/README.md
+++ b/npm/ox-content-code-play/README.md
@@ -23,6 +23,7 @@ export default {
       languages: {
         typescript: { execute: true, typecheck: true },
         rust: true,
+        go: true,
       },
       ui: "default",
       viewers: { config: true, stdio: true, stderr: true, provenance: true, timing: true },
@@ -42,6 +43,16 @@ console.log(n);
 ```rust play typecheck play-title="Release-mode Rust" play-mode=release
 fn main() {
     println!("ok");
+}
+```
+
+```go play typecheck play-title="Go vet on"
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("ok")
 }
 ```
 ````
@@ -120,7 +131,7 @@ A runnable Vite site lives in [`examples/code-play`](../../examples/code-play):
 corepack pnpm --filter ./examples/code-play dev
 ```
 
-The docs site also dogfoods JavaScript and TypeScript widgets on
+The docs site also dogfoods JavaScript, TypeScript, Rust, and Go widgets on
 [Code Play](../../docs/content/examples/code-play.md).
 
 See [Code Play](../../docs/content/packages/code-play.md) in the docs site.

--- a/npm/ox-content-code-play/src/markdown.test.ts
+++ b/npm/ox-content-code-play/src/markdown.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vite-plus/test";
 import { enhanceGeneratedModule, enhancePlayHtml } from "./html";
 import { parseCodePlayTags, parsePlayFences, rewritePlayFences, stripPlayMeta } from "./markdown";
@@ -78,6 +79,41 @@ describe("markdown and viewers", () => {
     expect(payload.project?.files).toEqual([
       { path: "src/main.ts", code: "console.log('project');" },
     ]);
+  });
+
+  it("keeps the standalone Rust and Go samples as live playground payloads", () => {
+    const source = readFileSync(
+      new URL("../../../examples/code-play/content/index.md", import.meta.url),
+      "utf8",
+    );
+    const fences = parsePlayFences(source);
+    const rust = fences.find(
+      (fence) => fence.language === "rust" && fence.title === "Rust heading slugs",
+    );
+    const go = fences.find(
+      (fence) => fence.language === "go" && fence.title === "Go fence summary",
+    );
+    if (!rust || !go) {
+      throw new Error("expected live Rust and Go Code Play samples in examples/code-play");
+    }
+
+    expect(rust.typecheck).toBe(true);
+    expect(rust.config).toMatchObject({ edition: 2024, mode: "release" });
+    expect(rust.code).toContain("collect_headings");
+    expect(go.typecheck).toBe(true);
+    expect(go.config).toEqual({});
+    expect(go.code).toContain("collectFences");
+
+    const options = resolveCodePlayOptions({ languages: { rust: true, go: true } });
+    const rustPayload = payloadFromFence(rust, options);
+    const goPayload = payloadFromFence(go, options);
+
+    expect(rustPayload.capabilities).toEqual({ execute: true, typecheck: true });
+    expect(rustPayload.endpoints?.rust).toBe("https://play.rust-lang.org/execute");
+    expect(rustPayload.config).toMatchObject({ crateType: "auto", mode: "release" });
+    expect(goPayload.capabilities).toEqual({ execute: true, typecheck: true });
+    expect(goPayload.endpoints?.go).toBe("https://play.golang.org/compile");
+    expect(goPayload.config.withVet).toBe(true);
   });
 
   it("rewrites play fences to comments and parses CodePlay tags", () => {


### PR DESCRIPTION
## Summary
- enable Rust and Go Code Play widgets on the docs example page
- replace trivial Rust/Go snippets with playground-safe heading/fence examples in docs and examples/code-play
- add a regression that parses the standalone example and verifies Rust/Go playground payloads
- normalize Cargo.lock workspace package versions to v3.0.0-beta.3 after the beta release

## Verification
- vp exec --filter @ox-content/code-play -- vp test src/markdown.test.ts src/adapters.test.ts src/adapters-edges.test.ts src/plugin.test.ts src/plugin-ssg.test.ts
- node live smoke against https://play.rust-lang.org/execute and https://play.golang.org/compile using examples/code-play samples
- vp fmt --check
- vp check
- vp exec --filter @ox-content/vite-plugin -- playwright test test/vrt/code-play.spec.ts
- vp run --filter ./examples/code-play build
- vp run --filter ./docs build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790845846&installation_model_id=422833&pr_number=1252&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1252&signature=84d30d0b2d21e72495698e5768ee589ff6d54a4fe4e97bb2c88629d5afc3e2d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live Rust and Go playground examples to the documentation and standalone Code Play app.
  * Expanded Code Play documentation and configuration examples with Go support.
  * Added more comprehensive Rust and Go samples demonstrating practical code analysis tasks.
* **Documentation**
  * Updated installation guidance to use the beta release.
  * Documented official playground defaults and options for controlled execution endpoints.
* **Tests**
  * Added coverage verifying Rust and Go examples remain executable playground samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->