### PR TITLE
feat(custom-host): resolve island stylesheets via assets context

### DIFF
--- a/docs/content/built-in/custom-host.md
+++ b/docs/content/built-in/custom-host.md
@@ -119,6 +119,37 @@ whole-directory `import.meta.glob()`. The generated module contains only the
 selected island dynamic-import roots; Vite still keeps their transitive
 dependencies.
 
+## Island stylesheets
+
+When a rendered route knows the browser module ids used by SSR-visible islands,
+resolve their blocking CSS through `ctx.assets.stylesheets()`.
+
+```ts
+const islandStyles = ctx.assets.stylesheets({
+  modules: rendered.clientModules.map((module) => module.moduleId),
+});
+
+const assets = ctx.assets.document({
+  islandStyles: islandStyles.stylesheets,
+  clientEntries: ["src/main.ts"],
+});
+
+return {
+  html: `<!doctype html><html><head>${assets.headHtml}</head><body>${rendered.html}</body></html>`,
+  dependencies: islandStyles.dependencies,
+};
+```
+
+In development, after the host renders islands through `ctx.loadModule()`, the
+resolver walks the internal Vite module graph for each rendered browser module
+id, includes direct and transitive CSS in dependency order, preserves CSS query
+strings, and returns source file dependencies that can invalidate the cached
+route. In build, it reads the Vite manifest and returns the same module
+identities with emitted hashed stylesheet hrefs. Missing entries are reported
+as diagnostics instead of silently dropping styles. Pass the returned styles
+into `ctx.assets.document()` so document-level dedupe, nonce, base, shared CSS,
+and page CSS composition all stay in one place.
+
 ## Theme token stylesheet
 
 `themeTokens` writes and serves a small stylesheet, defaulting to

--- a/docs/content/ja/built-in/custom-host.md
+++ b/docs/content/ja/built-in/custom-host.md
@@ -101,6 +101,42 @@ route の出力 path が重複すると、どの route 同士が衝突したか�
 失敗させます。公開対象の選択はホストが持ち、Ox Content はホストが返した route
 だけを書きます。
 
+Solid HTML-string host は、同じ選択済み route / document set から browser island registry を
+生成できます。`@ox-content/vite-plugin-solid` の
+`createSolidHtmlHostIslandRegistry()` を使い、client entry では directory 全体の
+`import.meta.glob()` の代わりに `virtual:ox-content-solid/html-host/modules` を
+import します。生成 module には選択された island dynamic-import root だけが入り、
+Vite はその transitive dependency を保持します。
+
+## Island stylesheet
+
+描画済み route が SSR-visible island の browser module id を知っている場合は、
+blocking CSS を `ctx.assets.stylesheets()` から解決します。
+
+```ts
+const islandStyles = ctx.assets.stylesheets({
+  modules: rendered.clientModules.map((module) => module.moduleId),
+});
+
+const assets = ctx.assets.document({
+  islandStyles: islandStyles.stylesheets,
+  clientEntries: ["src/main.ts"],
+});
+
+return {
+  html: `<!doctype html><html><head>${assets.headHtml}</head><body>${rendered.html}</body></html>`,
+  dependencies: islandStyles.dependencies,
+};
+```
+
+development では、host が `ctx.loadModule()` で island を描画したあと、描画済み browser module id
+に対応する内部 Vite module graph を辿り、direct / transitive CSS を依存順に返します。
+CSS query string は保持され、source file dependency も返るため cached route を invalidation
+できます。build では Vite manifest を使い、同じ module identity から emitted hashed stylesheet
+href を返します。entry が見つからない場合は style を黙って落とさず diagnostic に出ます。
+返された style は `ctx.assets.document()` に渡すと、document-level dedupe、nonce、base、
+shared CSS、page CSS と同じ場所で合成できます。
+
 ## テーマトークン stylesheet
 
 `themeTokens` は小さな stylesheet を書き出して dev でも配信します。既定 href は

--- a/docs/content/ja/packages/vite-plugin-ox-content-solid.md
+++ b/docs/content/ja/packages/vite-plugin-ox-content-solid.md
@@ -160,31 +160,31 @@ unknown module、loader、runtime、export、render の失敗は `onError` に�
 ## 独自ホストの island stylesheet
 
 server-rendered island は、client module が mount する前から CSS を必要とすることが
-あります。`resolveSolidIslandStylesheets()` は Vite build manifest または
-development module graph から、island module identity に必要な stylesheet URL を
-解決します。
+あります。`oxContentCustomHost()` を使う場合は public host assets context から解決し、
+host が Vite manifest や development module graph を直接触らない形にします。
 
 ```ts
-import { resolveSolidIslandStylesheets } from "@ox-content/vite-plugin-solid";
-
-const styles = resolveSolidIslandStylesheets({
-  modules: rendered.modules.map((module) => module.serverModuleId),
-  manifest: viteManifest,
-  base: "/docs/",
+const styles = ctx.assets.stylesheets({
+  modules: rendered.clientModules.map((module) => module.moduleId),
 });
 
-for (const stylesheet of styles.stylesheets) {
-  head.push(`<link rel="stylesheet" href="${escapeHtml(stylesheet.href)}">`);
-}
+const assets = ctx.assets.document({
+  islandStyles: styles.stylesheets,
+  clientEntries: ["src/main.ts"],
+});
+
+return {
+  html: `<!doctype html><html><head>${assets.headHtml}</head><body>${rendered.html}</body></html>`,
+  dependencies: styles.dependencies,
+};
 ```
 
