### PR TITLE
fix(solid): add browser-safe HTML host client

### DIFF
--- a/docs/content/credits.md
+++ b/docs/content/credits.md
@@ -65,6 +65,9 @@ Contribution summary:
 - Requested the collection asset URL rewriter, public external-feed ingestion,
   redirect-output planner/writer, Solid HTML-string host adapter, and Solid
   island stylesheet resolver used by custom hosts.
+- Reported that Solid HTML-string hosts needed a browser-only lazy client
+  contract with cancellable island lifecycle and document-scoped module
+  identities.
 
 ### bulebrainbrand
 

--- a/docs/content/ja/credits.md
+++ b/docs/content/ja/credits.md
@@ -62,6 +62,8 @@ Markdown 属性とリッチなソーシャル埋め込みの見た目の同等�
 - 独自ホスト向けに、collection asset URL rewriter、公開 external-feed ingestion、
   redirect-output planner/writer、Solid HTML-string host adapter、Solid island
   stylesheet resolver を要望しました。
+- Solid HTML-string host 向けに、cancellable island lifecycle と document-scoped
+  module identity を持つ browser-only lazy client contract が必要だと報告しました。
 
 ### bulebrainbrand
 

--- a/docs/content/ja/packages/vite-plugin-ox-content-solid.md
+++ b/docs/content/ja/packages/vite-plugin-ox-content-solid.md
@@ -96,35 +96,40 @@ const rendered = await renderSolidHtmlHost({
   imports,
   components: { Badge: "./src/components/Badge.tsx" },
   loadModule: (moduleId) => viteDevServer.ssrLoadModule(moduleId),
-  resolveClientModule: (module) => `/assets/islands/${module.name}.js`,
+  resolveClientModule: (module) =>
+    module.source === "document" ? `./docs/${module.name}.tsx` : `./components/${module.name}.tsx`,
 });
 ```
 
 module cache は 1 回の render call に閉じます。development edit 後は host 側で page
-state を invalidation し、改めて呼び直してください。`modules` はその render の
-server-side metadata です。browser に渡す JSON には `clientModules` か host の
-resolver が返した公開 identity だけを serialize し、absolute filesystem path を
-混ぜないでください。
+state を invalidation し、改めて呼び直してください。`resolveClientModule()` が返した
+identity は各 island の `data-ox-module` に書かれ、`data-ox-export` も一緒に出力されます。
+browser 側の loader map でも同じ key を使ってください。これにより、2 つの document が同じ
+local component 名を使っても、downstream の HTML replacement なしで別 module を読めます。
 
 diagnostics は missing component、module load failure、missing export、SSR error、
 unsupported document-local import form を document/component context 付きで返します。
 対応する document-local form は Markdown-module adapter と同じで、default import と
 local binding 付き named import です。
 
-client helper は Solid hydration ではなく fresh mount の bridge です。既存の
-Ox Content island payload と slot HTML を読み、target を空にしてから caller の
-`@solidjs/web` renderer に渡します。load strategy、dispose、cancellation を共有
-runtime に任せるため、`initIslands()` と組み合わせます。
+browser client は別 subpath にあります:
+`@ox-content/vite-plugin-solid/html-host/client`。custom host が Vite、Node helper、native
+optional dependency を巻き込まずに bundle できる browser-only entry です。これは Solid
+hydration ではなく fresh mount の bridge です。既存の Ox Content island payload と
+authoring 時の slot HTML を読み、target を空にしてから caller の `@solidjs/web` renderer に
+渡します。SSR 済み self-closing island の rendered HTML は children として渡しません。
 
 ```tsx
 import { initIslands } from "@ox-content/islands";
 import { render } from "@solidjs/web";
-import { createSolidHtmlHostHydrate } from "@ox-content/vite-plugin-solid";
-import * as components from "./generated-island-client-modules";
+import { initSolidHtmlHost } from "@ox-content/vite-plugin-solid/html-host/client";
 
