### PR TITLE
fix: handle beta autolink and watcher regressions

### DIFF
--- a/crates/ox_content_parser/src/parser/inline/gfm_autolink/scan.rs
+++ b/crates/ox_content_parser/src/parser/inline/gfm_autolink/scan.rs
@@ -95,13 +95,13 @@ pub(super) fn scheme_prefix_len(bytes: &[u8], at: usize) -> Option<usize> {
     SCHEMES.iter().find(|name| bytes[..at].ends_with(name.as_bytes())).map(|name| name.len() + 3)
 }
 
-/// Start-of-text, whitespace, or `*`, `_`, `~`, `(` may precede an
+/// Start-of-text, whitespace, or common delimiter punctuation may precede an
 /// autolink.
 fn valid_boundary(value: &str, start: usize) -> bool {
     value[..start]
         .chars()
         .next_back()
-        .is_none_or(|ch| ch.is_whitespace() || matches!(ch, '*' | '_' | '~' | '('))
+        .is_none_or(|ch| ch.is_whitespace() || matches!(ch, '*' | '_' | '~' | '(' | '\'' | '"'))
 }
 
 pub(super) fn validate_url(value: &str, start: usize, prefix_len: usize) -> Option<Candidate> {

--- a/crates/ox_content_parser/tests/edge_cases/autolinks.rs
+++ b/crates/ox_content_parser/tests/edge_cases/autolinks.rs
@@ -146,3 +146,71 @@ fn gfm_autolink_keeps_non_ascii_iri_paths() {
         other => panic!("expected paragraph, got {other:?}"),
     }
 }
+
+#[test]
+fn smart_punctuation_output_stays_outside_following_gfm_autolink() {
+    let cases = [
+        (
+            r#"The URL "https://example.com" is valid."#,
+            "The URL “",
+            "https://example.com",
+            "” is valid.",
+        ),
+        (
+            "The URL 'https://example.com' is valid.",
+            "The URL ‘",
+            "https://example.com",
+            "’ is valid.",
+        ),
+        ("See https://example.com...", "See ", "https://example.com", "…"),
+    ];
+
+    for (source, before, href, after) in cases {
+        let allocator = Allocator::new();
+        let doc = parse_with_options(
+            &allocator,
+            source,
+            ParserOptions { autolinks: true, smart_punctuation: true, ..Default::default() },
+        );
+
+        let Node::Paragraph(paragraph) = &doc.children[0] else {
+            panic!("expected paragraph, got {:?}", doc.children[0]);
+        };
+        let [Node::Text(prefix), Node::Link(link), Node::Text(suffix)] =
+            paragraph.children.as_slice()
+        else {
+            panic!("expected text, autolink, text for {source:?}, got {:?}", paragraph.children);
+        };
+
+        assert_eq!(prefix.value, before, "prefix for {source:?}");
+        assert_eq!(link.url, href, "href for {source:?}");
+        assert_eq!(link.children.iter().map(super::flatten_text).collect::<String>(), href);
+        assert_eq!(suffix.value, after, "suffix for {source:?}");
+    }
+}
+
+#[test]
+fn literal_unicode_punctuation_stays_inside_gfm_autolink() {
+    for (source, expected) in [
+        ("https://example.com”", "https://example.com”"),
+        ("https://example.com’", "https://example.com’"),
+        ("https://example.com…", "https://example.com…"),
+    ] {
+        let allocator = Allocator::new();
+        let doc = parse_with_options(
+            &allocator,
+            source,
+            ParserOptions { autolinks: true, smart_punctuation: true, ..Default::default() },
+        );
+
+        let Node::Paragraph(paragraph) = &doc.children[0] else {
+            panic!("expected paragraph, got {:?}", doc.children[0]);
+        };
+        let Node::Link(link) = &paragraph.children[0] else {
+            panic!("expected autolink for {source:?}, got {:?}", paragraph.children);
+        };
+
+        assert_eq!(link.url, expected);
+        assert_eq!(link.children.iter().map(super::flatten_text).collect::<String>(), expected);
+    }
+}

--- a/crates/ox_content_renderer/tests/edge_links.rs
+++ b/crates/ox_content_renderer/tests/edge_links.rs
@@ -133,6 +133,32 @@ fn script_and_smart_punctuation_extensions_render_when_enabled() {
 }
 
 #[test]
