### PR TITLE
fix(opengraph): avoid broken favicon candidates

### DIFF
--- a/npm/vite-plugin-ox-content/src/plugins/ogp-parse.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/ogp-parse.test.ts
@@ -76,6 +76,46 @@ describe("Open Graph metadata parsing", () => {
     }
   });
 
+  it("skips a known-broken GitHub favicon URL", () => {
+    const githubPage =
+      "https://github.com/ryoppippi/zig-tflite-mnist/blob/main/notebook/MNIST_TFLite.ipynb";
+    const data = parseOgpFromHtml(
+      meta(
+        `<meta property="og:title" content="MNIST TFLite">`,
+        `<meta property="og:description" content="Notebook preview">`,
+        `<meta property="og:image" content="https://opengraph.githubassets.com/card.png">`,
+        `<link rel="icon" href="https://github.githubassets.com/favicons/favicon">`,
+      ),
+      githubPage,
+    );
+
+    expect(data.title).toBe("MNIST TFLite");
+    expect(data.description).toBe("Notebook preview");
+    expect(data.image).toBe("https://opengraph.githubassets.com/card.png");
+    expect(data.favicon).toBe("https://github.com/favicon.ico");
+  });
+
+  it("chooses the first usable icon from multiple rel variants", () => {
+    const data = parseOgpFromHtml(
+      meta(
+        `<link rel="shortcut icon" href="javascript:alert(1)">`,
+        `<link rel="icon" href="https://github.githubassets.com/favicons/favicon">`,
+        `<link href="/assets/icon-180.png" rel="apple-touch-icon">`,
+      ),
+      PAGE,
+    );
+
+    expect(data.favicon).toBe("https://example.com/assets/icon-180.png");
+  });
+
+  it("omits the favicon when no usable icon or fallback can be resolved", () => {
+    const data = parseOgpFromHtml(
+      meta(`<link rel="icon" href="javascript:alert(1)">`),
+      "not a url",
+    );
+    expect(data.favicon).toBeUndefined();
+  });
+
   it("falls back to the host name when the page names no title", () => {
     const data = parseOgpFromHtml(meta(""), PAGE);
     expect(data.title).toBe("example.com");

--- a/npm/vite-plugin-ox-content/src/plugins/ogp/parse.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/ogp/parse.ts
@@ -21,6 +21,13 @@ const NAMED_ENTITIES: Record<string, string> = {
   rdquo: "”",
 };
 
+const ICON_REL_TOKENS = new Set([
+  "icon",
+  "apple-touch-icon",
+  "apple-touch-icon-precomposed",
+  "mask-icon",
+]);
+
 /**
  * Expand the character references that show up in `<meta>` content.
  *
@@ -89,10 +96,46 @@ function metaContent(
 }
 
 function declaredIcon(html: string, pageUrl: string): string | undefined {
-  const match =
-    html.match(/<link[^>]*rel=["'](?:shortcut )?icon["'][^>]*href=["']([^"']+)["']/i) ??
-    html.match(/<link[^>]*href=["']([^"']+)["'][^>]*rel=["'](?:shortcut )?icon["']/i);
-  return match ? resolveMetaUrl(match[1], pageUrl) : undefined;
+  for (const tag of html.matchAll(/<link\b[^>]*>/gi)) {
+    const attributes = linkAttributes(tag[0]);
+    if (!isIconRel(attributes.rel) || !attributes.href) continue;
+
+    const resolved = resolveMetaUrl(attributes.href, pageUrl);
+    if (resolved && isUsableFaviconUrl(resolved)) return resolved;
+  }
+}
+
+function linkAttributes(tag: string): Record<string, string> {
+  const attributes: Record<string, string> = {};
+  for (const match of tag.matchAll(
+    /([^\s"'<>/=]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g,
+  )) {
+    const name = match[1].toLowerCase();
+    if (name === "link") continue;
+    attributes[name] = decodeHtmlEntities(match[2] ?? match[3] ?? match[4] ?? "");
+  }
+  return attributes;
+}
+
+function isIconRel(value: string | undefined): boolean {
+  return Boolean(
+    value
+      ?.toLowerCase()
+      .split(/\s+/)
+      .some((token) => ICON_REL_TOKENS.has(token)),
+  );
+}
+
+function isUsableFaviconUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return !(
+      url.hostname.toLowerCase() === "github.githubassets.com" &&
+      url.pathname === "/favicons/favicon"
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
Summary:
- Scan multiple link rel icon variants in document order and choose the first safe usable candidate.
- Skip unsafe icon hrefs and the known-broken GitHub assets favicon URL before falling back to the page origin /favicon.ico.
- Keep existing Open Graph title, description, and image parsing behavior unchanged.

Evidence:
- curl -I -L https://github.githubassets.com/favicons/favicon returned HTTP 404 on 2026-09-02 JST.

Tests:
- vp exec --filter @ox-content/vite-plugin -- vp test src/plugins/ogp.test.ts src/plugins/ogp-parse.test.ts
- vp fmt --check
- node tools/scripts/check-file-lines.ts --base origin/main
- git diff --check

Closes #1259

Co-authored-by: ryoppippi <1560508+ryoppippi@users.noreply.github.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790882420&installation_model_id=422833&pr_number=1263&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1263&signature=e67a024c66225018a19ee82ccc03cfcb225fb94a0e49b6d7f66c4cfb2201c473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->