### PR TITLE
fix(parser): curl elision apostrophes as closing quotes

### DIFF
--- a/crates/ox_content_parser/src/parser/inline/smart_punctuation.rs
+++ b/crates/ox_content_parser/src/parser/inline/smart_punctuation.rs
@@ -73,10 +73,7 @@ impl<'a> Parser<'a> {
                     1,
                     if state.is_opening_quote_context() { "\u{201c}" } else { "\u{201d}" },
                 )),
-                b'\'' => Some((
-                    1,
-                    if state.is_opening_quote_context() { "\u{2018}" } else { "\u{2019}" },
-                )),
+                b'\'' => Some((1, single_quote_replacement(value, pos, state))),
                 _ => None,
             };
 
@@ -158,4 +155,47 @@ fn is_gfm_autolink_like(link: &Link<'_>) -> bool {
     text.value == link.url
         || link.url.strip_prefix("http://") == Some(text.value)
         || link.url.strip_prefix("mailto:") == Some(text.value)
+}
+
+fn single_quote_replacement(
+    value: &str,
+    pos: usize,
+    state: &SmartPunctuationState,
+) -> &'static str {
+    if state.is_opening_quote_context() && !is_elision_apostrophe(value, pos) {
+        "\u{2018}"
+    } else {
+        "\u{2019}"
+    }
+}
+
+fn is_elision_apostrophe(value: &str, pos: usize) -> bool {
+    let after = &value[pos + 1..];
+    let Some(next) = after.chars().next() else {
+        return false;
+    };
+    if next.is_ascii_digit() {
+        return true;
+    }
+    if is_single_letter_elision(after) {
+        return true;
+    }
+    if starts_common_elision(after) {
+        return true;
+    }
+    next.is_alphabetic() && !after.contains('\'')
+}
+
+fn is_single_letter_elision(after: &str) -> bool {
+    let mut chars = after.chars();
+    matches!(chars.next(), Some('n' | 'N')) && chars.next() == Some('\'')
+}
+
+fn starts_common_elision(after: &str) -> bool {
+    const ELISIONS: &[&str] = &["cause", "em", "gainst", "round", "til", "tis", "twas", "twere"];
+    let Some(word_end) = after.find(|ch: char| !ch.is_alphabetic()) else {
+        return ELISIONS.iter().any(|elision| after.eq_ignore_ascii_case(elision));
+    };
+    let word = &after[..word_end];
+    ELISIONS.iter().any(|elision| word.eq_ignore_ascii_case(elision))
 }

--- a/crates/ox_content_parser/tests/edge_cases/extensions.rs
+++ b/crates/ox_content_parser/tests/edge_cases/extensions.rs
@@ -105,6 +105,19 @@ fn smart_punctuation_is_opt_in_and_leaves_code_literal() {
 }
 
 #[test]
+fn smart_punctuation_curls_elision_apostrophes_as_closing_quotes() {
+    let allocator = Allocator::new();
+    let options = ParserOptions { smart_punctuation: true, ..ParserOptions::default() };
+    let doc =
+        parse_with_options(&allocator, "the '90s\n'tis\nrock 'n' roll\ndon't\n'quoted'\n", options);
+
+    assert_eq!(
+        flatten_text(&doc.children[0]),
+        "the \u{2019}90s\n\u{2019}tis\nrock \u{2019}n\u{2019} roll\ndon\u{2019}t\n\u{2018}quoted\u{2019}"
+    );
+}
+
+#[test]
 fn smart_punctuation_skips_bare_autolink_text() {
     let allocator = Allocator::new();
     let options =


### PR DESCRIPTION
## Summary

- Triage: valid bug. `smart_punctuation` treated word-initial elision apostrophes as opening quotes.
- Curl elision apostrophes such as `'90s`, `'tis`, and `'n'` as closing apostrophes while preserving normal quoted words.
- Credit: reported by @lambdalisue.

## Risk

- Risk level: low
- User or production impact: changes only opt-in smart punctuation apostrophe classification.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_parser --test edge_cases smart_punctuation`
- [x] Manual verification completed: checked the new regression output and existing quoted-word behavior.
- [x] Edge cases or failure modes considered: quoted words still receive opening/closing quote marks.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

Closes #1327.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791342545&installation_model_id=422833&pr_number=1331&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1331&signature=5dcb23a02ae2a79fcf371c57d46f3efcf688bac75a5aba4c7d894d4e7c88d9b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smart punctuation for apostrophes in contractions, elisions, and decade abbreviations.
  * Preserved opening quotation marks while converting elision apostrophes to closing curly quotes.

* **Tests**
  * Added coverage for apostrophes in expressions such as `'90s`, `'tis`, `don't`, and quoted words.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->