+fn smart_punctuation_delimiters_stay_outside_gfm_autolink_rendering() {
+    let parser_options =
+        ParserOptions { autolinks: true, smart_punctuation: true, ..ParserOptions::default() };
+    let renderer_options = HtmlRendererOptions { link_target_blank: false, ..Default::default() };
+
+    for (source, expected) in [
+        (
+            r#"The URL "https://example.com" is valid."#,
+            "<p>The URL “<a href=\"https://example.com\">https://example.com</a>” is valid.</p>\n",
+        ),
+        (
+            "The URL 'https://example.com' is valid.",
+            "<p>The URL ‘<a href=\"https://example.com\">https://example.com</a>’ is valid.</p>\n",
+        ),
+        (
+            "See https://example.com...",
+            "<p>See <a href=\"https://example.com\">https://example.com</a>…</p>\n",
+        ),
+    ] {
+        let html = render(source, parser_options.clone(), renderer_options.clone());
+
+        assert_eq!(html, expected, "source: {source}");
+    }
+}
+
+#[test]
 fn markdown_urls_on_another_origin_are_left_alone() {
     // A `.md` on another origin is not a page this build generates, so there
     // is no `index.html` route to rewrite it to. It must stay verbatim — and

--- a/npm/vite-plugin-ox-content/src/custom-host-module-deps.test.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-module-deps.test.ts
@@ -28,6 +28,16 @@ describe("custom host module dependency inference", () => {
     expect(dependencies.every((dependency) => !dependency.includes("\0"))).toBe(true);
     expect(dependencies.every((dependency) => !dependency.includes("__x00__"))).toBe(true);
   });
+
+  it("keeps real files whose names contain Vite escape text", () => {
+    const root = path.resolve("fixtures/custom-host");
+    const file = path.join(root, "src", "__x00__literal.ts");
+    const moduleGraph = graph([node({ file })]);
+
+    const dependencies = collectDevModuleDependencies(moduleGraph, file, root);
+
+    expect(dependencies).toEqual([normalize(file)]);
+  });
 });
 
 function node(input: {

--- a/npm/vite-plugin-ox-content/src/custom-host-module-deps.test.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-module-deps.test.ts
@@ -1,0 +1,70 @@
+import * as path from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+import { collectDevModuleDependencies } from "./custom-host-module-deps";
+import type { CustomHostDevModuleGraph, CustomHostDevModuleNode } from "./custom-host-stylesheets";
+
+describe("custom host module dependency inference", () => {
+  it("skips virtual module ids as watch dependencies while traversing their imports", () => {
+    const root = path.resolve("fixtures/custom-host");
+    const realTransitive = node({ file: path.join(root, "src", "collections.ts") });
+    const virtualCollection = node({
+      id: "\0virtual:ox-content/collections",
+      url: "/@id/__x00__virtual:ox-content/collections",
+      imports: [realTransitive],
+    });
+    const host = node({
+      id: "/src/host.ts",
+      imports: [virtualCollection],
+    });
+    const moduleGraph = graph([host, virtualCollection, realTransitive]);
+
+    const dependencies = collectDevModuleDependencies(moduleGraph, "/src/host.ts", root);
+
+    expect(dependencies).toContain(normalize(path.join(root, "src", "host.ts")));
+    expect(dependencies).toContain(normalize(path.join(root, "src", "collections.ts")));
+    expect(dependencies).not.toContain(
+      normalize(path.join(root, "\0virtual:ox-content/collections")),
+    );
+    expect(dependencies.every((dependency) => !dependency.includes("\0"))).toBe(true);
+    expect(dependencies.every((dependency) => !dependency.includes("__x00__"))).toBe(true);
+  });
+});
+
+function node(input: {
+  id?: string;
+  url?: string;
+  file?: string;
+  imports?: CustomHostDevModuleNode[];
+}): CustomHostDevModuleNode {
+  return {
+    id: input.id,
+    url: input.url,
+    file: input.file,
+    importedModules: input.imports,
+  };
+}
+
+function graph(nodes: CustomHostDevModuleNode[]): CustomHostDevModuleGraph {
+  const modulesByFile = new Map<string, Set<CustomHostDevModuleNode>>();
+  for (const moduleNode of nodes) {
+    if (!moduleNode.file) {
+      continue;
+    }
+    modulesByFile.set(normalize(moduleNode.file), new Set([moduleNode]));
+  }
+  return {
+    idToModuleMap: new Map(
+      nodes.flatMap((moduleNode) => (moduleNode.id ? [[moduleNode.id, moduleNode]] : [])),
+    ),
+    getModuleById(id) {
+      return nodes.find((moduleNode) => moduleNode.id === id);
+    },
+    getModulesByFile(file) {
+      return modulesByFile.get(normalize(file));
+    },
+  };
+}
+
+function normalize(file: string): string {
+  return path.resolve(file).replace(/\\/g, "/");
+}

--- a/npm/vite-plugin-ox-content/src/custom-host-module-deps.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-module-deps.ts
@@ -98,11 +98,20 @@ function moduleFileCandidates(moduleId: string, root: string): string[] {
 }
 
 function devDependency(node: CustomHostDevModuleNode, root: string): string | undefined {
-  const raw = node.file ?? node.id ?? node.url;
-  if (!raw) {
+  for (const raw of [node.file, node.id, node.url]) {
+    const dependency = raw ? normalizeDevDependency(raw, root) : undefined;
+    if (dependency) {
+      return dependency;
+    }
+  }
+  return undefined;
+}
+
+function normalizeDevDependency(raw: string, root: string): string | undefined {
+  const clean = cleanModulePath(raw);
+  if (!isFilesystemModulePath(clean)) {
     return undefined;
   }
-  const clean = cleanModulePath(raw);
   if (clean.startsWith("/@fs/")) {
     return normalizeFilePath(clean.slice("/@fs".length));
   }
@@ -112,7 +121,23 @@ function devDependency(node: CustomHostDevModuleNode, root: string): string | un
   if (clean.startsWith("/")) {
     return normalizeFilePath(path.join(root, clean.slice(1)));
   }
-  return clean ? normalizeFilePath(path.join(root, clean)) : undefined;
+  return normalizeFilePath(path.join(root, clean));
+}
+
+function isFilesystemModulePath(value: string): boolean {
+  if (
+    value.includes("\0") ||
+    value.includes("__x00__") ||
+    value.startsWith("virtual:") ||
+    value.startsWith("/@id/") ||
+    value.startsWith("/@vite/")
+  ) {
+    return false;
+  }
+  if (value.startsWith("/@fs/") || path.isAbsolute(value) || value.startsWith(".")) {
+    return true;
+  }
+  return value.includes("/") && !!path.extname(value);
 }
 
 function rootRelativeId(value: string, root: string): boolean {

--- a/npm/vite-plugin-ox-content/src/custom-host-module-deps.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-module-deps.ts
@@ -127,7 +127,6 @@ function normalizeDevDependency(raw: string, root: string): string | undefined {
 function isFilesystemModulePath(value: string): boolean {
   if (
     value.includes("\0") ||
-    value.includes("__x00__") ||
     value.startsWith("virtual:") ||
     value.startsWith("/@id/") ||
     value.startsWith("/@vite/")


### PR DESCRIPTION
## Summary
- keep smart-punctuation delimiters outside following GFM autolink literals while preserving literal Unicode punctuation behavior
- exclude Vite virtual and internal module ids from custom-host dev watcher dependencies while still traversing them for real transitive source files

## Validation
- vp run fmt:check
- node tools/scripts/check-file-lines.ts --base origin/main
- git diff origin/main..HEAD --check
- cargo test -p ox_content_parser --test edge_cases autolink -- --nocapture
- cargo test -p ox_content_renderer --test edge_links -- --nocapture
- vp test npm/vite-plugin-ox-content/src/custom-host-module-deps.test.ts npm/vite-plugin-ox-content/src/custom-host-dev-lifecycle.test.ts npm/vite-plugin-ox-content/src/custom-host-dev-cache.test.ts
- cargo clippy -p ox_content_parser -p ox_content_renderer --all-targets -- -D warnings
- vp run --filter ./npm/vite-plugin-ox-content build
- node tools/scripts/package-dry-run.mjs

## Risk
- Level: low to moderate
- Impact: GFM autolink boundaries with smart punctuation, and custom-host development dependency watching
- Performance: no extra autolink scan pass; watcher fix filters module ids during existing dependency traversal
- Rollback: revert the merge commit and publish the next beta if needed

Closes #1308
Closes #1309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GFM autolink handling for apostrophes, quotation marks, ellipses, and smart punctuation.
  - Punctuation surrounding links now remains outside the rendered link, while supported punctuation within URLs is preserved.
  - Improved development dependency detection for Vite integrations, including virtual and filesystem-based module paths.

- **Tests**
  - Added coverage for punctuation-aware autolinking, link rendering, and development dependency resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->