### PR TITLE
fix(twitter): decode syndication text entities

### DIFF
--- a/npm/vite-plugin-ox-content/src/plugins/twitter-full.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter-full.test.ts
@@ -83,6 +83,48 @@ describe("full-fidelity Tweet cards", () => {
     expect(html).not.toContain("👍");
   });
 
+  it("decodes syndication HTML entities once before escaping tweet text", () => {
+    const html = renderTweetText({
+      text: "0.13.4 -&gt; 0.13.5 &#45; &lt;b&gt; &amp;lt;i&amp;gt;",
+      user: user(),
+    });
+    expect(html).toContain("0.13.4 -&gt; 0.13.5 - &lt;b&gt; &amp;lt;i&amp;gt;");
+    expect(html).not.toContain("-&amp;gt;");
+    expect(html).not.toContain("<b>");
+    expect(html).not.toContain("<i>");
+  });
+
+  it("keeps entity ranges aligned after decoding syndication text", () => {
+    const docs = "https://t.co/docs";
+    const decoded = `Read & share ${docs} #ox @ox_content`;
+    const encoded = `Read &amp; share ${docs} #ox @ox_content`;
+    const html = renderTweetText({
+      text: encoded,
+      display_text_range: [0, decoded.length],
+      user: user(),
+      entities: {
+        urls: [
+          {
+            url: docs,
+            expanded_url: "https://example.com/docs",
+            display_url: "example.com/docs",
+            indices: span(decoded, docs),
+          },
+        ],
+        hashtags: [{ text: "ox", indices: span(decoded, "#ox") }],
+        user_mentions: [{ screen_name: "ox_content", indices: span(decoded, "@ox_content") }],
+      },
+    });
+    expect(html).toContain("Read &amp; share");
+    expect(html).toContain('href="https://example.com/docs"');
+    expect(html).toContain(">example.com/docs</a>");
+    expect(html).toContain('href="https://x.com/hashtag/ox"');
+    expect(html).toContain(">#ox</a>");
+    expect(html).toContain('href="https://x.com/ox_content"');
+    expect(html).toContain(">@ox_content</a>");
+    expect(html).not.toContain("&amp;amp;");
+  });
+
   it("drops unsafe mention hrefs and keeps JA/EN body text", () => {
     const text = "こんにちは <script> @bad";
     const html = renderTweetText(
@@ -122,7 +164,7 @@ describe("full-fidelity Tweet cards", () => {
         user: user(),
         quoted_tweet: {
           id_str: "99",
-          text: "Quoted 写真",
+          text: "Quoted &lt;photo&gt; &#45; safe",
           user: { name: "Other", screen_name: "other", is_blue_verified: true },
           mediaDetails: [
             { type: "photo", media_url_https: "https://pbs.twimg.com/media/quoted.jpg" },
@@ -131,7 +173,9 @@ describe("full-fidelity Tweet cards", () => {
       },
       { appearance: "full" },
     );
-    expect(quoted).toContain("Quoted 写真");
+    expect(quoted).toContain("Quoted &lt;photo&gt; - safe");
+    expect(quoted).not.toContain("&amp;lt;photo&amp;gt;");
+    expect(quoted).not.toContain("<photo>");
     expect(quoted).toContain("ox-tweet__badge--blue");
     expect(quoted).toContain("/tweets/555-quoted-media-1.jpg");
 

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/text.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/text.ts
@@ -4,6 +4,15 @@ import { sanitizeScreenName, visibleTextRange } from "./validate";
 
 type EntityKind = "url" | "media" | "hashtag" | "mention" | "symbol";
 
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  nbsp: "\u00a0",
+  quot: '"',
+};
+
 interface CollectedEntity extends TweetIndexedEntity {
   kind: EntityKind;
   href?: string;
@@ -14,7 +23,9 @@ export function renderTweetText(
   data: TweetBodyData,
   options?: { omitTrailingQuoteUrl?: boolean },
 ): string {
-  const [start, end] = visibleTextRange(data, options?.omitTrailingQuoteUrl === true);
+  const text = decodeTweetText(data.text);
+  const textData = text === data.text ? data : { ...data, text };
+  const [start, end] = visibleTextRange(textData, options?.omitTrailingQuoteUrl === true);
   const entities = collectEntities(data)
     .filter((entity) => validRange(entity.indices, start, end))
     .sort((left, right) => left.indices![0] - right.indices![0]);
@@ -24,14 +35,14 @@ export function renderTweetText(
   for (const entity of entities) {
     const [entityStart, entityEnd] = entity.indices!;
     if (entityStart < cursor) continue;
-    output += escapeText(data.text.slice(cursor, entityStart));
+    output += escapeText(text.slice(cursor, entityStart));
     if (entity.href) {
-      const label = entity.label ?? data.text.slice(entityStart, entityEnd);
+      const label = entity.label ?? text.slice(entityStart, entityEnd);
       output += `<a href="${escapeAttribute(entity.href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(label)}</a>`;
     }
     cursor = entityEnd;
   }
-  output += escapeText(data.text.slice(cursor, end));
+  output += escapeText(text.slice(cursor, end));
   return output.trim();
 }
 
@@ -82,4 +93,27 @@ function validRange(
   end: number,
 ): indices is [number, number] {
   return Boolean(indices && indices[0] >= start && indices[1] <= end && indices[0] < indices[1]);
+}
+
+function decodeTweetText(value: string): string {
+  if (!value.includes("&")) {
+    return value;
+  }
+  return value.replace(/&(#[0-9]+|#[xX][0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);/g, (match, body) => {
+    if (body.startsWith("#")) {
+      const code =
+        body[1] === "x" || body[1] === "X"
+          ? Number.parseInt(body.slice(2), 16)
+          : Number.parseInt(body.slice(1), 10);
+      if (!Number.isInteger(code) || code <= 0 || code > 0x10ffff) {
+        return match;
+      }
+      try {
+        return String.fromCodePoint(code);
+      } catch {
+        return match;
+      }
+    }
+    return NAMED_ENTITIES[body.toLowerCase()] ?? match;
+  });
 }


### PR DESCRIPTION
Summary:
- Decode Twitter/X syndication HTML entities exactly once before display range trimming and entity expansion.
- Keep final tweet text and entity labels escaped so decoded markup cannot become HTML.
- Add regression coverage for the -&gt; case, numeric entities, preserved &amp;amp; semantics, entity ranges, and quoted tweet text.

Tests:
- vp run build:napi
- vp exec --filter @ox-content/vite-plugin -- vp test src/plugins/twitter-full.test.ts src/plugins/twitter.test.ts
- vp fmt --check
- node tools/scripts/check-file-lines.ts --base origin/main
- git diff --check

Closes #1258

Co-authored-by: ryoppippi <1560508+ryoppippi@users.noreply.github.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790882185&installation_model_id=422833&pr_number=1262&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1262&signature=f0dbbfa88bf21f73a43bb1747ee61f9283243e2d2b53e461237811fb95969d38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tweet text rendering for HTML-encoded content.
  * Prevented double-escaping and ensured character ranges remain correctly aligned.
  * Improved handling of numeric and common named HTML entities, including angle brackets, quotes, apostrophes, ampersands, and non-breaking spaces.
  * Preserved unrecognized entities without altering their content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->