### PR TITLE
feat(custom-host): generate selected Solid island registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,21 +1356,21 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "ox_content_allocator"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "bumpalo",
 ]
 
 [[package]]
 name = "ox_content_ast"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "ox_content_allocator",
 ]
 
 [[package]]
 name = "ox_content_component_resolver"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "corsa_client",
  "insta",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_docs"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "criterion",
  "insta",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_highlight"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "tree-sitter",
  "tree-sitter-bash",
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_i18n"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "insta",
  "miette",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_i18n_checker"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "insta",
  "miette",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_i18n_cli"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "clap",
  "miette",
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_i18n_lsp"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "ox_content_i18n",
  "ox_content_i18n_checker",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_incremental"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "compact_str 0.10.0",
  "criterion",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_link_checker"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "clap",
  "insta",
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_lsp"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "compact_str 0.10.0",
  "insta",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_markdown_lint"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "compact_str 0.10.0",
  "ox_content_allocator",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_mdast"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "ox_content_allocator",
  "ox_content_ast",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_mdc_checker"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "clap",
  "insta",
@@ -1600,11 +1600,11 @@ dependencies = [
 
 [[package]]
 name = "ox_content_mermaid"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 
 [[package]]
 name = "ox_content_napi"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "criterion",
  "insta",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_og_image"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "insta",
  "serde",
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_parser"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "compact_str 0.10.0",
  "criterion",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_profile_cli"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "clap",
  "ox_content_allocator",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_profiler"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "insta",
  "serde",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_renderer"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "compact_str 0.10.0",
  "criterion",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_search"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "compact_str 0.10.0",
  "insta",
@@ -1719,7 +1719,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_ssg"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "askama",
  "insta",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_theme_generator"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "regex",
  "serde",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_transform"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "compact_str 0.10.0",
  "insta",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_vite"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "insta",
  "ox_content_allocator",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_wasm"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.12"
 dependencies = [
  "js-sys",
  "ox_content_allocator",

--- a/docs/content/built-in/custom-host.md
+++ b/docs/content/built-in/custom-host.md
@@ -111,6 +111,14 @@ Duplicate route output paths fail the build with the conflicting owners. The
 host still owns publication selection; Ox Content only writes the routes the
 host returns.
 
+Solid HTML-string hosts can generate their browser island registry from that
+same selected route/document set. Use `createSolidHtmlHostIslandRegistry()` from
+`@ox-content/vite-plugin-solid` and import
+`virtual:ox-content-solid/html-host/modules` in the client entry instead of a
+whole-directory `import.meta.glob()`. The generated module contains only the
+selected island dynamic-import roots; Vite still keeps their transitive
+dependencies.
+
 ## Theme token stylesheet
 
 `themeTokens` writes and serves a small stylesheet, defaulting to

--- a/docs/content/packages/vite-plugin-ox-content-solid.md
+++ b/docs/content/packages/vite-plugin-ox-content-solid.md
@@ -224,12 +224,80 @@ slot HTML, clears the target, and lets the caller mount with `@solidjs/web`.
 When SSR produced HTML for a self-closing island, that rendered output is not
 passed back as children.
 
+For production custom hosts, generate the module map from the same
+site-selected document set instead of a broad source-directory glob. Keep the
+publication rule in your site code and share that selected list with both the
+custom host routes and the registry plugin.
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import solid from "@solidjs/vite-plugin";
+import { oxContentCustomHost } from "@ox-content/vite-plugin";
+import { createSolidHtmlHostIslandRegistry } from "@ox-content/vite-plugin-solid";
+import { selectedDocuments } from "./src/site-content";
+
+const solidIslands = createSolidHtmlHostIslandRegistry({
+  documents: async () =>
+    (await selectedDocuments()).map((document) => ({
+      documentPath: document.file,
+      source: document.source,
+    })),
+});
+
+export default defineConfig({
+  appType: "custom",
+  plugins: [
+    solidIslands.plugin,
+    oxContentCustomHost({ host: "./src/site-host.ts" }),
+    solid({ compiler: "native" }),
+  ],
+});
+```
+
+```ts
+// src/site-host.ts
+import { renderMarkdown, type MdxImport } from "@ox-content/vite-plugin";
+import { renderSolidHtmlHost, toSolidHtmlHostClientModuleId } from "@ox-content/vite-plugin-solid";
+import { selectedDocuments } from "./site-content";
+
+export default {
+  async routes() {
+    return (await selectedDocuments()).map((document) => ({
+      path: document.url,
+      inputPath: document.file,
+      source: document.source,
+      async render(ctx) {
+        const markdown = await renderMarkdown(document.source, document.file, {
+          srcDir: "content",
+        });
+        const rendered = await renderSolidHtmlHost({
+          html: markdown.html,
+          imports: markdown.imports as MdxImport[],
+          documentPath: document.file,
+          root: ctx.root,
+          srcDir: "content",
+          loadModule: ctx.loadModule,
+          resolveClientModule: (module) =>
+            toSolidHtmlHostClientModuleId(module.serverModuleId, ctx.root),
+        });
+        return { html: rendered.html, source: document.source };
+      },
+    }));
+  },
+};
+```
+
+The browser imports the generated virtual module. Its static dynamic-import
+roots are the selected island modules only, so Vite does not create entry chunks
+for unpublished documents that were omitted by your site policy. Dependencies
+reachable from those selected modules are still bundled normally.
+
 ```tsx
 import { initIslands } from "@ox-content/islands";
 import { render } from "@solidjs/web";
 import { initSolidHtmlHost } from "@ox-content/vite-plugin-solid/html-host/client";
-
-const modules = import.meta.glob("./{docs,components}/**/*.tsx");
+import modules from "virtual:ox-content-solid/html-host/modules";
 
 initSolidHtmlHost({
   initIslands,
@@ -273,7 +341,7 @@ URLs from either a Vite build manifest or a development module graph.
 import { resolveSolidIslandStylesheets } from "@ox-content/vite-plugin-solid";
 
 const styles = resolveSolidIslandStylesheets({
-  modules: rendered.modules.map((module) => module.serverModuleId),
+  modules: rendered.clientModules.map((module) => module.moduleId),
   manifest: viteManifest,
   base: "/docs/",
 });
@@ -287,10 +355,12 @@ Build resolution walks static `imports`, deduplicates CSS, keeps imported chunk
 CSS before the importing island, and respects `base` plus emitted hashed file
 names. Development resolution accepts a Vite-like module graph with
 `getModuleById()` and optional `getModulesByFile()`, preserving CSS query
-parameters so HMR URLs remain loadable. A valid island with no CSS returns no
-stylesheet and no diagnostic; missing manifest/module-graph entries report a
-`missing-module` diagnostic. If neither resolver is supplied, each requested
-module reports `missing-resolver`.
+parameters so HMR URLs remain loadable. The resolver accepts the registry's
+root-relative module ids, even when Vite's manifest stores the same source
+without a leading slash. A valid island with no CSS returns no stylesheet and no
+diagnostic; missing manifest/module-graph entries report a `missing-module`
+diagnostic. If neither resolver is supplied, each requested module reports
+`missing-resolver`.
 
 ## HMR
 

--- a/npm/vite-plugin-ox-content-solid/package.json
+++ b/npm/vite-plugin-ox-content-solid/package.json
@@ -45,7 +45,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "vp pack && node ../../tools/scripts/stabilize-public-declaration-exports.mjs @ox-content/vite-plugin-solid",
+    "build": "vp pack && node ../../tools/scripts/stabilize-public-declaration-exports.mjs @ox-content/vite-plugin-solid && node ../../tools/scripts/write-solid-virtual-declarations.mjs",
     "dev": "vp pack --watch",
     "typecheck": "tsgo --noEmit"
   },

--- a/npm/vite-plugin-ox-content-solid/src/html-host-registry-paths.ts
+++ b/npm/vite-plugin-ox-content-solid/src/html-host-registry-paths.ts
@@ -1,0 +1,82 @@
+import fsSync from "node:fs";
+import path from "node:path";
+import { stripViteQuery } from "@ox-content/vite-plugin";
+
+export function toSolidHtmlHostClientModuleId(moduleId: string, root = process.cwd()): string {
+  const [pathname, suffix = ""] = splitModuleSuffix(moduleId);
+  if (isBareSpecifier(pathname) || pathname.startsWith("/@fs/")) {
+    return `${pathname}${suffix}`;
+  }
+
+  const rootPath = path.resolve(root);
+  const realRoot = existingRealpath(rootPath) ?? rootPath;
+  const absolute = path.isAbsolute(pathname)
+    ? path.resolve(pathname)
+    : path.resolve(rootPath, pathname);
+  const realAbsolute = existingRealpath(absolute);
+  const isInsideRealRoot = realAbsolute ? isInsideRoot(realAbsolute, realRoot) : false;
+  const isInsideLexicalRoot = isInsideRoot(absolute, rootPath);
+
+  if (path.isAbsolute(pathname) && !isInsideRealRoot && !isInsideLexicalRoot) {
+    return fsSync.existsSync(pathname)
+      ? `/@fs${toPosixPath(pathname)}${suffix}`
+      : `${toPosixPath(pathname)}${suffix}`;
+  }
+
+  const relativeRoot = isInsideRealRoot ? realRoot : rootPath;
+  const relativePath = isInsideRealRoot && realAbsolute ? realAbsolute : absolute;
+  const relative = path.relative(relativeRoot, relativePath).replace(/\\/g, "/");
+  return `/${relative}${suffix}`;
+}
+
+export function resolveDocumentPath(documentPath: string, root: string): string {
+  return path.isAbsolute(documentPath)
+    ? stripViteQuery(documentPath)
+    : path.resolve(root, stripViteQuery(documentPath));
+}
+
+export function resolveWatchFile(file: string, root: string): string {
+  return path.isAbsolute(file) ? stripViteQuery(file) : path.resolve(root, stripViteQuery(file));
+}
+
+export function shouldInvalidate(
+  file: string,
+  root: string,
+  srcDir: string | undefined,
+  watchFiles: readonly string[],
+  extraWatchFiles: readonly string[] | undefined,
+): boolean {
+  const changed = path.resolve(file);
+  if (watchFiles.some((watchFile) => changed === watchFile)) return true;
+  if (extraWatchFiles?.some((watchFile) => changed === resolveWatchFile(watchFile, root))) {
+    return true;
+  }
+  const contentRoot = path.resolve(root, srcDir ?? "content");
+  return isInsideRoot(changed, contentRoot);
+}
+
+function splitModuleSuffix(moduleId: string): [string, string?] {
+  const match = /[?#]/u.exec(moduleId);
+  return match ? [moduleId.slice(0, match.index), moduleId.slice(match.index)] : [moduleId];
+}
+
+export function isBareSpecifier(moduleId: string): boolean {
+  return !moduleId.startsWith(".") && !moduleId.startsWith("/") && !moduleId.includes("\\");
+}
+
+function isInsideRoot(file: string, root: string): boolean {
+  const relative = path.relative(path.resolve(root), path.resolve(file));
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function existingRealpath(file: string): string | undefined {
+  try {
+    return fsSync.realpathSync.native(file);
+  } catch {
+    return undefined;
+  }
+}
+
+function toPosixPath(file: string): string {
+  return file.replace(/\\/g, "/");
+}

--- a/npm/vite-plugin-ox-content-solid/src/html-host-registry.test.ts
+++ b/npm/vite-plugin-ox-content-solid/src/html-host-registry.test.ts
@@ -1,0 +1,264 @@
+import fs from "node:fs/promises";
+import * as os from "node:os";
+import path from "node:path";
+import solid from "@solidjs/vite-plugin";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { build as viteBuild, type Plugin, type ViteDevServer } from "vite";
+import {
+  SOLID_HTML_HOST_MODULES_VIRTUAL_ID,
+  createSolidHtmlHostIslandRegistry,
+  renderSolidHtmlHost,
+  resolveSolidHtmlHostIslandRegistry,
+  resolveSolidIslandStylesheets,
+  toSolidHtmlHostClientModuleId,
+  type MdxImport,
+} from ".";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("createSolidHtmlHostIslandRegistry", () => {
+  it("shares custom-host SSR marker identities with the generated client registry", async () => {
+    const root = await createProject("ox-solid-html-registry-");
+    const documentPath = path.join(root, "content", "published.mdx");
+    const imports = [defaultImport("Probe", "./published/Probe.tsx")];
+    const html = '<div data-ox-island="Probe"></div>';
+    const registry = createSolidHtmlHostIslandRegistry({
+      root,
+      documents: [{ documentPath, html, imports }],
+    });
+
+    const rendered = await renderSolidHtmlHost({
+      html,
+      documentPath,
+      root,
+      srcDir: "content",
+      imports,
+      resolveClientModule: (module) => registry.resolveClientModule(module),
+      loadModule: async () => ({ default: "probe" }),
+      renderComponent: (component) => `<strong>${component as string}</strong>`,
+    });
+    const resolved = await registry.resolve();
+
+    expect(rendered.clientModules).toEqual([
+      { name: "Probe", moduleId: "/content/published/Probe.tsx", exportName: "default" },
+    ]);
+    expect(rendered.html).toContain('data-ox-module="/content/published/Probe.tsx"');
+    expect(resolved.modules).toEqual(rendered.clientModules);
+  });
+
+  it("resolves selected documents and explicit approved entries without broad globs", async () => {
+    const root = await createProject("ox-solid-html-selection-");
+    const result = await resolveSolidHtmlHostIslandRegistry(
+      {
+        components: { Shared: "./src/Shared.tsx" },
+        entries: [{ name: "Approved", moduleId: "./src/Approved.tsx" }],
+        documents: [
+          {
+            documentPath: path.join(root, "content", "published.mdx"),
+            html: '<div data-ox-island="Probe"></div><div data-ox-island="Shared"></div>',
+            imports: [defaultImport("Probe", "./published/Probe.tsx")],
+          },
+        ],
+      },
+      { root, mode: "production", command: "build" },
+    );
+
+    expect(result.modules).toEqual([
+      { name: "Probe", moduleId: "/content/published/Probe.tsx", exportName: "default" },
+      { name: "Approved", moduleId: "/src/Approved.tsx", exportName: "default" },
+      { name: "Shared", moduleId: "/src/Shared.tsx", exportName: "default" },
+    ]);
+    expect(result.modules).not.toContainEqual(
+      expect.objectContaining({ moduleId: expect.stringContaining("draft") }),
+    );
+  });
+
+  it("builds a browser registry that includes reachable selected chunks only", async () => {
+    const root = await createProject("ox-solid-html-build-");
+    const registry = createSolidHtmlHostIslandRegistry({
+      root,
+      documents: [
+        {
+          documentPath: path.join(root, "content", "published.mdx"),
+          html: '<div data-ox-island="Probe"></div><div data-ox-island="SharedProbe"></div>',
+          imports: [
+            defaultImport("Probe", "./published/Probe.ts"),
+            namedImport("SharedProbe", "SharedProbe", "./published/Probe.ts"),
+          ],
+        },
+        {
+          documentPath: path.join(root, "content", "second.mdx"),
+          html: '<div data-ox-island="SharedProbe"></div>',
+          imports: [namedImport("SharedProbe", "SharedProbe", "./published/Probe.ts")],
+        },
+      ],
+      watch: ["content/publication.json"],
+    });
+
+    await fs.writeFile(
+      path.join(root, "src", "client.tsx"),
+      [
+        `import { clientModules, modules } from "${SOLID_HTML_HOST_MODULES_VIRTUAL_ID}";`,
+        "globalThis.__oxModules = modules;",
+        "globalThis.__oxClientModules = clientModules;",
+      ].join("\n"),
+    );
+
+    await viteBuild({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [registry.plugin, solid({ compiler: "native" })],
+      build: {
+        outDir: "dist",
+        emptyOutDir: true,
+        manifest: true,
+        minify: false,
+        rollupOptions: { input: path.join(root, "src", "client.tsx") },
+      },
+    });
+
+    const output = await readDist(root);
+    expect(output).toContain("PUBLIC_SENTINEL");
+    expect(output).toContain("SHARED_HELPER_SENTINEL");
+    expect(output).not.toContain("DRAFT_ONLY_SENTINEL");
+    expect(output).not.toContain("MISSING_POLICY_SENTINEL");
+    expect(output).not.toContain("@ox-content/vite-plugin");
+    expect(output).not.toContain("node:");
+
+    const manifest = JSON.parse(
+      await fs.readFile(path.join(root, "dist", ".vite", "manifest.json"), "utf8"),
+    );
+    const resolved = await registry.resolve();
+    const styles = resolveSolidIslandStylesheets({
+      modules: resolved.modules.map((module) => module.moduleId),
+      manifest,
+    });
+    expect(styles.diagnostics).toEqual([]);
+    expect(styles.stylesheets.map((style) => style.href).join("\n")).toContain("Probe");
+  });
+
+  it("invalidates the virtual registry when selected content changes in dev", async () => {
+    const root = await createProject("ox-solid-html-dev-");
+    let document = {
+      html: '<div data-ox-island="Probe"></div>',
+      imports: [defaultImport("Probe", "./published/Probe.tsx")],
+    };
+    const registry = createSolidHtmlHostIslandRegistry({
+      root,
+      documents: () => [
+        {
+          documentPath: path.join(root, "content", "published.mdx"),
+          ...document,
+        },
+      ],
+    });
+    const plugin = registry.plugin as Plugin;
+    await (plugin.configResolved as (config: unknown) => void | Promise<void>)({
+      root,
+      mode: "development",
+    });
+
+    const id = `\0${SOLID_HTML_HOST_MODULES_VIRTUAL_ID}`;
+    const first = await loadVirtual(plugin, id);
+    document = {
+      html: '<div data-ox-island="DraftProbe"></div>',
+      imports: [defaultImport("DraftProbe", "./draft.tsx")],
+    };
+    const invalidated: unknown[] = [];
+    const messages: unknown[] = [];
+    const handleHotUpdate = plugin.handleHotUpdate as (ctx: unknown) => Promise<unknown[]>;
+    const updated = await handleHotUpdate({
+      file: path.join(root, "content", "published.mdx"),
+      modules: [],
+      server: {
+        moduleGraph: {
+          getModuleById: () => ({}),
+          invalidateModule: (mod: unknown) => invalidated.push(mod),
+        },
+        ws: { send: (message: unknown) => messages.push(message) },
+      } as unknown as ViteDevServer,
+    } as never);
+    const second = await loadVirtual(plugin, id);
+
+    expect(first).toContain("/content/published/Probe.tsx");
+    expect(second).toContain("/content/draft.tsx");
+    expect(second).not.toContain("/content/published/Probe.tsx");
+    expect(updated).toEqual([]);
+    expect(invalidated).toHaveLength(1);
+    expect(messages).toEqual([{ type: "full-reload" }]);
+  });
+
+  it("normalizes filesystem and Vite module ids for browser loaders", () => {
+    expect(toSolidHtmlHostClientModuleId("/repo/src/Chart.tsx", "/repo")).toBe("/src/Chart.tsx");
+    expect(toSolidHtmlHostClientModuleId("./src/Chart.tsx", "/repo")).toBe("/src/Chart.tsx");
+    expect(toSolidHtmlHostClientModuleId("solid-js")).toBe("solid-js");
+  });
+});
+
+async function createProject(prefix: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(root);
+  await fs.mkdir(path.join(root, "content", "published"), { recursive: true });
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.writeFile(path.join(root, "package.json"), '{"type":"module"}\n');
+  await fs.writeFile(path.join(root, "content", "published.mdx"), "# Published\n<Probe />\n");
+  await fs.writeFile(path.join(root, "content", "draft.mdx"), "# Draft\n<DraftProbe />\n");
+  await fs.writeFile(path.join(root, "content", "missing.mdx"), "# Missing\n<MissingProbe />\n");
+  const probeModule = [
+    'import "./Probe.css";',
+    'import { helper } from "./helper";',
+    'export function SharedProbe() { console.log("PUBLIC_SENTINEL", helper); return "shared"; }',
+    'export default function Probe() { console.log("PUBLIC_SENTINEL", helper); return "probe"; }',
+  ].join("\n");
+  await fs.writeFile(path.join(root, "content", "published", "Probe.ts"), probeModule);
+  await fs.writeFile(path.join(root, "content", "published", "Probe.tsx"), probeModule);
+  await fs.writeFile(
+    path.join(root, "content", "published", "helper.ts"),
+    'export const helper = "SHARED_HELPER_SENTINEL";\n',
+  );
+  await fs.writeFile(path.join(root, "content", "published", "Probe.css"), ".Probe{color:red}\n");
+  await fs.writeFile(
+    path.join(root, "content", "draft.tsx"),
+    'export default function DraftProbe() { console.log("DRAFT_ONLY_SENTINEL"); return <i />; }\n',
+  );
+  await fs.writeFile(
+    path.join(root, "content", "missing.tsx"),
+    'export default function MissingProbe() { console.log("MISSING_POLICY_SENTINEL"); return <i />; }\n',
+  );
+  return root;
+}
+
+function defaultImport(local: string, source: string): MdxImport {
+  return { source, specifiers: [{ imported: "default", local, kind: "default" }] };
+}
+
+function namedImport(local: string, imported: string, source: string): MdxImport {
+  return { source, specifiers: [{ imported, local, kind: "named" }] };
+}
+
+async function loadVirtual(plugin: Plugin, id: string): Promise<string> {
+  const loaded = await (plugin.load as (id: string) => Promise<string>)(id);
+  return String(loaded);
+}
+
+async function readDist(root: string): Promise<string> {
+  const chunks: string[] = [];
+  await collectFiles(path.join(root, "dist"), chunks);
+  return chunks.join("\n");
+}
+
+async function collectFiles(dir: string, chunks: string[]): Promise<void> {
+  for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
+    const file = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await collectFiles(file, chunks);
+    } else if (entry.isFile()) {
+      chunks.push(await fs.readFile(file, "utf8"));
+    }
+  }
+}

--- a/npm/vite-plugin-ox-content-solid/src/html-host-registry.ts
+++ b/npm/vite-plugin-ox-content-solid/src/html-host-registry.ts
@@ -1,0 +1,331 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { ModuleNode, Plugin, ResolvedConfig, ViteDevServer } from "vite";
+import {
+  collectMdxIslandNamesFromHtml,
+  customHostOxContentOptions,
+  discoverDocumentMdxIslands,
+  intersectHydratableComponentNames,
+  renderMarkdown,
+  resolveContentRootPath,
+  stripViteQuery,
+  type MdxImport,
+  type OxContentOptions,
+} from "@ox-content/vite-plugin";
+import { resolveComponentsGlob } from "./components";
+import type { SolidHtmlHostClientModule, SolidHtmlHostModule } from "./html-host";
+import {
+  isBareSpecifier,
+  resolveDocumentPath,
+  resolveWatchFile,
+  shouldInvalidate,
+  toSolidHtmlHostClientModuleId,
+} from "./html-host-registry-paths";
+import type { ComponentsMap, ComponentsOption } from "./types";
+
+export { toSolidHtmlHostClientModuleId } from "./html-host-registry-paths";
+
+export const SOLID_HTML_HOST_MODULES_VIRTUAL_ID = "virtual:ox-content-solid/html-host/modules";
+
+type MaybePromise<T> = T | Promise<T>;
+
+export interface SolidHtmlHostIslandDocument {
+  documentPath: string;
+  source?: string;
+  html?: string;
+  imports?: readonly MdxImport[];
+  components?: ComponentsMap;
+  dependencies?: readonly string[];
+}
+
+export interface SolidHtmlHostIslandEntry {
+  moduleId: string;
+  name?: string;
+  exportName?: string;
+  documentPath?: string;
+}
+
+export interface SolidHtmlHostIslandRegistryContext {
+  root: string;
+  mode: string;
+  command: "build" | "serve";
+}
+
+export interface CreateSolidHtmlHostIslandRegistryInput {
+  documents?:
+    | readonly SolidHtmlHostIslandDocument[]
+    | ((
+        context: SolidHtmlHostIslandRegistryContext,
+      ) => MaybePromise<readonly SolidHtmlHostIslandDocument[]>);
+  entries?:
+    | readonly SolidHtmlHostIslandEntry[]
+    | ((
+        context: SolidHtmlHostIslandRegistryContext,
+      ) => MaybePromise<readonly SolidHtmlHostIslandEntry[]>);
+  components?: ComponentsOption;
+  oxContent?: OxContentOptions;
+  root?: string;
+  watch?: readonly string[];
+  virtualModuleId?: string;
+}
+
+export interface ResolvedSolidHtmlHostIslandRegistry {
+  modules: SolidHtmlHostClientModule[];
+  watchFiles: string[];
+}
+
+export interface SolidHtmlHostIslandRegistry {
+  plugin: Plugin;
+  virtualModuleId: string;
+  resolve(): Promise<ResolvedSolidHtmlHostIslandRegistry>;
+  resolveClientModule(module: Pick<SolidHtmlHostModule, "serverModuleId">): string;
+}
+
+export function createSolidHtmlHostIslandRegistry(
+  input: CreateSolidHtmlHostIslandRegistryInput = {},
+): SolidHtmlHostIslandRegistry {
+  const virtualModuleId = input.virtualModuleId ?? SOLID_HTML_HOST_MODULES_VIRTUAL_ID;
+  const resolvedVirtualModuleId = `\0${virtualModuleId}`;
+  let config: ResolvedConfig | undefined;
+  let command: "build" | "serve" = "build";
+  let components: ComponentsMap | undefined;
+  let cache: Promise<ResolvedSolidHtmlHostIslandRegistry> | undefined;
+  let resolved: ResolvedSolidHtmlHostIslandRegistry = { modules: [], watchFiles: [] };
+
+  const context = (): SolidHtmlHostIslandRegistryContext => ({
+    root: config?.root ?? input.root ?? process.cwd(),
+    mode: config?.mode ?? "production",
+    command,
+  });
+
+  const resolve = async () => {
+    cache ??= resolveSolidHtmlHostIslandRegistry(input, context(), components).then((next) => {
+      resolved = next;
+      return next;
+    });
+    return cache;
+  };
+
+  const invalidate = () => {
+    cache = undefined;
+  };
+
+  const plugin: Plugin = {
+    name: "ox-content:solid-html-host-island-registry",
+
+    config(_config, env) {
+      command = env.command;
+    },
+
+    async configResolved(resolvedConfig) {
+      config = resolvedConfig;
+      components = input.components
+        ? await resolveComponentsGlob(input.components, resolvedConfig.root)
+        : {};
+      invalidate();
+    },
+
+    buildStart() {
+      invalidate();
+    },
+
+    resolveId(id) {
+      return id === virtualModuleId ? resolvedVirtualModuleId : null;
+    },
+
+    async load(id) {
+      if (id !== resolvedVirtualModuleId) return null;
+      return renderModulesVirtualModule(await resolve());
+    },
+
+    handleHotUpdate(ctx) {
+      if (
+        !shouldInvalidate(
+          ctx.file,
+          context().root,
+          input.oxContent?.srcDir,
+          resolved.watchFiles,
+          input.watch,
+        )
+      ) {
+        return undefined;
+      }
+      invalidate();
+      invalidateVirtualModule(ctx.server, resolvedVirtualModuleId);
+      ctx.server.ws.send({ type: "full-reload" });
+      return [];
+    },
+  };
+
+  return {
+    plugin,
+    virtualModuleId,
+    resolve,
+    resolveClientModule(module) {
+      return toSolidHtmlHostClientModuleId(module.serverModuleId, context().root);
+    },
+  };
+}
+
+export async function resolveSolidHtmlHostIslandRegistry(
+  input: CreateSolidHtmlHostIslandRegistryInput,
+  context: SolidHtmlHostIslandRegistryContext,
+  resolvedComponents?: ComponentsMap,
+): Promise<ResolvedSolidHtmlHostIslandRegistry> {
+  const components =
+    resolvedComponents ??
+    (input.components ? await resolveComponentsGlob(input.components, context.root) : {});
+  const documents = await resolveMaybe(input.documents, context);
+  const entries = await resolveMaybe(input.entries, context);
+  const modules = new Map<string, SolidHtmlHostClientModule>();
+  const watchFiles = new Set<string>();
+
+  for (const file of input.watch ?? []) {
+    watchFiles.add(resolveWatchFile(file, context.root));
+  }
+
+  for (const entry of entries ?? []) {
+    addModule(modules, {
+      name:
+        entry.name ?? path.basename(stripViteQuery(entry.moduleId), path.extname(entry.moduleId)),
+      moduleId: toSolidHtmlHostClientModuleId(entry.moduleId, context.root),
+      exportName: entry.exportName ?? "default",
+    });
+    if (entry.documentPath) watchFiles.add(resolveWatchFile(entry.documentPath, context.root));
+  }
+
+  const oxContent = customHostOxContentOptions(input.oxContent ?? {});
+  const srcDir = oxContent.srcDir ?? "content";
+  const contentRoot = resolveContentRootPath({ root: context.root, srcDir });
+  for (const document of documents ?? []) {
+    const documentPath = resolveDocumentPath(document.documentPath, context.root);
+    watchFiles.add(documentPath);
+    for (const dependency of document.dependencies ?? []) {
+      watchFiles.add(resolveWatchFile(dependency, context.root));
+    }
+
+    const materialized = await materializeDocument(document, documentPath, oxContent);
+    if (!materialized) continue;
+
+    const documentComponents = document.components ?? components;
+    const discovered = await discoverDocumentMdxIslands({
+      source: materialized.source,
+      html: materialized.html,
+      components: documentComponents,
+      imports: materialized.imports,
+      documentPath,
+      contentRoot,
+      srcDir,
+      root: context.root,
+    });
+    const usedComponents = new Set(discovered.usedComponents);
+    if (materialized.html) {
+      for (const name of intersectHydratableComponentNames(
+        collectMdxIslandNamesFromHtml(materialized.html),
+        documentComponents,
+        discovered.localBindings.keys(),
+      )) {
+        usedComponents.add(name);
+      }
+    }
+
+    for (const name of usedComponents) {
+      const local = discovered.localBindings.get(name);
+      const serverModuleId = local
+        ? local.resolvedPath
+        : resolveComponentPath(documentComponents, name, context.root);
+      if (!serverModuleId) continue;
+      addModule(modules, {
+        name,
+        moduleId: toSolidHtmlHostClientModuleId(serverModuleId, context.root),
+        exportName: local?.imported ?? "default",
+      });
+    }
+  }
+
+  return {
+    modules: [...modules.values()].sort((a, b) =>
+      `${a.moduleId}\0${a.exportName}\0${a.name}`.localeCompare(
+        `${b.moduleId}\0${b.exportName}\0${b.name}`,
+      ),
+    ),
+    watchFiles: [...watchFiles],
+  };
+}
+
+function renderModulesVirtualModule(registry: ResolvedSolidHtmlHostIslandRegistry): string {
+  const moduleIds = [...new Set(registry.modules.map((module) => module.moduleId))].sort();
+  return [
+    "export const modules = {",
+    ...moduleIds.map(
+      (moduleId) => `  ${JSON.stringify(moduleId)}: () => import(${JSON.stringify(moduleId)}),`,
+    ),
+    "};",
+    `export const clientModules = ${JSON.stringify(registry.modules, null, 2)};`,
+    "export default modules;",
+    "",
+  ].join("\n");
+}
+
+async function materializeDocument(
+  document: SolidHtmlHostIslandDocument,
+  documentPath: string,
+  oxContent: OxContentOptions,
+): Promise<{ source: string; html?: string; imports: readonly MdxImport[] } | undefined> {
+  const source = document.source ?? (await readOptional(documentPath));
+  if (source === undefined && document.html === undefined) return undefined;
+  if (document.imports && document.html !== undefined) {
+    return { source: source ?? "", html: document.html, imports: document.imports };
+  }
+  if (source === undefined) {
+    return { source: "", html: document.html, imports: document.imports ?? [] };
+  }
+  const rendered = await renderMarkdown(source, documentPath, oxContent);
+  return {
+    source,
+    html: document.html ?? rendered.html,
+    imports: document.imports ?? rendered.imports,
+  };
+}
+
+async function readOptional(file: string): Promise<string | undefined> {
+  try {
+    return await fs.readFile(file, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function addModule(
+  modules: Map<string, SolidHtmlHostClientModule>,
+  module: SolidHtmlHostClientModule,
+) {
+  modules.set(`${module.moduleId}\0${module.exportName}\0${module.name}`, module);
+}
+
+function resolveMaybe<T>(
+  value:
+    | readonly T[]
+    | ((context: SolidHtmlHostIslandRegistryContext) => MaybePromise<readonly T[]>)
+    | undefined,
+  context: SolidHtmlHostIslandRegistryContext,
+): MaybePromise<readonly T[] | undefined> {
+  return typeof value === "function" ? value(context) : value;
+}
+
+function resolveComponentPath(
+  components: ComponentsMap,
+  name: string,
+  root: string,
+): string | undefined {
+  const specifier = components[name];
+  if (!specifier) return undefined;
+  if (isBareSpecifier(specifier) || specifier.startsWith("/@fs/")) return specifier;
+  if (specifier.startsWith("/") && !path.isAbsolute(specifier)) return specifier;
+  return path.isAbsolute(specifier) ? specifier : path.resolve(root, specifier);
+}
+
+function invalidateVirtualModule(server: ViteDevServer, resolvedVirtualModuleId: string): void {
+  const mod = server.moduleGraph.getModuleById(resolvedVirtualModuleId);
+  if (mod) server.moduleGraph.invalidateModule(mod as ModuleNode);
+}

--- a/npm/vite-plugin-ox-content-solid/src/index.ts
+++ b/npm/vite-plugin-ox-content-solid/src/index.ts
@@ -75,6 +75,18 @@ export {
   type SolidHtmlHostModuleIdResolver,
 } from "./html-host-client";
 export {
+  SOLID_HTML_HOST_MODULES_VIRTUAL_ID,
+  createSolidHtmlHostIslandRegistry,
+  resolveSolidHtmlHostIslandRegistry,
+  toSolidHtmlHostClientModuleId,
+  type CreateSolidHtmlHostIslandRegistryInput,
+  type ResolvedSolidHtmlHostIslandRegistry,
+  type SolidHtmlHostIslandDocument,
+  type SolidHtmlHostIslandEntry,
+  type SolidHtmlHostIslandRegistry,
+  type SolidHtmlHostIslandRegistryContext,
+} from "./html-host-registry";
+export {
   resolveSolidIslandStylesheets,
   type ResolveSolidIslandStylesheetsInput,
   type ResolveSolidIslandStylesheetsResult,
@@ -86,35 +98,7 @@ export {
   type SolidStylesheetManifestChunk,
 } from "./stylesheets";
 
-/**
- * Creates the Ox Content Solid integration plugin.
- *
- * Unlike the React and Svelte integrations, this plugin must be listed **before**
- * `@solidjs/vite-plugin`, and that plugin must be told about the Markdown
- * extensions. Markdown is turned into Solid JSX here, and Solid's JSX is
- * compile-time only — the Solid 2 Vite plugin is what turns it into DOM or SSR
- * instructions through its native compiler.
- *
- * @example
- * ```ts
- * // vite.config.ts
- * import { defineConfig } from 'vite';
- * import solid from '@solidjs/vite-plugin';
- * import { oxContentSolid } from '@ox-content/vite-plugin-solid';
- *
- * export default defineConfig({
- *   plugins: [
- *     oxContentSolid({
- *       srcDir: 'docs',
- *       components: {
- *         Counter: './src/components/Counter.tsx',
- *       },
- *     }),
- *     solid({ extensions: ['.md', '.markdown', '.mdx'], compiler: 'native' }),
- *   ],
- * });
- * ```
- */
+/** Creates the Ox Content Solid integration plugin. */
 export function oxContentSolid(options: SolidIntegrationOptions = {}): PluginOption[] {
   const resolved = resolveSolidOptions(options);
   let componentMap = new Map<string, string>();

--- a/npm/vite-plugin-ox-content-solid/src/stylesheets.ts
+++ b/npm/vite-plugin-ox-content-solid/src/stylesheets.ts
@@ -169,12 +169,33 @@ function visitDevModule(
 }
 
 function manifestKey(manifest: SolidStylesheetManifest, moduleId: string): string | undefined {
-  if (manifest[moduleId]) {
-    return moduleId;
+  for (const candidate of manifestKeyCandidates(moduleId)) {
+    if (manifest[candidate]) {
+      return candidate;
+    }
   }
+  const candidates = new Set(manifestKeyCandidates(moduleId));
   return Object.entries(manifest).find(
-    ([key, chunk]) => key === moduleId || chunk.src === moduleId,
+    ([key, chunk]) => candidates.has(key) || (chunk.src ? candidates.has(chunk.src) : false),
   )?.[0];
+}
+
+function manifestKeyCandidates(moduleId: string): string[] {
+  const [pathname, suffix = ""] = splitModuleSuffix(moduleId);
+  const normalized = pathname.replace(/\\/g, "/");
+  const withoutLeading = normalized.replace(/^\/+/, "");
+  return [
+    moduleId,
+    `${normalized}${suffix}`,
+    `${withoutLeading}${suffix}`,
+    normalized,
+    withoutLeading,
+  ].filter((candidate, index, values) => candidate && values.indexOf(candidate) === index);
+}
+
+function splitModuleSuffix(moduleId: string): [string, string?] {
+  const match = /[?#]/u.exec(moduleId);
+  return match ? [moduleId.slice(0, match.index), moduleId.slice(match.index)] : [moduleId];
 }
 
 function devCssHref(node: SolidDevModuleNode, base: string | undefined): string | undefined {

--- a/npm/vite-plugin-ox-content-solid/src/virtual.ts
+++ b/npm/vite-plugin-ox-content-solid/src/virtual.ts
@@ -1,0 +1,13 @@
+declare module "virtual:ox-content-solid/html-host/modules" {
+  export interface SolidHtmlHostClientModule {
+    name: string;
+    moduleId: string;
+    exportName: string;
+  }
+
+  export type SolidHtmlHostClientModules = Readonly<Record<string, () => Promise<unknown>>>;
+
+  export const modules: SolidHtmlHostClientModules;
+  export const clientModules: readonly SolidHtmlHostClientModule[];
+  export default modules;
+}

--- a/tools/scripts/package-dry-run-public-declarations.mjs
+++ b/tools/scripts/package-dry-run-public-declarations.mjs
@@ -32,6 +32,42 @@ export function checkPublicDeclarationExports({
   }
   checkRuntimeConsumer({ tarball, entry, packDir, failures, packedPackages, mode: "import" });
   checkRuntimeConsumer({ tarball, entry, packDir, failures, packedPackages, mode: "require" });
+
+  if (pkg.name === "@ox-content/vite-plugin-solid") {
+    checkSolidHtmlHostRegistryConsumer({ tarball, packDir, failures, packedPackages });
+  }
+}
+
+function checkSolidHtmlHostRegistryConsumer({ tarball, packDir, failures, packedPackages }) {
+  const entry = {
+    packageName: "@ox-content/vite-plugin-solid",
+    packageDir: "npm/vite-plugin-ox-content-solid",
+    specifier: "@ox-content/vite-plugin-solid",
+    packedDependencies: ["@ox-content/vite-plugin", "@ox-content/islands"],
+    runtimeLinks: ["@types/node", "vite", "@solidjs/vite-plugin", "@solidjs/web", "solid-js"],
+  };
+  const consumerRoot = prepareConsumer({ tarball, entry, packDir, packedPackages });
+  for (const dependency of [
+    "@ox-content/napi",
+    "glob",
+    "rehype-parse",
+    "rehype-stringify",
+    "unified",
+  ]) {
+    linkPackageDependency(consumerRoot, "npm/vite-plugin-ox-content", dependency);
+  }
+  writeFileSync(join(consumerRoot, "package.json"), JSON.stringify({ type: "module" }));
+  writeFileSync(join(consumerRoot, "registry-fixture.ts"), solidHtmlHostRegistryFixture());
+  writeFileSync(join(consumerRoot, "tsconfig.json"), tsconfig("bundler", ["registry-fixture.ts"]));
+
+  const result = spawnSync(tscBin, ["-p", join(consumerRoot, "tsconfig.json")], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    failures.push(`${entry.specifier} registry consumer failed:\n${result.stdout}${result.stderr}`);
+  }
 }
 
 function checkDeclarationNames({ declaration, entry, extension, failures }) {
@@ -224,7 +260,34 @@ function runtimeAssertions(namespace, entry) {
     .join("\n");
 }
 
-function tsconfig(mode) {
+function solidHtmlHostRegistryFixture() {
+  return [
+    "import {",
+    "  SOLID_HTML_HOST_MODULES_VIRTUAL_ID,",
+    "  createSolidHtmlHostIslandRegistry,",
+    "  toSolidHtmlHostClientModuleId,",
+    "  type SolidHtmlHostIslandDocument,",
+    "  type SolidHtmlHostIslandEntry,",
+    '} from "@ox-content/vite-plugin-solid";',
+    'import modules, { clientModules } from "virtual:ox-content-solid/html-host/modules";',
+    "",
+    'const documents: SolidHtmlHostIslandDocument[] = [{ documentPath: "content/published.mdx" }];',
+    'const entries: SolidHtmlHostIslandEntry[] = [{ name: "Probe", moduleId: "./src/Probe.tsx" }];',
+    "const registry = createSolidHtmlHostIslandRegistry({ documents, entries });",
+    'const clientModuleId: string = registry.resolveClientModule({ serverModuleId: "./src/Probe.tsx" });',
+    "const virtualModuleId: string = registry.virtualModuleId;",
+    "const normalizedModuleId: string = toSolidHtmlHostClientModuleId(clientModuleId);",
+    "for (const module of clientModules) {",
+    "  const exportName: string = module.exportName;",
+    "  void exportName;",
+    "}",
+    "void modules;",
+    "void virtualModuleId;",
+    "void normalizedModuleId;",
+  ].join("\n");
+}
+
+function tsconfig(mode, files) {
   const compilerOptions =
     mode === "bundler"
       ? {
@@ -249,7 +312,8 @@ function tsconfig(mode) {
   return JSON.stringify(
     {
       compilerOptions,
-      files: mode === "bundler" ? ["esm-fixture.ts"] : ["esm-fixture.ts", "cjs-fixture.cts"],
+      files:
+        files ?? (mode === "bundler" ? ["esm-fixture.ts"] : ["esm-fixture.ts", "cjs-fixture.cts"]),
     },
     null,
     2,

--- a/tools/scripts/release.ts
+++ b/tools/scripts/release.ts
@@ -45,6 +45,7 @@ const CARGO_PUBLISH_PACKAGES = [
 ];
 
 const CARGO_TOML = "Cargo.toml";
+const CARGO_LOCK = "Cargo.lock";
 const RUST_DOC_FILES = ["docs/content/getting-started.md"];
 const ZED_EXTENSION_TOML = "editors/zed/extension.toml";
 const ZED_CARGO_TOML = "editors/zed/Cargo.toml";
@@ -93,6 +94,17 @@ function setCargoVersion(version: string): void {
   content = content.replace(/(ox_content_\w+\s*=\s*\{\s*version\s*=\s*)"[^"]+"/g, `$1"${version}"`);
   fs.writeFileSync(fullPath, content, "utf-8");
   console.log(`  Updated Cargo.toml workspace version to ${version}`);
+}
+
+function setCargoLockVersion(version: string): void {
+  const fullPath = path.join(ROOT, CARGO_LOCK);
+  let content = fs.readFileSync(fullPath, "utf-8");
+  content = content.replace(
+    /(\[\[package\]\]\nname = "ox_content_[^"]+"\nversion = )"[^"]+"/g,
+    `$1"${version}"`,
+  );
+  fs.writeFileSync(fullPath, content, "utf-8");
+  console.log(`  Updated Cargo.lock workspace package versions to ${version}`);
 }
 
 function setZedVersion(version: string): void {
@@ -279,6 +291,7 @@ async function main(): Promise<void> {
 
   console.log("Updating Cargo.toml version...");
   setCargoVersion(newVersion);
+  setCargoLockVersion(newVersion);
   setZedVersion(newVersion);
 
   console.log("Updating package versions...");

--- a/tools/scripts/write-solid-virtual-declarations.mjs
+++ b/tools/scripts/write-solid-virtual-declarations.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+import { rm, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const dist = join(root, "npm", "vite-plugin-ox-content-solid", "dist");
+const reference = '/// <reference path="./virtual.d.ts" />';
+
+const virtualDeclaration = `declare module "virtual:ox-content-solid/html-host/modules" {
+  import type { SolidHtmlHostClientModules } from "@ox-content/vite-plugin-solid/html-host/client";
+  import type { SolidHtmlHostClientModule } from "@ox-content/vite-plugin-solid";
+
+  export const modules: SolidHtmlHostClientModules;
+  export const clientModules: readonly SolidHtmlHostClientModule[];
+  export default modules;
+}
+`;
+
+await writeFile(join(dist, "virtual.d.ts"), virtualDeclaration);
+
+for (const extension of ["mts", "cts"]) {
+  const declarationFile = join(dist, `index.d.${extension}`);
+  let declaration = await readFile(declarationFile, "utf8");
+  declaration = declaration
+    .replace(new RegExp(`\\n//# sourceMappingURL=index\\.d\\.${extension}\\.map\\s*$`, "u"), "")
+    .trimStart();
+  if (!declaration.startsWith(reference)) {
+    declaration = `${reference}\n${declaration}`;
+  }
+  await writeFile(declarationFile, `${declaration.trimEnd()}\n`);
+  await rm(`${declarationFile}.map`, { force: true });
+}


### PR DESCRIPTION
## Summary
- Add a Solid custom-host island registry plugin that generates a virtual lazy module map from host-selected documents or explicit approved entries.
- Reuse the same module/export identity for SSR markers, client hydration, and stylesheet manifest lookup.
- Add dev invalidation, packed tarball consumer type checks, and release Cargo.lock version sync.
- Document replacing downstream broad globs with the generated virtual module.

## Verification
- `vp exec --filter @ox-content/vite-plugin-solid -- vp test src/html-host-registry.test.ts src/html-host.test.ts src/stylesheets.test.ts src/html-host-client.test.ts`
- `vp run --filter @ox-content/vite-plugin-solid typecheck`
- `vp run --filter @ox-content/vite-plugin-solid build`
- `node tools/scripts/package-dry-run.mjs`
- `vp run workspace:fmt:check`
- `vp run workspace:check`
- `node tools/scripts/check-file-lines.ts`
- `git diff --check`

Closes #1287.

Co-authored-by: ryoppippi <1560508+ryoppippi@users.noreply.github.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791217833&installation_model_id=422833&pr_number=1290&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1290&signature=90fbb087e486a585b8f2259b2d77ed022797d26914b986f957058b086d87a029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating Solid HTML host island registries from selected routes and documents.
  * Custom hosts now load only the required browser islands, improving output efficiency and avoiding unnecessary content.
  * Added support for development updates when selected content changes, including automatic reloads.
  * Improved stylesheet resolution across normalized module paths.

* **Documentation**
  * Added production guidance and examples for configuring custom Solid HTML hosts and selected content registries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->