-build 解決は static `imports` を辿り、CSS を重複排除し、imported chunk の CSS を
-importing island の CSS より先に並べ、`base` と emitted hashed filename を尊重します。
-development 解決は Vite 風の module graph（`getModuleById()` と任意の
-`getModulesByFile()`）を受け取り、CSS query parameter を残すため HMR URL をそのまま
-stylesheet として読めます。CSS を持たない有効な island は stylesheet も diagnostic も
-返しません。manifest / module graph に entry が無ければ `missing-module`、resolver を
-何も渡さなければ `missing-resolver` diagnostic を返します。
+assets context は direct / transitive island CSS を client module script より前に解決し、
+`ctx.assets.document()` 側で dedupe します。dev CSS query string は保持され、stylesheet 編集で
+cached custom-host route を更新する dependency path も返ります。build mode では同じ method が
+Vite manifest を内部で使い、同じ module identity から emitted hashed href を返します。
+manifest や module graph を意図的に自分で管理する non-custom host 向けには、
+低レベルの `resolveSolidIslandStylesheets()` helper も残っています。
 
 ## HMR
 

--- a/docs/content/packages/vite-plugin-ox-content-solid.md
+++ b/docs/content/packages/vite-plugin-ox-content-solid.md
@@ -334,33 +334,32 @@ and render failures are reported to `onError`.
 ## Island stylesheets for custom hosts
 
 Server-rendered islands often need their CSS before the client module mounts.
-`resolveSolidIslandStylesheets()` maps island module identities to stylesheet
-URLs from either a Vite build manifest or a development module graph.
+When you use `oxContentCustomHost()`, prefer the public host assets context so
+the host never touches a Vite manifest or development module graph directly.
 
 ```ts
-import { resolveSolidIslandStylesheets } from "@ox-content/vite-plugin-solid";
-
-const styles = resolveSolidIslandStylesheets({
+const styles = ctx.assets.stylesheets({
   modules: rendered.clientModules.map((module) => module.moduleId),
-  manifest: viteManifest,
-  base: "/docs/",
 });
 
-for (const stylesheet of styles.stylesheets) {
-  head.push(`<link rel="stylesheet" href="${escapeHtml(stylesheet.href)}">`);
-}
+const assets = ctx.assets.document({
+  islandStyles: styles.stylesheets,
+  clientEntries: ["src/main.ts"],
+});
+
+return {
+  html: `<!doctype html><html><head>${assets.headHtml}</head><body>${rendered.html}</body></html>`,
+  dependencies: styles.dependencies,
+};
 ```
 
-Build resolution walks static `imports`, deduplicates CSS, keeps imported chunk
-CSS before the importing island, and respects `base` plus emitted hashed file
-names. Development resolution accepts a Vite-like module graph with
-`getModuleById()` and optional `getModulesByFile()`, preserving CSS query
-parameters so HMR URLs remain loadable. The resolver accepts the registry's
-root-relative module ids, even when Vite's manifest stores the same source
-without a leading slash. A valid island with no CSS returns no stylesheet and no
-diagnostic; missing manifest/module-graph entries report a `missing-module`
-diagnostic. If neither resolver is supplied, each requested module reports
-`missing-resolver`.
+The assets context resolves direct and transitive island CSS before the client
+module script, deduplicates through `ctx.assets.document()`, preserves dev CSS
+query strings, and returns dependency paths that keep cached custom-host routes
+fresh after stylesheet edits. Build mode uses the Vite manifest behind the same
+method and returns emitted hashed hrefs for the same module identities. The
+lower-level `resolveSolidIslandStylesheets()` helper remains available for
+non-custom hosts that intentionally own the manifest or module graph.
 
 ## HMR
 

--- a/npm/vite-plugin-ox-content/src/custom-host-assets.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-assets.ts
@@ -3,6 +3,10 @@ import * as path from "node:path";
 import type { Connect } from "vite";
 import { resolveSelfHostedAssetManifest } from "./assets";
 import { DEFAULT_THEME_TOKEN_HREF } from "./custom-host-constants";