-const hydrate = createSolidHtmlHostHydrate({
-  components,
-  render(Component, props, element, slotHtml) {
+const modules = import.meta.glob("./{docs,components}/**/*.tsx");
+
+initSolidHtmlHost({
+  initIslands,
+  modules,
+  render({ component: Component, props, element, slotHtml }) {
     const dispose = render(
       () =>
         slotHtml ? (
@@ -138,10 +143,19 @@ const hydrate = createSolidHtmlHostHydrate({
     );
     return dispose;
   },
+  onError(error) {
+    console.error(error.message);
+  },
+  options: { selector: ".ox-content [data-ox-island]" },
 });
-
-initIslands(hydrate, { selector: ".ox-content [data-ox-island]" });
 ```
+
+`initSolidHtmlHost()` は host が渡した `initIslands()` を呼び、その controller を返します。
+island runtime を host 側で直接管理している場合は、同じ subpath の
+`createSolidHtmlHostLazyHydrate()` を使い、返ってきた同期 hydrate function を
+`initIslands()` に渡してください。adapter は pending lazy import を cancellation 可能にします。
+module 解決前に dispose された island は stale mount せず、mounted cleanup は 1 回だけ走り、
+unknown module、loader、runtime、export、render の失敗は `onError` に通知されます。
 
 ## 独自ホストの island stylesheet
 

--- a/docs/content/packages/vite-plugin-ox-content-solid.md
+++ b/docs/content/packages/vite-plugin-ox-content-solid.md
@@ -199,34 +199,42 @@ const rendered = await renderSolidHtmlHost({
   imports,
   components: { Badge: "./src/components/Badge.tsx" },
   loadModule: (moduleId) => viteDevServer.ssrLoadModule(moduleId),
-  resolveClientModule: (module) => `/assets/islands/${module.name}.js`,
+  resolveClientModule: (module) =>
+    module.source === "document" ? `./docs/${module.name}.tsx` : `./components/${module.name}.tsx`,
 });
 ```
 
 The module cache is scoped to one render call, so development edits should
-trigger a fresh call after the host invalidates its page state. `modules` is
-server-side metadata for this render; serialize only `clientModules` or your own
-resolver output when sending island module identities to the browser.
+trigger a fresh call after the host invalidates its page state.
+`resolveClientModule()` writes the returned identity to each island as
+`data-ox-module`, along with `data-ox-export`. Use the same keys in the browser
+loader map so two documents can reuse a local component name without downstream
+HTML replacement.
 
 Diagnostics report missing components, module load failures, missing exports,
 SSR errors, and unsupported document-local import forms with document/component
 context. The supported document-local forms are the same ones the Markdown-module
 adapter understands: default imports and named imports with local bindings.
 
-The client helper is a fresh-mount bridge, not Solid hydration. It reads the
-existing Ox Content island payload and slot HTML, clears the target, and lets the
-caller mount with `@solidjs/web`. Use it with `initIslands()` so load strategies,
-disposal, and cancellation stay owned by the shared island runtime.
+The browser client lives on a separate subpath so custom hosts can bundle it
+without importing Vite, Node helpers, or native optional dependencies:
+`@ox-content/vite-plugin-solid/html-host/client`. It is a fresh-mount bridge,
+not Solid hydration. It reads the existing Ox Content island payload and authored
+slot HTML, clears the target, and lets the caller mount with `@solidjs/web`.
+When SSR produced HTML for a self-closing island, that rendered output is not
+passed back as children.
 
 ```tsx
 import { initIslands } from "@ox-content/islands";
 import { render } from "@solidjs/web";
-import { createSolidHtmlHostHydrate } from "@ox-content/vite-plugin-solid";
-import * as components from "./generated-island-client-modules";
+import { initSolidHtmlHost } from "@ox-content/vite-plugin-solid/html-host/client";
 
-const hydrate = createSolidHtmlHostHydrate({
-  components,
-  render(Component, props, element, slotHtml) {
+const modules = import.meta.glob("./{docs,components}/**/*.tsx");
+
+initSolidHtmlHost({
+  initIslands,
+  modules,
+  render({ component: Component, props, element, slotHtml }) {
     const dispose = render(
       () =>
         slotHtml ? (
@@ -240,10 +248,20 @@ const hydrate = createSolidHtmlHostHydrate({
     );
     return dispose;
   },
+  onError(error) {
+    console.error(error.message);
+  },
+  options: { selector: ".ox-content [data-ox-island]" },
 });
-
-initIslands(hydrate, { selector: ".ox-content [data-ox-island]" });
 ```
+
+`initSolidHtmlHost()` calls the `initIslands()` function supplied by the host and
+returns its controller. If you already manage the island runtime yourself, use
+`createSolidHtmlHostLazyHydrate()` from the same subpath and pass the returned
+synchronous hydrate function to `initIslands()`. The adapter keeps pending lazy
+imports cancellable: disposal before a module resolves prevents stale mount,
+mounted cleanup runs exactly once, and unknown module, loader, runtime, export,
+and render failures are reported to `onError`.
 
 ## Island stylesheets for custom hosts
 

--- a/npm/vite-plugin-ox-content-solid/package.json
+++ b/npm/vite-plugin-ox-content-solid/package.json
@@ -28,6 +28,16 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs",
       "types": "./dist/index.d.mts"
+    },
+    "./html-host/client": {
+      "import": {
+        "types": "./dist/html-host-client.d.mts",
+        "default": "./dist/html-host-client.mjs"
+      },
+      "require": {
+        "types": "./dist/html-host-client.d.cts",
+        "default": "./dist/html-host-client.cjs"
+      }
     }
   },
   "publishConfig": {

--- a/npm/vite-plugin-ox-content-solid/src/html-host-client-types.ts
+++ b/npm/vite-plugin-ox-content-solid/src/html-host-client-types.ts
@@ -1,0 +1,85 @@
+import type { InitIslandsOptions } from "@ox-content/islands";
+
+export type SolidHtmlHostClientDiagnosticCode =
+  | "missing-island-name"
+  | "missing-module-id"
+  | "unknown-module"
+  | "module-load-failed"
+  | "runtime-load-failed"
+  | "missing-export"
+  | "render-failed";
+
+export interface SolidHtmlHostClientError {
+  code: SolidHtmlHostClientDiagnosticCode;
+  message: string;
+  element: HTMLElement;
+  props: Record<string, unknown>;
+  componentName?: string;
+  moduleId?: string;
+  exportName?: string;
+  cause?: unknown;
+}
+
+export type SolidHtmlHostClientComponentValue = (...args: never[]) => unknown;
+export type SolidHtmlHostClientModuleValue =
+  | Record<string, unknown>
+  | SolidHtmlHostClientComponentValue;
+
+export type SolidHtmlHostClientModuleLoader<
+  TModule extends object = SolidHtmlHostClientModuleValue,
+> = () => TModule | PromiseLike<TModule>;
+
+export type SolidHtmlHostClientModules =
+  | Readonly<Record<string, SolidHtmlHostClientModuleLoader>>
+  | ReadonlyMap<string, SolidHtmlHostClientModuleLoader>;
+
+export interface SolidHtmlHostClientContext<TRuntime = undefined> {
+  component: unknown;
+  componentName: string;
+  element: HTMLElement;
+  exportName: string;
+  moduleExports: unknown;
+  moduleId: string;
+  props: Record<string, unknown>;
+  runtime: TRuntime | undefined;
+  slotHtml: string | undefined;
+}
+
+export type SolidHtmlHostClientRenderer<TRuntime = undefined> = (
+  context: SolidHtmlHostClientContext<TRuntime>,
+) => void | (() => void);
+
+export type SolidHtmlHostClientRuntimeLoader<TRuntime = undefined> = () =>
+  | TRuntime
+  | Promise<TRuntime>;
+
+export type SolidHtmlHostModuleIdResolver = (
+  element: HTMLElement,
+  context: { componentName: string; props: Record<string, unknown> },
+) => string | undefined;
+
+export type SolidHtmlHostExportNameResolver = (
+  element: HTMLElement,
+  context: { componentName: string; moduleId: string; props: Record<string, unknown> },
+) => string | undefined;
+
+export interface CreateSolidHtmlHostLazyHydrateInput<TRuntime = undefined> {
+  modules: SolidHtmlHostClientModules;
+  render: SolidHtmlHostClientRenderer<TRuntime>;
+  loadRuntime?: SolidHtmlHostClientRuntimeLoader<TRuntime>;
+  resolveModuleId?: SolidHtmlHostModuleIdResolver;
+  resolveExportName?: SolidHtmlHostExportNameResolver;
+  onError?: (error: SolidHtmlHostClientError) => void;
+}
+
+export type SolidHtmlHostInitIslands<TController = unknown> = (
+  hydrate: (element: HTMLElement, props: Record<string, unknown>) => void | (() => void),
+  options?: InitIslandsOptions,
+) => TController;
+
+export interface InitSolidHtmlHostInput<
+  TRuntime = undefined,
+> extends CreateSolidHtmlHostLazyHydrateInput<TRuntime> {
+  initIslands: SolidHtmlHostInitIslands;
+  options?: InitIslandsOptions;
+}

--- a/npm/vite-plugin-ox-content-solid/src/html-host-client.test.ts
+++ b/npm/vite-plugin-ox-content-solid/src/html-host-client.test.ts
@@ -1,0 +1,284 @@
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path, { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "vite";
+import { describe, expect, it } from "vite-plus/test";
+import packageJson from "../package.json" with { type: "json" };
+import {
+  createSolidHtmlHostLazyHydrate,
+  initSolidHtmlHost,
+  readSolidHtmlHostSlot,
+  type SolidHtmlHostClientError,
+} from "./html-host-client";
+
+const packageRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+const require = createRequire(import.meta.url);
+
+describe("Solid HTML host browser client", () => {
+  it("declares a browser-only package subpath and pack entry", () => {
+    const exportsField = packageJson.exports as unknown as Record<string, PackageConditionalExport>;
+    const client = exportsField["./html-host/client"];
+
+    expect(client.import.types).toBe("./dist/html-host-client.d.mts");
+    expect(client.import.default).toBe("./dist/html-host-client.mjs");
+    expect(client.require.types).toBe("./dist/html-host-client.d.cts");
+    expect(client.require.default).toBe("./dist/html-host-client.cjs");
+
+    const viteConfig = requireViteConfig();
+    expect(viteConfig.default.pack.entry).toContain("src/html-host-client.ts");
+  });
+
+  it("bundles a minimal browser entry without Vite, Node or native dependencies", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "ox-solid-html-client-"));
+    try {
+      await fs.writeFile(
+        path.join(root, "entry.js"),
+        [
+          'import { createSolidHtmlHostLazyHydrate } from "@ox-content/vite-plugin-solid/html-host/client";',
+          "console.log(typeof createSolidHtmlHostLazyHydrate);",
+        ].join("\n"),
+      );
+
+      const output = await build({
+        root,
+        configFile: false,
+        logLevel: "silent",
+        resolve: {
+          alias: {
+            "@ox-content/vite-plugin-solid/html-host/client": fileURLToPath(
+              new URL("./html-host-client.ts", import.meta.url),
+            ),
+            "@ox-content/islands": fileURLToPath(
+              new URL("../../ox-content-islands/src/index.ts", import.meta.url),
+            ),
+          },
+        },
+        build: {
+          write: false,
+          lib: {
+            entry: path.join(root, "entry.js"),
+            formats: ["es"],
+          },
+        },
+      });
+      const bundle = bundleCode(output);
+
+      expect(bundle).not.toContain("@ox-content/vite-plugin");
+      expect(bundle).not.toContain("node:");
+      expect(bundle).not.toContain("fsevents");
+      expect(bundle).not.toContain("resvg");
+    } finally {
+      await fs.rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("loads distinct document-scoped modules for reused local component names", async () => {
+    const calls: string[] = [];
+    const hydrate = createSolidHtmlHostLazyHydrate({
+      modules: {
+        "./docs/a/Chart.tsx": () => ({ default: "chart-a" }),
+        "./docs/b/Chart.tsx": () => ({ default: "chart-b" }),
+      },
+      render: ({ component, moduleId }) => {
+        calls.push(`${moduleId}:${String(component)}`);
+      },
+    });
+
+    hydrate(
+      element({ oxIsland: "Chart", oxModule: "./docs/a/Chart.tsx", oxExport: "default" }),
+      {},
+    );
+    hydrate(
+      element({ oxIsland: "Chart", oxModule: "./docs/b/Chart.tsx", oxExport: "default" }),
+      {},
+    );
+    await settle();
+
+    expect(calls).toEqual(["./docs/a/Chart.tsx:chart-a", "./docs/b/Chart.tsx:chart-b"]);
+  });
+
+  it("passes a synchronous lazy hydrate function to the supplied initIslands", () => {
+    const controller = { destroy: () => {} };
+    let received:
+      | {
+          hydrate: (element: HTMLElement, props: Record<string, unknown>) => unknown;
+          selector?: string;
+        }
+      | undefined;
+
+    const returned = initSolidHtmlHost({
+      initIslands(hydrate, options) {
+        received = { hydrate, selector: options?.selector };
+        return controller;
+      },
+      modules: { "./Chart.tsx": () => ({ default: "chart" }) },
+      render: () => {},
+      options: { selector: ".ox-content [data-ox-island]" },
+    });
+
+    expect(returned).toBe(controller);
+    expect(typeof received?.hydrate).toBe("function");
+    expect(received?.selector).toBe(".ox-content [data-ox-island]");
+  });
+
+  it("reports unknown modules, load failures, missing exports and render failures", async () => {
+    const errors: SolidHtmlHostClientError[] = [];
+    const hydrate = createSolidHtmlHostLazyHydrate({
+      modules: {
+        "./Bad.tsx": () => Promise.reject(new Error("network gone")),
+        "./Missing.tsx": () => ({}),
+        "./Render.tsx": () => ({ default: "component" }),
+      },
+      render: () => {
+        throw new Error("render boom");
+      },
+      onError: (error) => errors.push(error),
+    });
+
+    hydrate(element({ oxIsland: "Unknown", oxModule: "./Unknown.tsx" }), {});
+    hydrate(element({ oxIsland: "Bad", oxModule: "./Bad.tsx" }), {});
+    hydrate(element({ oxIsland: "Missing", oxModule: "./Missing.tsx" }), {});
+    hydrate(element({ oxIsland: "Render", oxModule: "./Render.tsx" }), {});
+    await settle();
+
+    expect(errors.map((error) => error.code).sort()).toEqual([
+      "missing-export",
+      "module-load-failed",
+      "render-failed",
+      "unknown-module",
+    ]);
+    expect(errors.map((error) => error.message).join("\n")).toContain("network gone");
+    expect(errors.map((error) => error.message).join("\n")).toContain("render boom");
+  });
+
+  it("cancels stale pending loads and disposes mounted islands exactly once", async () => {
+    const pending = deferred<Record<string, unknown>>();
+    let renders = 0;
+    let disposals = 0;
+    const hydrate = createSolidHtmlHostLazyHydrate({
+      modules: { "./Slow.tsx": () => pending.promise },
+      render: () => {
+        renders += 1;
+        return () => {
+          disposals += 1;
+        };
+      },
+    });
+
+    const staleDispose = hydrate(element({ oxIsland: "Slow", oxModule: "./Slow.tsx" }), {});
+    staleDispose();
+    pending.resolve({ default: "slow" });
+    await settle();
+    expect(renders).toBe(0);
+
+    const dispose = hydrate(element({ oxIsland: "Slow", oxModule: "./Slow.tsx" }), {});
+    await settle();
+    dispose();
+    dispose();
+
+    expect(renders).toBe(1);
+    expect(disposals).toBe(1);
+  });
+
+  it("passes authored slots without treating self-closing SSR output as children", async () => {
+    const calls: Array<{ component: string; slotHtml: string | undefined }> = [];
+    const hydrate = createSolidHtmlHostLazyHydrate({
+      modules: {
+        "./Slot.tsx": () => ({ default: "slot" }),
+        "./Self.tsx": () => ({ default: "self" }),
+      },
+      render: ({ component, slotHtml }) => {
+        calls.push({ component: String(component), slotHtml });
+      },
+    });
+    const slot = element(
+      { oxIsland: "Slot", oxModule: "./Slot.tsx", oxSsr: "true", oxContent: "<em>authored</em>" },
+      "<strong>SSR output</strong>",
+    );
+    const selfClosing = element(
+      { oxIsland: "Self", oxModule: "./Self.tsx", oxSsr: "true" },
+      "<strong>SSR output</strong>",
+    );
+
+    hydrate(slot, {});
+    hydrate(selfClosing, {});
+    await settle();
+
+    expect(calls).toEqual([
+      { component: "slot", slotHtml: "<em>authored</em>" },
+      { component: "self", slotHtml: undefined },
+    ]);
+    expect(slot.innerHTML).toBe("");
+    expect(selfClosing.innerHTML).toBe("");
+    expect(
+      readSolidHtmlHostSlot(
+        element({}, '<script type="application/json">{"props":{}}</script><em>fallback</em>'),
+      ),
+    ).toBe("<em>fallback</em>");
+  });
+});
+
+interface PackageConditionalExport {
+  import: { types: string; default: string };
+  require: { types: string; default: string };
+}
+
+function requireViteConfig(): { default: { pack: { entry: string[] } } } {
+  const configPath = join(packageRoot, "vite.config.ts");
+  return require(configPath) as { default: { pack: { entry: string[] } } };
+}
+
+function bundleCode(output: unknown): string {
+  const outputs = Array.isArray(output) ? output : [output];
+  return outputs
+    .flatMap((result) => {
+      const chunks = (result as { output?: unknown }).output;
+      return Array.isArray(chunks) ? chunks : [];
+    })
+    .map((chunk) => {
+      const outputChunk = chunk as { type?: string; code?: string };
+      return outputChunk.type === "chunk" ? (outputChunk.code ?? "") : "";
+    })
+    .join("\n");
+}
+
+function element(
+  dataset: Record<string, string> = {},
+  innerHTML = "",
+): HTMLElement & { events: unknown[] } {
+  const classes = new Set<string>();
+  const events: unknown[] = [];
+  return {
+    dataset: { ...dataset },
+    innerHTML,
+    classList: {
+      add: (...names: string[]) => names.forEach((name) => classes.add(name)),
+      remove: (...names: string[]) => names.forEach((name) => classes.delete(name)),
+    },
+    dispatchEvent(event: Event) {
+      events.push(event);
+      return true;
+    },
+    events,
+  } as unknown as HTMLElement & { events: unknown[] };
+}
+
+function settle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}

--- a/npm/vite-plugin-ox-content-solid/src/html-host-client.ts
+++ b/npm/vite-plugin-ox-content-solid/src/html-host-client.ts
@@ -1,0 +1,338 @@
+import type {
+  CreateSolidHtmlHostLazyHydrateInput,
+  InitSolidHtmlHostInput,
+  SolidHtmlHostClientDiagnosticCode,
+  SolidHtmlHostClientError,
+  SolidHtmlHostClientModuleLoader,
+  SolidHtmlHostClientModules,
+} from "./html-host-client-types";
+
+export type {
+  CreateSolidHtmlHostLazyHydrateInput,
+  InitSolidHtmlHostInput,
+  SolidHtmlHostClientContext,
+  SolidHtmlHostClientDiagnosticCode,
+  SolidHtmlHostClientError,
+  SolidHtmlHostClientComponentValue,
+  SolidHtmlHostClientModuleLoader,
+  SolidHtmlHostClientModules,
+  SolidHtmlHostClientModuleValue,
+  SolidHtmlHostClientRenderer,
+  SolidHtmlHostClientRuntimeLoader,
+  SolidHtmlHostExportNameResolver,
+  SolidHtmlHostInitIslands,
+  SolidHtmlHostModuleIdResolver,
+} from "./html-host-client-types";
+
+const ISLAND_JSON_SCRIPT = /^\s*<script type="application\/json">[\s\S]*?<\/script>/;
+
+export function initSolidHtmlHost<TRuntime = undefined>(
+  input: InitSolidHtmlHostInput<TRuntime>,
+): ReturnType<InitSolidHtmlHostInput<TRuntime>["initIslands"]> {
+  return input.initIslands(createSolidHtmlHostLazyHydrate(input), input.options);
+}
+
+export function createSolidHtmlHostLazyHydrate<TRuntime = undefined>(
+  input: CreateSolidHtmlHostLazyHydrateInput<TRuntime>,
+): (element: HTMLElement, props: Record<string, unknown>) => () => void {
+  const moduleCache = new Map<string, Promise<unknown>>();
+  let runtimeCache: Promise<TRuntime> | undefined;
+
+  return (element, props) => {
+    const componentName = element.dataset.oxIsland;
+    if (!componentName) {
+      reportError(input, clientError("missing-island-name", element, props));
+      return noop;
+    }
+
+    const moduleId =
+      input.resolveModuleId?.(element, { componentName, props }) ?? element.dataset.oxModule;
+    if (!moduleId) {
+      reportError(input, clientError("missing-module-id", element, props, { componentName }));
+      return noop;
+    }
+    if (!moduleLoader(input.modules, moduleId)) {
+      reportError(
+        input,
+        clientError("unknown-module", element, props, {
+          componentName,
+          moduleId,
+        }),
+      );
+      return noop;
+    }
+
+    const exportName =
+      input.resolveExportName?.(element, { componentName, moduleId, props }) ??
+      element.dataset.oxExport ??
+      "default";
+    const slotHtml = readSolidHtmlHostSlot(element);
+    let disposed = false;
+    let disposeMounted: (() => void) | undefined;
+
+    const dispose = () => {
+      if (disposed) return;
+      disposed = true;
+      disposeMounted?.();
+      disposeMounted = undefined;
+    };
+
+    void (async () => {
+      let moduleExports: unknown;
+      let runtime: TRuntime | undefined;
+      try {
+        moduleExports = await loadClientModule(input.modules, moduleId, moduleCache);
+      } catch (cause) {
+        if (!disposed) {
+          reportError(
+            input,
+            clientError("module-load-failed", element, props, {
+              componentName,
+              moduleId,
+              exportName,
+              cause,
+            }),
+          );
+        }
+        return;
+      }
+
+      if (disposed) return;
+
+      try {
+        runtime = await loadRuntime(
+          input,
+          () => runtimeCache,
+          (pending) => {
+            runtimeCache = pending;
+          },
+        );
+      } catch (cause) {
+        if (!disposed) {
+          reportError(
+            input,
+            clientError("runtime-load-failed", element, props, {
+              componentName,
+              moduleId,
+              exportName,
+              cause,
+            }),
+          );
+        }
+        return;
+      }
+
+      if (disposed) return;
+
+      const component = exportedValue(moduleExports, exportName);
+      if (component == null) {
+        reportError(
+          input,
+          clientError("missing-export", element, props, {
+            componentName,
+            moduleId,
+            exportName,
+            cause: new Error(`Export "${exportName}" was not found.`),
+          }),
+        );
+        return;
+      }
+
+      element.innerHTML = "";
+      try {
+        const cleanup = input.render({
+          component,
+          componentName,
+          element,
+          exportName,
+          moduleExports,
+          moduleId,
+          props,
+          runtime,
+          slotHtml,
+        });
+        disposeMounted = cleanup ? once(cleanup) : undefined;
+        if (disposed) {
+          disposeMounted?.();
+          disposeMounted = undefined;
+        }
+      } catch (cause) {
+        if (!disposed) {
+          reportError(
+            input,
+            clientError("render-failed", element, props, {
+              componentName,
+              moduleId,
+              exportName,
+              cause,
+            }),
+          );
+        }
+      }
+    })();
+
+    return dispose;
+  };
+}
+
+export function readSolidHtmlHostSlot(
+  element: Pick<HTMLElement, "dataset" | "innerHTML">,
+): string | undefined {
+  const fromAttr = element.dataset.oxContent;
+  if (fromAttr) return fromAttr;
+  if (element.dataset.oxSsr === "true") return undefined;
+
+  const slotHtml = element.innerHTML.replace(ISLAND_JSON_SCRIPT, "");
+  return slotHtml || undefined;
+}
+
+async function loadClientModule(
+  modules: SolidHtmlHostClientModules,
+  moduleId: string,
+  cache: Map<string, Promise<unknown>>,
+): Promise<unknown> {
+  const cached = cache.get(moduleId);
+  if (cached) return cached;
+
+  const loader = moduleLoader(modules, moduleId);
+  if (!loader) {
+    throw new Error(`Unknown module "${moduleId}".`);
+  }
+
+  const pending = Promise.resolve()
+    .then(loader)
+    .catch((cause: unknown) => {
+      cache.delete(moduleId);
+      throw cause;
+    });
+  cache.set(moduleId, pending);
+  return pending;
+}
+
+async function loadRuntime<TRuntime>(
+  input: CreateSolidHtmlHostLazyHydrateInput<TRuntime>,
+  getCached: () => Promise<TRuntime> | undefined,
+  setCached: (pending: Promise<TRuntime> | undefined) => void,
+): Promise<TRuntime | undefined> {
+  const load = input.loadRuntime;
+  if (!load) return undefined;
+
+  const cached = getCached();
+  if (cached) return cached;
+
+  const pending = Promise.resolve()
+    .then(load)
+    .catch((cause: unknown) => {
+      setCached(undefined);
+      throw cause;
+    });
+  setCached(pending);
+  return pending;
+}
+
+function moduleLoader(
+  modules: SolidHtmlHostClientModules,
+  moduleId: string,
+): SolidHtmlHostClientModuleLoader | undefined {
+  return isReadonlyMap(modules) ? modules.get(moduleId) : modules[moduleId];
+}
+
+function isReadonlyMap(
+  value: SolidHtmlHostClientModules,
+): value is ReadonlyMap<string, SolidHtmlHostClientModuleLoader> {
+  return typeof (value as ReadonlyMap<string, SolidHtmlHostClientModuleLoader>).get === "function";
+}
+
+function exportedValue(moduleExports: unknown, exportName: string): unknown {
+  if (exportName === "default" && typeof moduleExports === "function") {
+    return moduleExports;
+  }
+  if (!moduleExports || typeof moduleExports !== "object") {
+    return undefined;
+  }
+  return (moduleExports as Record<string, unknown>)[exportName];
+}
+
+function reportError(
+  input: Pick<CreateSolidHtmlHostLazyHydrateInput, "onError">,
+  error: SolidHtmlHostClientError,
+): void {
+  error.element.classList?.add("ox-island-error");
+  error.element.dataset.oxError = error.message;
+  input.onError?.(error);
+
+  if (typeof CustomEvent === "function" && typeof error.element.dispatchEvent === "function") {
+    error.element.dispatchEvent(
+      new CustomEvent("ox-content-solid-html-host:error", { detail: error }),
+    );
+  }
+}
+
+function clientError(
+  code: SolidHtmlHostClientDiagnosticCode,
+  element: HTMLElement,
+  props: Record<string, unknown>,
+  context: {
+    componentName?: string;
+    moduleId?: string;
+    exportName?: string;
+    cause?: unknown;
+  } = {},
+): SolidHtmlHostClientError {
+  return {
+    code,
+    element,
+    props,
+    ...context,
+    message: clientErrorMessage(code, context),
+  };
+}
+
+function clientErrorMessage(
+  code: SolidHtmlHostClientDiagnosticCode,
+  context: { componentName?: string; moduleId?: string; exportName?: string; cause?: unknown },
+): string {
+  const component = context.componentName
+    ? `Solid island "${context.componentName}"`
+    : "Solid island";
+  const reason = causeMessage(context.cause);
+  switch (code) {
+    case "missing-island-name":
+      return "Solid island element is missing data-ox-island.";
+    case "missing-module-id":
+      return `${component} is missing data-ox-module.`;
+    case "unknown-module":
+      return `${component} references unknown module "${context.moduleId ?? ""}".`;
+    case "module-load-failed":
+      return `${component} module "${context.moduleId ?? ""}" failed to load: ${reason}`;
+    case "runtime-load-failed":
+      return `Solid runtime failed to load: ${reason}`;
+    case "missing-export":
+      return `${component} module "${context.moduleId ?? ""}" is missing export "${context.exportName ?? "default"}".`;
+    case "render-failed":
+      return `${component} failed to render: ${reason}`;
+  }
+}
+
+function causeMessage(cause: unknown): string {
+  if (cause == null) return "";
+  if (cause instanceof Error) return cause.message;
+  if (typeof cause === "string") return cause;
+  if (typeof cause === "number" || typeof cause === "boolean") return cause.toString();
+  try {
+    return JSON.stringify(cause);
+  } catch {
+    return Object.prototype.toString.call(cause);
+  }
+}
+
+function once(cleanup: () => void): () => void {
+  let called = false;
+  return () => {
+    if (called) return;
+    called = true;
+    cleanup();
+  };
+}
+
+function noop(): void {}

--- a/npm/vite-plugin-ox-content-solid/src/html-host.test.ts
+++ b/npm/vite-plugin-ox-content-solid/src/html-host.test.ts
@@ -48,10 +48,12 @@ describe("renderSolidHtmlHost", () => {
       },
     ]);
     expect(result.clientModules).toEqual([
-      { name: "Chart", moduleId: "/assets/Chart.js" },
-      { name: "Badge", moduleId: "/assets/Badge.js" },
+      { name: "Chart", moduleId: "/assets/Chart.js", exportName: "default" },
+      { name: "Badge", moduleId: "/assets/Badge.js", exportName: "default" },
     ]);
     expect(result.html).toContain('data-ox-ssr="true"');
+    expect(result.html).toContain('data-ox-module="/assets/Chart.js"');
+    expect(result.html).toContain('data-ox-export="default"');
     expect(result.html).toContain("data-ox-content='&lt;p&gt;slot&lt;/p&gt;'");
     expect(result.html).toContain(
       '<strong data-component="Chart">chart-component:Revenue:<p>slot</p></strong>',
@@ -80,12 +82,20 @@ describe("renderSolidHtmlHost", () => {
           specifiers: [{ imported: "Chart", local: "Plot", kind: "named" }],
         },
       ],
+      resolveClientModule: () => "./Chart.tsx",
       loadModule: async () => ({ Chart: "named-chart" }),
       renderComponent: (component) => `<strong>${component as string}</strong>`,
     });
 
     expect(result.diagnostics).toEqual([]);
     expect(result.modules[0]).toMatchObject({ name: "Plot", exportName: "Chart" });
+    expect(result.clientModules[0]).toEqual({
+      name: "Plot",
+      moduleId: "./Chart.tsx",
+      exportName: "Chart",
+    });
+    expect(result.html).toContain('data-ox-module="./Chart.tsx"');
+    expect(result.html).toContain('data-ox-export="Chart"');
     expect(result.html).toContain("<strong>named-chart</strong>");
   });
 

--- a/npm/vite-plugin-ox-content-solid/src/html-host.ts
+++ b/npm/vite-plugin-ox-content-solid/src/html-host.ts
@@ -22,6 +22,7 @@ export interface SolidHtmlHostModule {
 export interface SolidHtmlHostClientModule {
   name: string;
   moduleId: string;
+  exportName: string;
 }
 
 export type SolidHtmlHostDiagnosticCode =
@@ -134,10 +135,12 @@ export async function renderSolidHtmlHost(
   );
 
   return {
-    html,
+    html: markClientModules(html, modules),
     modules,
     clientModules: modules.flatMap((module) =>
-      module.clientModuleId ? [{ name: module.name, moduleId: module.clientModuleId }] : [],
+      module.clientModuleId
+        ? [{ name: module.name, moduleId: module.clientModuleId, exportName: module.exportName }]
+        : [],
     ),
     diagnostics,
   };
@@ -277,7 +280,54 @@ function isReadonlyMap(
 
 function readIslandSlotHtml(element: Pick<HTMLElement, "dataset" | "innerHTML">): string {
   const fromAttr = element.dataset.oxContent;
-  return fromAttr || element.innerHTML.replace(ISLAND_JSON_SCRIPT, "");
+  if (fromAttr) return fromAttr;
+  if (element.dataset.oxSsr === "true") return "";
+  return element.innerHTML.replace(ISLAND_JSON_SCRIPT, "");
+}
+
+function markClientModules(html: string, modules: readonly SolidHtmlHostModule[]): string {
+  const clientModules = new Map(
+    modules.filter((module) => module.clientModuleId).map((module) => [module.name, module]),
+  );
+  if (clientModules.size === 0) return html;
+
+  return html.replace(
+    /<(div|span)\b([^>]*\bdata-ox-island="([^"]+)"[^>]*)>/gi,
+    (openTag: string, _tag: string, _attrs: string, encodedName: string) => {
+      const module = clientModules.get(decodeHtmlAttr(encodedName));
+      if (!module?.clientModuleId) return openTag;
+
+      const attrs: string[] = [];
+      if (!hasAttr(openTag, "data-ox-module")) {
+        attrs.push(`data-ox-module="${escapeDoubleQuotedAttr(module.clientModuleId)}"`);
+      }
+      if (!hasAttr(openTag, "data-ox-export")) {
+        attrs.push(`data-ox-export="${escapeDoubleQuotedAttr(module.exportName)}"`);
+      }
+      return attrs.length === 0 ? openTag : openTag.replace(/>$/, ` ${attrs.join(" ")}>`);
+    },
+  );
+}
+
+function escapeDoubleQuotedAttr(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function decodeHtmlAttr(value: string): string {
+  return value
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
+}
+
+function hasAttr(openTag: string, name: string): boolean {
+  return new RegExp(`\\s${name}(?:\\s*=|\\s|>|$)`, "i").test(openTag);
 }
 
 async function defaultRenderComponent(

--- a/npm/vite-plugin-ox-content-solid/src/index.test.ts
+++ b/npm/vite-plugin-ox-content-solid/src/index.test.ts
@@ -26,6 +26,8 @@ describe("oxContentSolid", () => {
 
   it("keeps custom-host helpers on the package entrypoint", () => {
     expect(solidApi).toHaveProperty("createSolidHtmlHostHydrate");
+    expect(solidApi).toHaveProperty("createSolidHtmlHostLazyHydrate");
+    expect(solidApi).toHaveProperty("initSolidHtmlHost");
     expect(solidApi).toHaveProperty("renderSolidHtmlHost");
     expect(solidApi).toHaveProperty("resolveSolidIslandStylesheets");
   });

--- a/npm/vite-plugin-ox-content-solid/src/index.ts
+++ b/npm/vite-plugin-ox-content-solid/src/index.ts
@@ -56,6 +56,25 @@ export {
   type SolidServerModuleLoader,
 } from "./html-host";
 export {
+  createSolidHtmlHostLazyHydrate,
+  initSolidHtmlHost,
+  readSolidHtmlHostSlot,
+  type CreateSolidHtmlHostLazyHydrateInput,
+  type InitSolidHtmlHostInput,
+  type SolidHtmlHostClientComponentValue,
+  type SolidHtmlHostClientContext,
+  type SolidHtmlHostClientDiagnosticCode,
+  type SolidHtmlHostClientError,
+  type SolidHtmlHostClientModuleLoader,
+  type SolidHtmlHostClientModules,
+  type SolidHtmlHostClientModuleValue,
+  type SolidHtmlHostClientRenderer,
+  type SolidHtmlHostClientRuntimeLoader,
+  type SolidHtmlHostExportNameResolver,
+  type SolidHtmlHostInitIslands,
+  type SolidHtmlHostModuleIdResolver,
+} from "./html-host-client";
+export {
   resolveSolidIslandStylesheets,
   type ResolveSolidIslandStylesheetsInput,
   type ResolveSolidIslandStylesheetsResult,

--- a/npm/vite-plugin-ox-content-solid/vite.config.ts
+++ b/npm/vite-plugin-ox-content-solid/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     ignorePatterns: ["dist/**"],
   },
   pack: definePackConfig({
-    entry: ["src/index.ts"],
+    entry: ["src/index.ts", "src/html-host-client.ts"],
     format: ["esm", "cjs"],
     dts: true,
     clean: true,


### PR DESCRIPTION
## Summary
- add a browser-only `@ox-content/vite-plugin-solid/html-host/client` subpath for lazy Solid HTML host islands
- write canonical `data-ox-module` / `data-ox-export` markers from SSR output for document-scoped loaders
- keep pending lazy loads cancellable, report client failures, and preserve authored slots without treating self-closing SSR output as children
- document the custom-host contract and credit the reporter

Fixes #1280

## Verification
- `vp test --exclude '.claude/**' npm/vite-plugin-ox-content-solid/src/html-host-client.test.ts npm/vite-plugin-ox-content-solid/src/html-host.test.ts npm/vite-plugin-ox-content-solid/src/index.test.ts`
- `vp run check:ts`
- `vp run --filter @ox-content/vite-plugin-solid build`
- Solid package dry pack includes `html-host/client` artifacts
- `node tools/scripts/check-file-lines.ts --base origin/main`
- `vp run workspace:fmt:check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a browser client for Solid HTML hosts with initialization, lazy hydration, slot handling, module loading, and rendering.
  - Added cancellable lazy loading, reliable island cleanup, and structured error reporting for loading, rendering, and missing exports.
  - Added support for document-scoped module identities and export metadata to reliably hydrate reused components.
  - Added a dedicated browser client package entry point with TypeScript support.

- **Documentation**
  - Updated English and Japanese guidance for custom Solid HTML hosts, lazy hydration, module resolution, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->