### PR TITLE
fix(vite-plugin): preserve VitePress object social icons

### DIFF
--- a/npm/vite-plugin-ox-content/src/vitepress.test.ts
+++ b/npm/vite-plugin-ox-content/src/vitepress.test.ts
@@ -116,6 +116,43 @@ describe("vitepress migration helpers", () => {
     expect(theme.footer?.message).toBe("Migrated from VitePress");
   });
 
+  it("preserves VitePress object-form social link icons as array links", () => {
+    const svg = '<svg viewBox="0 0 16 16"></svg>';
+    const options = fromVitePressConfig({
+      title: "Demo",
+      themeConfig: {
+        socialLinks: [
+          { icon: { svg }, link: "https://example.com", ariaLabel: "Example" },
+          { icon: "mastodon", link: "https://social.example/@demo" },
+        ],
+      },
+    });
+
+    expect(options.ssg).not.toBe(false);
+    if (!options.ssg || options.ssg === true) {
+      throw new Error("Expected migrated SSG options");
+    }
+    const theme = options.ssg.theme;
+    if (!theme || Array.isArray(theme)) {
+      throw new Error("Expected a single migrated theme");
+    }
+
+    expect(theme.socialLinks).toEqual([
+      { icon: { svg }, link: "https://example.com", ariaLabel: "Example" },
+      { icon: "mastodon", link: "https://social.example/@demo" },
+    ]);
+
+    const source = generateVitePressMigrationConfig({
+      title: "Demo",
+      themeConfig: {
+        socialLinks: [{ icon: { svg }, link: "https://example.com" }],
+      },
+    });
+
+    expect(source).toContain("socialLinks: [");
+    expect(source).toContain('svg: "<svg viewBox=\\"0 0 16 16\\"></svg>"');
+  });
+
   it("generates an editable ox-content options module", () => {
     const source = generateVitePressMigrationConfig(
       {

--- a/npm/vite-plugin-ox-content/src/vitepress.ts
+++ b/npm/vite-plugin-ox-content/src/vitepress.ts
@@ -1,5 +1,11 @@
 import { importNapiModuleSync } from "./napi";
-import { defineTheme, mergeThemes, type ThemeConfig } from "./theme";
+import {
+  defineTheme,
+  mergeThemes,
+  type LegacySocialLinks,
+  type SocialLink,
+  type ThemeConfig,
+} from "./theme";
 import type { OxContentOptions, SsgNavigationGroup, SsgNavigationItem } from "./types";
 
 export interface VitePressLogo {
@@ -9,8 +15,10 @@ export interface VitePressLogo {
   alt?: string;
 }
 
+export type VitePressSocialLinkIcon = string | { svg: string };
+
 export interface VitePressSocialLink {
-  icon: string;
+  icon: VitePressSocialLinkIcon;
   link: string;
   ariaLabel?: string;
 }
@@ -248,7 +256,7 @@ function resolveLogoSrc(logo: string | VitePressLogo | undefined): string | unde
   return logo.light ?? logo.dark ?? logo.src;
 }
 
-function normalizeSocialIcon(icon: string): "github" | "twitter" | "discord" | undefined {
+function normalizeLegacySocialIcon(icon: string): keyof LegacySocialLinks | undefined {
   const normalized = icon.trim().toLowerCase();
 
   if (normalized === "github") return "github";
@@ -260,20 +268,76 @@ function normalizeSocialIcon(icon: string): "github" | "twitter" | "discord" | u
   return undefined;
 }
 
+function toArraySocialLink(link: VitePressSocialLink): SocialLink | undefined {
+  if (typeof link.icon === "string") {
+    const icon = link.icon.trim();
+    return icon
+      ? {
+          icon,
+          link: link.link,
+          ...(link.ariaLabel !== undefined ? { ariaLabel: link.ariaLabel } : {}),
+        }
+      : undefined;
+  }
+
+  if (isRecord(link.icon) && typeof link.icon.svg === "string" && link.icon.svg.trim()) {
+    return {
+      icon: { svg: link.icon.svg },
+      link: link.link,
+      ...(link.ariaLabel !== undefined ? { ariaLabel: link.ariaLabel } : {}),
+    };
+  }
+
+  return undefined;
+}
+
+function socialLinkNeedsArrayForm(link: VitePressSocialLink): boolean {
+  return (
+    typeof link.icon !== "string" ||
+    normalizeLegacySocialIcon(link.icon) === undefined ||
+    link.ariaLabel !== undefined
+  );
+}
+
+function convertSocialLinks(links: VitePressSocialLink[] | undefined): ThemeConfig["socialLinks"] {
+  if (!links?.length) {
+    return undefined;
+  }
+
+  if (!links.some(socialLinkNeedsArrayForm)) {
+    const legacy: LegacySocialLinks = {};
+    for (const link of links) {
+      if (typeof link.icon !== "string") {
+        continue;
+      }
+      const key = normalizeLegacySocialIcon(link.icon);
+      if (key) {
+        legacy[key] = link.link;
+      }
+    }
+    return Object.keys(legacy).length > 0 ? legacy : undefined;
+  }
+
+  const socialLinks = links
+    .map((link) => toArraySocialLink(link))
+    .filter((link): link is SocialLink => link !== undefined);
+
+  return socialLinks.length > 0 ? socialLinks : undefined;
+}
+
+function hasSocialLinks(socialLinks: ThemeConfig["socialLinks"]): boolean {
+  return Array.isArray(socialLinks)
+    ? socialLinks.length > 0
+    : Object.keys(socialLinks ?? {}).length > 0;
+}
+
 function toThemeConfig(themeConfig: VitePressThemeConfig | undefined): ThemeConfig | undefined {
   if (!themeConfig) {
     return undefined;
   }
 
   const logo = resolveLogoSrc(themeConfig.logo);
-  const socialLinks = Object.fromEntries(
-    (themeConfig.socialLinks ?? [])
-      .map((link) => {
-        const key = normalizeSocialIcon(link.icon);
-        return key ? [key, link.link] : null;
-      })
-      .filter((entry): entry is [string, string] => entry !== null),
-  );
+  const socialLinks = convertSocialLinks(themeConfig.socialLinks);
 
   const theme: ThemeConfig = {
     ...(logo
@@ -291,16 +355,14 @@ function toThemeConfig(themeConfig: VitePressThemeConfig | undefined): ThemeConf
           },
         }
       : {}),
-    ...(Object.keys(socialLinks).length > 0
+    ...(hasSocialLinks(socialLinks)
       ? {
           socialLinks,
         }
       : {}),
   };
 
-  return logo || Object.keys(socialLinks).length > 0 || themeConfig.footer
-    ? defineTheme(theme)
-    : undefined;
+  return logo || hasSocialLinks(socialLinks) || themeConfig.footer ? defineTheme(theme) : undefined;
 }
 
 function resolveSiteName(config: VitePressConfig): string | undefined {


### PR DESCRIPTION
## Summary
- accept VitePress social link icons as string or object-form SVG
- keep legacy github/twitter/discord records for simple links, and emit SocialLink[] when custom icons or ariaLabel need to be preserved
- add a regression for object-form SVG migration output

Closes #1253

## Tests
- vp exec --filter @ox-content/vite-plugin -- vp test src/vitepress.test.ts
- vp exec --filter @ox-content/vite-plugin -- vp test src
- vp fmt --check
- vp check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790849350&installation_model_id=422833&pr_number=1255&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1255&signature=8671d8d7bc0a9e70342a5371639a8acbd29e19c5f3c8d0d770b94d45d4711ee2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->