### PR TITLE
fix(icons): avoid colon syntax source scan matches

### DIFF
--- a/npm/vite-plugin-ox-content/src/icons.test.ts
+++ b/npm/vite-plugin-ox-content/src/icons.test.ts
@@ -92,11 +92,26 @@ describe("icon name parsing", () => {
     expect(parseIconName("https://example.com/x.svg")).toBeUndefined();
   });
 
-  it("collects used names from source text", () => {
+  it("collects icon classes from source text", () => {
     const names = collectIconNamesFromText(
-      `span.icon-[ox--mark] plus ox:mark and https://api.iconify.design/ox/unused.svg`,
+      `span.icon-[ox--mark] plus ox:unused and https://api.iconify.design/ox/unused.svg`,
     );
     expect([...names]).toEqual(["ox:mark"]);
+  });
+
+  it("ignores non-icon colon syntax in source text", () => {
+    const names = collectIconNamesFromText(`
+      import path from "node:path";
+
+      const classes = "dark:opacity-20 hover:scale-110 md:grid-cols-2";
+      const metadata = { "og:image": "/social.png" };
+
+      p:first-of-type {
+        color: var(--accent);
+      }
+    `);
+
+    expect([...names]).toEqual([]);
   });
 
   it("collects frontmatter icon fields only", () => {
@@ -159,6 +174,32 @@ describe("writeSelfHostedIcons", () => {
     expect(result.names).toEqual(["ox:mark"]);
     const css = await fs.readFile(result.files[0]!, "utf8");
     expect(css).not.toContain("ox--unused");
+  });
+
+  it("scans icon classes from include globs without colon false positives", async () => {
+    const root = await tempDir("ox-icons-glob-");
+    const outDir = path.join(root, "dist");
+    await writeFixtureCollection(root);
+    await fs.mkdir(path.join(root, "src"), { recursive: true });
+    await fs.writeFile(
+      path.join(root, "src", "page.ts"),
+      [
+        'import path from "node:path";',
+        'const classes = "dark:opacity-20 hover:scale-110 md:grid-cols-2 icon-[ox--mark]";',
+        'const selectors = "p:first-of-type h2:hover";',
+        'const metadata = { "og:image": "/social.png" };',
+        'const url = "https://example.com/a:b";',
+      ].join("\n"),
+    );
+
+    const result = await writeSelfHostedIcons({
+      options: enabledIcons({ include: ["src/**/*.{ts,tsx,md,css,json}"] }),
+      outDir,
+      root,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.names).toEqual(["ox:mark"]);
   });
 
   it("diagnoses a missing collection and icon name", async () => {

--- a/npm/vite-plugin-ox-content/src/icons.ts
+++ b/npm/vite-plugin-ox-content/src/icons.ts
@@ -34,7 +34,6 @@ const URL_SCHEMES = new Set([
   "blob",
 ]);
 
-const COLON_ICON = /(?<![A-Za-z0-9_-])([a-z][a-z0-9-]*):([a-z0-9][a-z0-9-]*)/gi;
 const CLASS_ICON = /icon-\[([a-z][a-z0-9-]*)--([a-z0-9][a-z0-9-]*)\]/gi;
 const ICON_FIELD = /(?:^|[\s,{])icon\s*:\s*["']([^"']+)["']/g;
 
@@ -95,10 +94,6 @@ function tokenPair(prefix: string, name: string): ParsedIconName | undefined {
 }
 
 export function collectIconNamesFromText(text: string, into: Set<string> = new Set()): Set<string> {
-  COLON_ICON.lastIndex = 0;
-  for (const match of text.matchAll(COLON_ICON)) {
-    addParsed(into, match[1], match[2]);
-  }
   CLASS_ICON.lastIndex = 0;
   for (const match of text.matchAll(CLASS_ICON)) {
     addParsed(into, match[1], match[2]);


### PR DESCRIPTION
## Summary
- stop source-glob icon scanning from collecting bare `prefix:name` text
- keep explicit `include`/`safelist`, structured `icon:` fields, and `icon-[prefix--name]` classes working
- add regression coverage for `node:path`, Tailwind variants, CSS pseudo selectors, metadata, URLs, and icon class scanning

Closes #1257

## Tests
- vp install --frozen-lockfile --prefer-offline
- vp exec --filter @ox-content/vite-plugin -- vp test src/icons.test.ts -t "icon name parsing|theme embed|writeSelfHostedIcons"
- vp fmt --check
- node tools/scripts/check-file-lines.ts --base origin/main
- git diff --check

## Notes
- A local `vp run build:napi` attempt was blocked by host disk exhaustion before this PR changed any Rust/NAPI code; the full NAPI-backed suite is left to GitHub Actions.

Co-authored-by: ryoppippi <1560508+ryoppippi@users.noreply.github.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790881611&installation_model_id=422833&pr_number=1261&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1261&signature=1c22a72831eba51aefcc13397e5d6f236d18604df67381bbb948919d73b95871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved icon detection to avoid treating imports, utility classes, metadata, CSS selectors, URLs, and other colon-based syntax as icons.
  * Icon scanning now reliably recognizes only supported icon class formats.
  * Added coverage for scanning TypeScript, CSS, and JSON files through configured include patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->