+import {
+  resolveCustomHostStylesheets,
+  type CustomHostDevModuleGraph,
+} from "./custom-host-stylesheets";
 import type {
   OxContentCustomHostAssetsContext,
   OxContentCustomHostOptions,
@@ -22,12 +26,23 @@ export function createAssetsContext(
   _outDir: string,
   clientManifest: DocumentAssetManifest | undefined,
   themeTokens: ResolvedThemeTokens | undefined,
+  moduleGraph?: CustomHostDevModuleGraph,
+  root?: string,
 ): OxContentCustomHostAssetsContext {
   const selfHosted = resolveSelfHostedAssetManifest(options);
   return {
     selfHosted,
     clientManifest,
     themeTokens,
+    stylesheets(input) {
+      return resolveCustomHostStylesheets({
+        ...input,
+        base: input.base ?? options.base,
+        manifest: clientManifest,
+        moduleGraph,
+        root,
+      });
+    },
     document(input: RenderDocumentAssetsInput = {}) {
       return renderDocumentAssets({
         base: options.base,

--- a/npm/vite-plugin-ox-content/src/custom-host-build.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-build.ts
@@ -52,7 +52,7 @@ export async function runCustomHostBuild(
   const outDir = resolveOutDir(config, options, root);
   const loaderServer = await createHostLoaderServer(config);
   const clientManifest = await readClientManifest(outDir);
-  const assets = createAssetsContext(options, outDir, clientManifest, themeTokens);
+  const assets = createAssetsContext(options, outDir, clientManifest, themeTokens, undefined, root);
   const loadModule = (moduleId: string) => loaderServer.ssrLoadModule(moduleId);
 
   try {

--- a/npm/vite-plugin-ox-content/src/custom-host-dev.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-dev.ts
@@ -41,7 +41,14 @@ export function configureDevServer(
 ): void {
   const root = server.config.root;
   const outDir = resolveOutDir(server.config, options, root);
-  const assets = createAssetsContext(options, outDir, undefined, themeTokens);
+  const assets = createAssetsContext(
+    options,
+    outDir,
+    undefined,
+    themeTokens,
+    server.moduleGraph,
+    root,
+  );
   let ssrVersion = 0;
   const loadModule = (moduleId: string) =>
     server.ssrLoadModule(versionedModuleId(moduleId, ssrVersion));

--- a/npm/vite-plugin-ox-content/src/custom-host-stylesheets.test.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-stylesheets.test.ts
@@ -1,0 +1,288 @@
+import * as fs from "node:fs/promises";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { build as viteBuild, createServer, type InlineConfig, type ViteDevServer } from "vite";
+import { oxContentCustomHost } from ".";
+import {
+  resolveCustomHostStylesheets,
+  type CustomHostDevModuleNode,
+} from "./custom-host-stylesheets";
+
+const tempDirs: string[] = [];
+const activeServers: ViteDevServer[] = [];
+const activeListeners: http.Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(activeListeners.splice(0).map((server) => closeHttpServer(server)));
+  await Promise.all(activeServers.splice(0).map((server) => server.close().catch(() => {})));
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("resolveCustomHostStylesheets", () => {
+  it("collects build CSS in dependency order and dev CSS dependencies", () => {
+    const manifest = {
+      "src/Island.ts": { css: ["assets/island.css"], imports: ["_child.js"] },
+      "_child.js": { css: ["assets/child.css"] },
+    };
+    expect(
+      resolveCustomHostStylesheets({
+        modules: ["/src/Island.ts"],
+        manifest,
+        base: "/docs/",
+      }).stylesheets.map((style) => style.href),
+    ).toEqual(["/docs/assets/child.css", "/docs/assets/island.css"]);
+
+    const childCss = node("/src/child.module.css?used", [], "/repo/src/child.module.css");
+    const island = node("/src/Island.ts", [childCss], "/repo/src/Island.ts");
+    const dev = resolveCustomHostStylesheets({
+      modules: ["/src/Island.ts", "/src/Missing.ts"],
+      moduleGraph: { getModuleById: (id) => (id === "/src/Island.ts" ? island : undefined) },
+      base: "/docs/",
+      root: "/repo",
+    });
+
+    expect(dev.stylesheets).toEqual([
+      { kind: "style", href: "/docs/src/child.module.css?used", moduleId: "/src/Island.ts" },
+    ]);
+    expect(dev.dependencies).toEqual(["/repo/src/Island.ts", "/repo/src/child.module.css"]);
+    expect(dev.diagnostics).toEqual([
+      expect.objectContaining({ code: "missing-module", moduleId: "/src/Missing.ts" }),
+    ]);
+  });
+
+  it("reports a missing resolver separately from a module with no CSS", () => {
+    expect(resolveCustomHostStylesheets({ modules: ["src/Island.ts"] })).toEqual({
+      stylesheets: [],
+      dependencies: [],
+      diagnostics: [
+        {
+          code: "missing-resolver",
+          moduleId: "src/Island.ts",
+          message:
+            'No Vite manifest or development module graph was available for "src/Island.ts".',
+        },
+      ],
+    });
+  });
+});
+
+describe("custom host island stylesheets", () => {
+  it("serves dev island CSS through assets context and invalidates CSS dependencies", async () => {
+    const root = await createProject("ox-custom-host-style-dev-");
+    const server = await trackDevServer(createServer(viteConfig(root, { reloadDebounceMs: 1 })));
+    installFixtureModuleGraph(server, root);
+    const listener = await listen(server);
+
+    const home = await read(listener.port, "/");
+    expect(home.status).toBe(200);
+    expect(home.text).toContain('data-render="1"');
+    expect(home.text).toContain('<link rel="stylesheet" href="/src/islands/child.css">');
+    expect(home.text.match(/href="\/src\/islands\/island\.css"/g)).toHaveLength(1);
+    expect(home.text.indexOf('href="/src/islands/child.css"')).toBeLessThan(
+      home.text.indexOf('src="/src/main.ts"'),
+    );
+    expect(home.text).not.toContain("missing-module");
+
+    const cached = await read(listener.port, "/");
+    expect(cached.text).toContain('data-render="1"');
+
+    const childCss = path.join(root, "src", "islands", "child.css");
+    await fs.writeFile(childCss, ".child{color:navy}\n");
+    server.watcher.emit("change", childCss);
+    await wait(20);
+
+    const updated = await read(listener.port, "/");
+    expect(updated.text).toContain('data-render="2"');
+  });
+
+  it("writes build island CSS from the manifest without exposing moduleGraph", async () => {
+    const root = await createProject("ox-custom-host-style-build-");
+
+    await viteBuild(viteConfig(root));
+
+    const html = await fs.readFile(path.join(root, "dist", "index.html"), "utf8");
+    expect(html).toContain('data-render="1"');
+    expect(html).toContain('href="/assets/');
+    expect(html).toContain('<script type="module" src="/assets/main-');
+    expect(html.indexOf('href="/assets/')).toBeLessThan(
+      html.indexOf('<script type="module" src="/assets/main-'),
+    );
+    expect(html).not.toContain("missing-module");
+
+    const css = await readDistCss(root);
+    expect(css).toContain(".island");
+    expect(css).toContain(".child");
+  });
+});
+
+function viteConfig(root: string, dev: { reloadDebounceMs?: number } = {}): InlineConfig {
+  return {
+    root,
+    configFile: false,
+    appType: "custom",
+    logLevel: "silent",
+    plugins: [
+      ...oxContentCustomHost({
+        host: "./src/host.ts",
+        oxContent: {
+          srcDir: "content",
+          outDir: "dist",
+          resources: false,
+          docs: false,
+          search: false,
+          ogViewer: false,
+          feeds: false,
+          siteMaps: false,
+        },
+        dev,
+      }),
+    ],
+    build: {
+      outDir: "dist",
+      emptyOutDir: true,
+      manifest: true,
+      rollupOptions: { input: path.join(root, "src", "main.ts") },
+    },
+  };
+}
+
+async function createProject(prefix: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(root);
+  await fs.mkdir(path.join(root, "src", "islands"), { recursive: true });
+  await fs.mkdir(path.join(root, "content"), { recursive: true });
+  await fs.writeFile(path.join(root, "package.json"), '{"type":"module"}\n');
+  await fs.writeFile(
+    path.join(root, "src", "main.ts"),
+    'import("./islands/client.ts");\ndocument.documentElement.dataset.client = "ready";\n',
+  );
+  await fs.writeFile(
+    path.join(root, "src", "islands", "Island.ts"),
+    'import { child } from "./Child.ts";\nexport function renderIsland() { return `<section class="island ${child}">Island</section>`; }\n',
+  );
+  await fs.writeFile(
+    path.join(root, "src", "islands", "client.ts"),
+    'import "./island.css";\nimport "./child.css";\nexport const hydrate = true;\n',
+  );
+  await fs.writeFile(
+    path.join(root, "src", "islands", "Child.ts"),
+    'export const child = "child";\n',
+  );
+  await fs.writeFile(path.join(root, "src", "islands", "island.css"), ".island{color:teal}\n");
+  await fs.writeFile(path.join(root, "src", "islands", "child.css"), ".child{color:maroon}\n");
+  await fs.writeFile(path.join(root, "src", "host.ts"), hostModuleSource());
+  return root;
+}
+
+function hostModuleSource(): string {
+  return `
+let renders = 0;
+
+export default {
+  routes: [
+    {
+      path: "/",
+      async render(ctx) {
+        renders += 1;
+        const island = await ctx.loadModule("/src/islands/Island.ts");
+        const styles = ctx.assets.stylesheets({
+          modules: ["/src/islands/client.ts", "/src/islands/client.ts"],
+        });
+        const assets = ctx.assets.document({
+          sharedStyles: ctx.mode === "serve" ? ["/src/islands/island.css"] : [],
+          islandStyles: styles.stylesheets,
+          clientEntries: ["src/main.ts"],
+        });
+        return {
+          html: "<!doctype html><html><head>" + assets.headHtml + "</head><body data-render=\\"" + renders + "\\"><main>" + island.renderIsland() + "</main><p>" + styles.diagnostics.map((diagnostic) => diagnostic.code).join(",") + "</p></body></html>",
+          dependencies: styles.dependencies,
+        };
+      },
+    },
+  ],
+};
+`;
+}
+
+function installFixtureModuleGraph(server: ViteDevServer, root: string): void {
+  const graph = server.moduleGraph as unknown as {
+    getModuleById(id: string): CustomHostDevModuleNode | undefined;
+    getModulesByFile?(file: string): Set<CustomHostDevModuleNode> | undefined;
+  };
+  const childCss = node(
+    "/src/islands/child.css",
+    [],
+    path.join(root, "src", "islands", "child.css"),
+  );
+  const islandCss = node(
+    "/src/islands/island.css",
+    [],
+    path.join(root, "src", "islands", "island.css"),
+  );
+  const client = node(
+    "/src/islands/client.ts",
+    [childCss, islandCss],
+    path.join(root, "src", "islands", "client.ts"),
+  );
+  const originalGetModuleById = graph.getModuleById.bind(graph);
+  const originalGetModulesByFile = graph.getModulesByFile?.bind(graph);
+
+  graph.getModuleById = (id: string) =>
+    id === "/src/islands/client.ts" ? client : originalGetModuleById(id);
+  graph.getModulesByFile = (file: string) =>
+    file === path.join(root, "src", "islands", "client.ts")
+      ? new Set([client])
+      : originalGetModulesByFile?.(file);
+}
+
+function node(
+  url: string,
+  imports: CustomHostDevModuleNode[] = [],
+  file?: string,
+): CustomHostDevModuleNode {
+  return {
+    id: url,
+    url,
+    file,
+    importedModules: imports,
+  };
+}
+
+async function trackDevServer(serverPromise: Promise<ViteDevServer>): Promise<ViteDevServer> {
+  const server = await serverPromise;
+  activeServers.push(server);
+  return server;
+}
+
+async function listen(server: ViteDevServer): Promise<{ port: number }> {
+  const listener = http.createServer(server.middlewares);
+  activeListeners.push(listener);
+  await new Promise<void>((resolve) => listener.listen(0, "127.0.0.1", resolve));
+  return { port: (listener.address() as AddressInfo).port };
+}
+
+async function read(port: number, requestPath: string) {
+  const response = await fetch(`http://127.0.0.1:${port}${requestPath}`);
+  return { status: response.status, headers: response.headers, text: await response.text() };
+}
+
+async function readDistCss(root: string): Promise<string> {
+  const assetDir = path.join(root, "dist", "assets");
+  const files = (await fs.readdir(assetDir)).filter((file) => file.endsWith(".css"));
+  return (
+    await Promise.all(files.map((file) => fs.readFile(path.join(assetDir, file), "utf8")))
+  ).join("\n");
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function closeHttpServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}

--- a/npm/vite-plugin-ox-content/src/custom-host-stylesheets.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-stylesheets.ts
@@ -1,0 +1,343 @@
+import * as fsSync from "node:fs";
+import * as path from "node:path";
+import type { DocumentAssetManifest } from "./document-assets";
+import type {
+  OxContentCustomHostStylesheet,
+  OxContentCustomHostStylesheetDiagnostic,
+  OxContentCustomHostStylesheetsInput,
+  OxContentCustomHostStylesheetsResult,
+} from "./custom-host-types";
+
+export interface CustomHostDevModuleNode {
+  id?: string | null;
+  url?: string | null;
+  file?: string | null;
+  importedModules?: Iterable<CustomHostDevModuleNode>;
+  ssrImportedModules?: Iterable<CustomHostDevModuleNode>;
+}
+
+export interface CustomHostDevModuleGraph {
+  idToModuleMap?: Map<string, CustomHostDevModuleNode>;
+  getModuleById(id: string): CustomHostDevModuleNode | undefined;
+  getModulesByFile?(file: string): Set<CustomHostDevModuleNode> | undefined;
+}
+
+export interface ResolveCustomHostStylesheetsInput extends OxContentCustomHostStylesheetsInput {
+  root?: string;
+  manifest?: DocumentAssetManifest;
+  moduleGraph?: CustomHostDevModuleGraph;
+}
+
+export function resolveCustomHostStylesheets(
+  input: ResolveCustomHostStylesheetsInput,
+): OxContentCustomHostStylesheetsResult {
+  if (input.manifest) {
+    return resolveBuildStylesheets(input.modules, input.manifest, input.base, input.root);
+  }
+  if (input.moduleGraph) {
+    return resolveDevStylesheets(input.modules, input.moduleGraph, input.base, input.root);
+  }
+  return {
+    stylesheets: [],
+    dependencies: [],
+    diagnostics: input.modules.map((moduleId) => ({
+      code: "missing-resolver",
+      moduleId,
+      message: `No Vite manifest or development module graph was available for "${moduleId}".`,
+    })),
+  };
+}
+
+function resolveBuildStylesheets(
+  moduleIds: readonly string[],
+  manifest: DocumentAssetManifest,
+  base: string | undefined,
+  root: string | undefined,
+): OxContentCustomHostStylesheetsResult {
+  const stylesheets: OxContentCustomHostStylesheet[] = [];
+  const diagnostics: OxContentCustomHostStylesheetDiagnostic[] = [];
+  const seenCss = new Set<string>();
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+
+  const visit = (key: string, requestedBy: string) => {
+    if (visiting.has(key) || visited.has(key)) {
+      return;
+    }
+    const chunk = manifest[key];
+    if (!chunk) {
+      diagnostics.push({
+        code: "missing-module",
+        moduleId: requestedBy,
+        message: `Vite manifest entry "${key}" was not found for custom host module "${requestedBy}".`,
+      });
+      return;
+    }
+    visiting.add(key);
+    for (const imported of chunk.imports ?? []) {
+      visit(imported, requestedBy);
+    }
+    for (const css of chunk.css ?? []) {
+      const href = joinBase(base, css);
+      if (!seenCss.has(href)) {
+        seenCss.add(href);
+        stylesheets.push({ kind: "style", href, moduleId: requestedBy });
+      }
+    }
+    visiting.delete(key);
+    visited.add(key);
+  };
+
+  for (const moduleId of moduleIds) {
+    const key = manifestKey(manifest, moduleId, root);
+    if (!key) {
+      diagnostics.push({
+        code: "missing-module",
+        moduleId,
+        message: `Vite manifest entry was not found for custom host module "${moduleId}".`,
+      });
+      continue;
+    }
+    visit(key, moduleId);
+  }
+
+  return { stylesheets, diagnostics, dependencies: [] };
+}
+
+function resolveDevStylesheets(
+  moduleIds: readonly string[],
+  moduleGraph: CustomHostDevModuleGraph,
+  base: string | undefined,
+  root: string | undefined,
+): OxContentCustomHostStylesheetsResult {
+  const stylesheets: OxContentCustomHostStylesheet[] = [];
+  const diagnostics: OxContentCustomHostStylesheetDiagnostic[] = [];
+  const seenCss = new Set<string>();
+  const dependencies = new Set<string>();
+
+  for (const moduleId of moduleIds) {
+    const entry = devEntry(moduleGraph, moduleId, root);
+    if (!entry) {
+      diagnostics.push({
+        code: "missing-module",
+        moduleId,
+        message: `Vite module graph entry was not found for custom host module "${moduleId}".`,
+      });
+      continue;
+    }
+    visitDevModule(entry, moduleId, base, root, new Set(), seenCss, stylesheets, dependencies);
+  }
+
+  return { stylesheets, diagnostics, dependencies: [...dependencies] };
+}
+
+function visitDevModule(
+  node: CustomHostDevModuleNode,
+  requestedBy: string,
+  base: string | undefined,
+  root: string | undefined,
+  seenNodes: Set<CustomHostDevModuleNode>,
+  seenCss: Set<string>,
+  stylesheets: OxContentCustomHostStylesheet[],
+  dependencies: Set<string>,
+): void {
+  if (seenNodes.has(node)) {
+    return;
+  }
+  seenNodes.add(node);
+
+  const dependency = devDependency(node, root);
+  if (dependency) {
+    dependencies.add(dependency);
+  }
+  const visitImport = (imported: CustomHostDevModuleNode) =>
+    visitDevModule(
+      imported,
+      requestedBy,
+      base,
+      root,
+      seenNodes,
+      seenCss,
+      stylesheets,
+      dependencies,
+    );
+  for (const imported of node.importedModules ?? []) {
+    visitImport(imported);
+  }
+  for (const imported of node.ssrImportedModules ?? []) {
+    visitImport(imported);
+  }
+
+  const href = devCssHref(node, base, root);
+  if (href && !seenCss.has(href)) {
+    seenCss.add(href);
+    stylesheets.push({ kind: "style", href, moduleId: requestedBy });
+  }
+}
+
+function devEntry(
+  moduleGraph: CustomHostDevModuleGraph,
+  moduleId: string,
+  root: string | undefined,
+): CustomHostDevModuleNode | undefined {
+  for (const id of moduleIdCandidates(moduleId, root)) {
+    const direct = moduleGraph.getModuleById(id);
+    if (direct) {
+      return direct;
+    }
+  }
+  for (const file of moduleFileCandidates(moduleId, root)) {
+    const byFile = first(moduleGraph.getModulesByFile?.(file));
+    if (byFile) {
+      return byFile;
+    }
+  }
+
+  const ids = new Set(moduleIdCandidates(moduleId, root).map(cleanModulePath));
+  const files = new Set(moduleFileCandidates(moduleId, root).map(normalizeFilePath));
+  for (const [id, node] of moduleGraph.idToModuleMap ?? []) {
+    const cleanId = cleanModulePath(id);
+    if (ids.has(cleanId) || (node.file && files.has(normalizeFilePath(node.file)))) {
+      return node;
+    }
+  }
+  return undefined;
+}
+
+function manifestKey(
+  manifest: DocumentAssetManifest,
+  moduleId: string,
+  root: string | undefined,
+): string | undefined {
+  const candidates = new Set(moduleIdCandidates(moduleId, root).map(cleanModulePath));
+  return Object.entries(manifest).find(([key, chunk]) => {
+    const values = [key, chunk.src, chunk.file].filter((value): value is string => !!value);
+    return values.some((value) => candidates.has(cleanModulePath(value)));
+  })?.[0];
+}
+
+function moduleIdCandidates(moduleId: string, root: string | undefined): string[] {
+  const clean = cleanModulePath(moduleId).replace(/\\/g, "/");
+  const withoutLeading = clean.replace(/^\/+/, "");
+  const result = [moduleId, clean, withoutLeading];
+  if (root && isWithinRoot(clean, root)) {
+    result.push(path.posix.relative(normalizeFilePath(root), clean));
+  } else if (root && clean.startsWith("/@fs/")) {
+    result.push(path.posix.relative(normalizeFilePath(root), clean.slice("/@fs".length)));
+  } else if (!clean.startsWith("/") && !clean.startsWith(".")) {
+    result.push(`/${clean}`);
+  }
+  return unique(result.filter(Boolean));
+}
+
+function moduleFileCandidates(moduleId: string, root: string | undefined): string[] {
+  const clean = cleanModulePath(moduleId);
+  const result: string[] = [];
+  if (clean.startsWith("/@fs/")) {
+    result.push(clean.slice("/@fs".length));
+  } else if (path.isAbsolute(clean) && !rootRelativeId(clean, root)) {
+    result.push(clean);
+  } else if (root && clean.startsWith("/")) {
+    result.push(path.join(root, clean.slice(1)));
+  } else if (root && clean) {
+    result.push(path.join(root, clean));
+  }
+  return unique(result.map(normalizeFilePath));
+}
+
+function devCssHref(
+  node: CustomHostDevModuleNode,
+  base: string | undefined,
+  root: string | undefined,
+): string | undefined {
+  const raw = node.url ?? node.id ?? node.file;
+  if (!raw) {
+    return undefined;
+  }
+  const [pathname, suffix = ""] = splitModuleSuffix(raw);
+  if (!pathname.endsWith(".css")) {
+    return undefined;
+  }
+  if (pathname.startsWith("/@fs/")) {
+    return joinBase(base, `${pathname}${suffix}`);
+  }
+  if (root && isWithinRoot(pathname, root)) {
+    const relative = path.posix.relative(normalizeFilePath(root), normalizeFilePath(pathname));
+    return joinBase(base, `/${relative}${suffix}`);
+  }
+  if (pathname.startsWith("/")) {
+    return joinBase(base, `${pathname}${suffix}`);
+  }
+  return joinBase(base, `/${pathname}${suffix}`);
+}
+
+function devDependency(
+  node: CustomHostDevModuleNode,
+  root: string | undefined,
+): string | undefined {
+  const raw = node.file ?? node.id ?? node.url;
+  if (!raw) {
+    return undefined;
+  }
+  const clean = cleanModulePath(raw);
+  if (clean.startsWith("/@fs/")) {
+    return normalizeFilePath(clean.slice("/@fs".length));
+  }
+  if (path.isAbsolute(clean) && !rootRelativeId(clean, root)) {
+    return normalizeFilePath(clean);
+  }
+  if (root && clean.startsWith("/")) {
+    return normalizeFilePath(path.join(root, clean.slice(1)));
+  }
+  return root && clean ? normalizeFilePath(path.join(root, clean)) : undefined;
+}
+
+function rootRelativeId(value: string, root: string | undefined): boolean {
+  if (!root || !value.startsWith("/")) {
+    return false;
+  }
+  return !isWithinRoot(value, root) && !value.startsWith("/@fs/");
+}
+
+function isWithinRoot(file: string, root: string): boolean {
+  const normalizedFile = normalizeFilePath(file);
+  const normalizedRoot = normalizeFilePath(root);
+  return normalizedFile === normalizedRoot || normalizedFile.startsWith(`${normalizedRoot}/`);
+}
+
+function cleanModulePath(moduleId: string): string {
+  return splitModuleSuffix(moduleId)[0].replace(/\\/g, "/");
+}
+
+function splitModuleSuffix(moduleId: string): [string, string?] {
+  const match = /[?#]/u.exec(moduleId);
+  return match ? [moduleId.slice(0, match.index), moduleId.slice(match.index)] : [moduleId];
+}
+
+function joinBase(base: string | undefined, href: string): string {
+  if (href.startsWith("#") || href.startsWith("//") || /^[a-z][a-z0-9+.-]*:/iu.test(href)) {
+    return href;
+  }
+  const normalizedBase = !base || base === "/" ? "/" : base.endsWith("/") ? base : `${base}/`;
+  if (normalizedBase !== "/" && href.startsWith(normalizedBase)) {
+    return href;
+  }
+  return `${normalizedBase}${href.replace(/^\/+/u, "")}`;
+}
+
+function normalizeFilePath(file: string): string {
+  const resolved = path.resolve(file);
+  try {
+    return fsSync.realpathSync.native(resolved).replace(/\\/g, "/");
+  } catch {
+    return resolved.replace(/\\/g, "/");
+  }
+}
+
+function unique(values: string[]): string[] {
+  return values.filter((value, index) => values.indexOf(value) === index);
+}
+
+function first<T>(set: Set<T> | undefined): T | undefined {
+  return set?.values().next().value;
+}

--- a/npm/vite-plugin-ox-content/src/custom-host-types.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-types.ts
@@ -1,6 +1,7 @@
 import type { OxContentAssetManifest } from "./assets";
 import type {
   DocumentAssetManifest,
+  DocumentStyleDescriptor,
   RenderDocumentAssetsInput,
   RenderDocumentAssetsResult,
 } from "./document-assets";
@@ -110,7 +111,35 @@ export interface OxContentCustomHostAssetsContext {
   selfHosted: OxContentAssetManifest;
   clientManifest?: DocumentAssetManifest;
   themeTokens?: ResolvedThemeTokens;
+  stylesheets(input: OxContentCustomHostStylesheetsInput): OxContentCustomHostStylesheetsResult;
   document(input?: RenderDocumentAssetsInput): RenderDocumentAssetsResult;
+}
+
+export interface OxContentCustomHostStylesheetsInput {
+  /** Route-rendered browser module identities, for example island client modules. */
+  modules: readonly string[];
+  /** Override the custom host base path for returned stylesheet hrefs. */
+  base?: string;
+}
+
+export interface OxContentCustomHostStylesheet extends DocumentStyleDescriptor {
+  kind: "style";
+  href: string;
+  /** Module id that requested this stylesheet. */
+  moduleId: string;
+}
+
+export interface OxContentCustomHostStylesheetDiagnostic {
+  code: "missing-module" | "missing-resolver";
+  moduleId: string;
+  message: string;
+}
+
+export interface OxContentCustomHostStylesheetsResult {
+  stylesheets: OxContentCustomHostStylesheet[];
+  diagnostics: OxContentCustomHostStylesheetDiagnostic[];
+  /** Dev-only source files that should be merged into route dependencies. */
+  dependencies: string[];
 }
 
 export interface OxContentCustomHostBaseContext {

--- a/npm/vite-plugin-ox-content/src/custom-host.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host.ts
@@ -20,6 +20,10 @@ export type {
   OxContentCustomHostRenderResult,
   OxContentCustomHostRoute,
   OxContentCustomHostRoutesContext,
+  OxContentCustomHostStylesheet,
+  OxContentCustomHostStylesheetDiagnostic,
+  OxContentCustomHostStylesheetsInput,
+  OxContentCustomHostStylesheetsResult,
   OxContentCustomHostThemeTokensOptions,
 } from "./custom-host-types";
 

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -1032,6 +1032,10 @@ export type {
   OxContentCustomHostRenderResult,
   OxContentCustomHostRoute,
   OxContentCustomHostRoutesContext,
+  OxContentCustomHostStylesheet,
+  OxContentCustomHostStylesheetDiagnostic,
+  OxContentCustomHostStylesheetsInput,
+  OxContentCustomHostStylesheetsResult,
   OxContentCustomHostThemeTokensOptions,
 } from "./custom-host";
 export { resolveNotFoundOptions } from "./not-found";

--- a/tools/scripts/package-dry-run-public-declarations.mjs
+++ b/tools/scripts/package-dry-run-public-declarations.mjs
@@ -236,10 +236,15 @@ function valueUsage(entry, prefix) {
   if (entry.distBase === "custom-host") {
     return [
       "declare const customOptions: OxContentCustomHostOptions;",
+      "declare const customAssets: OxContentCustomHostAssetsContext;",
       `const customPlugin = ${prefix}createOxContentCustomHostPlugin(customOptions);`,
       `const customOxOptions = ${prefix}customHostOxContentOptions();`,
+      `const customStyles = customAssets.stylesheets({ modules: ["/src/Island.ts"] });`,
+      "customAssets.document({ islandStyles: customStyles.stylesheets });",
+      "const customDeps: string[] = customStyles.dependencies;",
       "void customPlugin;",
       "void customOxOptions;",
+      "void customDeps;",
     ].join("\n");
   }
 

--- a/tools/scripts/public-declaration-contracts.mjs
+++ b/tools/scripts/public-declaration-contracts.mjs
@@ -18,6 +18,10 @@ export const publicDeclarationEntries = [
       "OxContentCustomHostRenderResult",
       "OxContentCustomHostRoute",
       "OxContentCustomHostRoutesContext",
+      "OxContentCustomHostStylesheet",
+      "OxContentCustomHostStylesheetDiagnostic",
+      "OxContentCustomHostStylesheetsInput",
+      "OxContentCustomHostStylesheetsResult",
       "OxContentCustomHostThemeTokensOptions",
     ],
     runtimeLinks: [


### PR DESCRIPTION
## Summary
- add ctx.assets.stylesheets() for dev/build island stylesheet descriptors without exposing Vite internals
- return diagnostics and dev dependencies so stylesheet edits invalidate cached custom-host routes
- document the public custom-host flow and cover packed declaration consumers

## Verification
- vp exec --filter @ox-content/vite-plugin -- vp test src/custom-host-stylesheets.test.ts src/custom-host.test.ts src/document-assets.test.ts
- vp run workspace:fmt:check
- node tools/scripts/check-file-lines.ts && git diff --check
- vp run --filter @ox-content/vite-plugin build
- vp run build
- node tools/scripts/package-dry-run.mjs
- vp run workspace:check

Closes #1289.

Co-authored-by: ryoppippi <1560508+ryoppippi@users.noreply.github.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791219203&installation_model_id=422833&pr_number=1291&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1291&signature=419497f9ffd4511e34e7d2636e807fa2a453ebc72ac90b6ebe1af073a1dfb2eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Custom hosts can now resolve stylesheets required by server-rendered islands through the public assets context.
  - Stylesheet resolution supports development and production builds, including dependency ordering, deduplication, and preserved CSS query strings.
  - Missing stylesheet entries are reported as diagnostics instead of being silently omitted.
  - New public types support stylesheet inputs, results, descriptors, and diagnostics.

- **Documentation**
  - Added English and Japanese guidance for island stylesheet handling and custom-host integration.

- **Tests**
  - Added coverage for build, development, diagnostics, injection, invalidation, and production CSS output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->