### PR TITLE
fix(parser): recognize CR line endings

### DIFF
--- a/crates/ox_content_parser/src/parser/block.rs
+++ b/crates/ox_content_parser/src/parser/block.rs
@@ -1,7 +1,10 @@
-use memchr::{memchr, memchr2};
+use memchr::memchr3;
 use ox_content_ast::{Heading, Node, Paragraph, Span};
 
 use super::Parser;
+use super::line_scan::{
+    is_line_ending_byte, line_terminator_end, next_line_start as scan_next_line_start,
+};
 use crate::error::{ParseError, ParseResult};
 #[allow(unused_imports)]
 use crate::{profile_span, profile_span_detail};
@@ -141,19 +144,19 @@ impl<'a> Parser<'a> {
         // Table recognition is the one feature that cannot be decided from
         // the first byte because table headers usually look like ordinary
         // paragraph text. Guard the expensive two-line delimiter check with
-        // a same-line `|` probe so non-table prose does one memchr2 scan and
+        // a same-line `|` probe so non-table prose does one marker scan and
         // then falls through to paragraph parsing — carrying the line end
         // that scan reached, which is the first thing `parse_paragraph`
         // needs.
         let mut first_line_end = None;
         if self.options.tables {
-            match memchr2(b'|', b'\n', &bytes[start..]) {
+            match memchr3(b'|', b'\n', b'\r', &bytes[start..]) {
                 Some(off) if bytes[start + off] == b'|' => {
                     if self.try_parse_table() {
                         return self.parse_table(start);
                     }
                 }
-                Some(off) => first_line_end = Some(start + off + 1),
+                Some(off) => first_line_end = Some(line_terminator_end(bytes, start + off)),
                 None => first_line_end = Some(self.source.len()),
             }
         }
@@ -204,7 +207,7 @@ impl<'a> Parser<'a> {
         // never return `Ok(None)` without progress on a non-blank line.
         let mut content_end = match first_line_end {
             Some(end) => end,
-            None => memchr(b'\n', &bytes[start..]).map_or(self.source.len(), |off| start + off + 1),
+            None => scan_next_line_start(bytes, start),
         };
         self.position = content_end;
 
@@ -221,7 +224,7 @@ impl<'a> Parser<'a> {
             while cursor < bytes.len() && matches!(bytes[cursor], b' ' | b'\t') {
                 cursor += 1;
             }
-            if cursor >= bytes.len() || bytes[cursor] == b'\n' {
+            if cursor >= bytes.len() || is_line_ending_byte(bytes[cursor]) {
                 break;
             }
 
@@ -230,11 +233,7 @@ impl<'a> Parser<'a> {
             // h2, not a paragraph followed by a thematic break), so it
             // must be checked before `line_starts_block`.
             if let Some(depth) = self.setext_underline_depth(line_start, cursor) {
-                let heading_end = if let Some(off) = memchr(b'\n', &bytes[line_start..]) {
-                    line_start + off + 1
-                } else {
-                    self.source.len()
-                };
+                let heading_end = scan_next_line_start(bytes, line_start);
                 self.position = heading_end;
                 let content = self.source[start..content_end].trim();
                 let children = self.parse_inline_block(content, start)?;
@@ -254,10 +253,9 @@ impl<'a> Parser<'a> {
             }
 
             content_end = match probe.line_end {
-                Some(line_end) if line_end < bytes.len() => line_end + 1,
+                Some(line_end) if line_end < bytes.len() => line_terminator_end(bytes, line_end),
                 Some(_) => self.source.len(),
-                None => memchr(b'\n', &bytes[line_start..])
-                    .map_or(self.source.len(), |off| line_start + off + 1),
+                None => scan_next_line_start(bytes, line_start),
             };
             self.position = content_end;
         }
@@ -311,10 +309,10 @@ impl<'a> Parser<'a> {
         while i < bytes.len() && bytes[i] == marker {
             i += 1;
         }
-        while i < bytes.len() && matches!(bytes[i], b' ' | b'\t' | b'\r') {
+        while i < bytes.len() && matches!(bytes[i], b' ' | b'\t') {
             i += 1;
         }
-        if i < bytes.len() && bytes[i] != b'\n' {
+        if i < bytes.len() && !is_line_ending_byte(bytes[i]) {
             return None;
         }
         Some(depth)

--- a/crates/ox_content_parser/src/parser/block_quote.rs
+++ b/crates/ox_content_parser/src/parser/block_quote.rs
@@ -1,7 +1,7 @@
-use memchr::memchr;
 use ox_content_ast::{BlockQuote, Node, Span};
 
 use super::Parser;
+use super::line_scan::{line_end as scan_line_end, next_line_start as scan_next_line_start};
 use super::reference::{closes_paragraph_context, fence_open, is_fence_close};
 use super::spans::SourceMap;
 use crate::error::ParseResult;
@@ -46,12 +46,11 @@ impl<'a> Parser<'a> {
             }
 
             // Blank line ends the block quote
-            if ws_cursor >= bytes.len() || bytes[ws_cursor] == b'\n' {
+            if ws_cursor >= bytes.len() || matches!(bytes[ws_cursor], b'\n' | b'\r') {
                 break;
             }
 
-            let line_end =
-                memchr(b'\n', &bytes[line_start..]).map_or(bytes.len(), |off| line_start + off);
+            let line_end = scan_line_end(bytes, line_start);
             let line = &self.source[line_start..line_end];
             let trimmed_offset = ws_cursor - line_start;
             let trimmed = &line[trimmed_offset..];
@@ -92,8 +91,9 @@ impl<'a> Parser<'a> {
                 inner.push('\n');
                 let content_start =
                     line_start + trimmed_offset + 1 + Self::quote_marker_space_bytes(after_gt);
+                let line_next = scan_next_line_start(bytes, line_start);
                 let source_len =
-                    line_end.saturating_sub(content_start) + usize::from(line_end < bytes.len());
+                    line_end.saturating_sub(content_start) + line_next.saturating_sub(line_end);
                 source_map.push_line(
                     generated_start,
                     indent_columns + stripped_trimmed.len() + 1,
@@ -120,7 +120,7 @@ impl<'a> Parser<'a> {
                     && !closes_paragraph_context(stripped_trimmed);
 
                 // Advance past this line (and the trailing newline if any).
-                self.position = if line_end < bytes.len() { line_end + 1 } else { line_end };
+                self.position = line_next;
             } else if fence.is_none()
                 && paragraph_open
                 && !Self::quote_lazy_blocked(trimmed)
@@ -135,13 +135,14 @@ impl<'a> Parser<'a> {
                 lazy_lines.insert(inner.len() as u32);
                 inner.push_str(line);
                 inner.push('\n');
+                let line_next = scan_next_line_start(bytes, line_start);
                 source_map.push_line(
                     generated_start,
                     line.len() + 1,
                     line_start,
-                    line.len() + usize::from(line_end < bytes.len()),
+                    line.len() + line_next.saturating_sub(line_end),
                 );
-                self.position = if line_end < bytes.len() { line_end + 1 } else { line_end };
+                self.position = line_next;
             } else {
                 // Line doesn't start with `>`, block quote ends
                 break;

--- a/crates/ox_content_parser/src/parser/cursor.rs
+++ b/crates/ox_content_parser/src/parser/cursor.rs
@@ -1,6 +1,9 @@
-use memchr::{memchr, memchr2};
+use memchr::memchr3;
 
 use super::Parser;
+use super::line_scan::{
+    is_line_ending_byte, line_end, line_terminator_end, next_line_start as scan_next_line_start,
+};
 #[allow(unused_imports)]
 use crate::profile_span_detail;
 
@@ -60,8 +63,8 @@ impl<'a> Parser<'a> {
             while pos < bytes.len() && matches!(bytes[pos], b' ' | b'\t') {
                 pos += 1;
             }
-            if pos < bytes.len() && bytes[pos] == b'\n' {
-                pos += 1;
+            if pos < bytes.len() && is_line_ending_byte(bytes[pos]) {
+                pos = line_terminator_end(bytes, pos);
             } else if pos >= bytes.len() {
                 // Spaces/tabs running to end of input with no newline are
                 // a blank final line: consume them. Rewinding instead
@@ -191,7 +194,7 @@ impl<'a> Parser<'a> {
         if !check_tables {
             return BlockProbe { starts_block: false, line_end: None };
         }
-        match memchr2(b'|', b'\n', &bytes[line_start..]) {
+        match memchr3(b'|', b'\n', b'\r', &bytes[line_start..]) {
             Some(off) if bytes[line_start + off] == b'|' => {
                 BlockProbe { starts_block: self.try_parse_table(), line_end: None }
             }
@@ -202,30 +205,20 @@ impl<'a> Parser<'a> {
 
     pub(super) fn line_at(&self, line_start: usize) -> &'a str {
         let bytes = self.source.as_bytes();
-        let end =
-            memchr(b'\n', &bytes[line_start..]).map_or(self.source.len(), |off| line_start + off);
+        let end = line_end(bytes, line_start);
         &self.source[line_start..end]
     }
 
     pub(super) fn next_line_start(&self, line_start: usize) -> usize {
-        let bytes = self.source.as_bytes();
-        match memchr(b'\n', &bytes[line_start..]) {
-            Some(off) => line_start + off + 1,
-            None => self.source.len(),
-        }
+        scan_next_line_start(self.source.as_bytes(), line_start)
     }
 
     pub(super) fn consume_line(&mut self) -> &'a str {
         let start = self.position;
         let bytes = self.source.as_bytes();
-        if let Some(off) = memchr(b'\n', &bytes[start..]) {
-            let line_end = start + off;
-            self.position = line_end + 1;
-            &self.source[start..line_end]
-        } else {
-            self.position = self.source.len();
-            &self.source[start..]
-        }
+        let end = line_end(bytes, start);
+        self.position = line_terminator_end(bytes, end);
+        &self.source[start..end]
     }
 
     /// Finds the first non-space, non-tab byte before the next newline.
@@ -241,7 +234,7 @@ impl<'a> Parser<'a> {
         while cursor < bytes.len() {
             match bytes[cursor] {
                 b' ' | b'\t' => cursor += 1,
-                b'\n' => return None,
+                byte if is_line_ending_byte(byte) => return None,
                 _ => return Some(cursor),
             }
         }

--- a/crates/ox_content_parser/src/parser/definition_list/lines.rs
+++ b/crates/ox_content_parser/src/parser/definition_list/lines.rs
@@ -1,3 +1,4 @@
+use super::super::line_scan::line_end;
 use super::Parser;
 
 pub(super) struct DefinitionBodyLine {
@@ -7,8 +8,7 @@ pub(super) struct DefinitionBodyLine {
 
 impl Parser<'_> {
     pub(super) fn line_end_at(&self, line_start: usize) -> usize {
-        memchr::memchr(b'\n', &self.source.as_bytes()[line_start..])
-            .map_or(self.source.len(), |offset| line_start + offset)
+        line_end(self.source.as_bytes(), line_start)
     }
 
     pub(super) fn is_blank_line_at(&self, line_start: usize) -> bool {

--- a/crates/ox_content_parser/src/parser/fenced_code.rs
+++ b/crates/ox_content_parser/src/parser/fenced_code.rs
@@ -1,7 +1,7 @@
-use memchr::memchr;
 use ox_content_ast::{Node, Span};
 
 use super::Parser;
+use super::line_scan::{line_end, line_terminator_end, next_line_start};
 use crate::error::{ParseError, ParseResult};
 #[allow(unused_imports)]
 use crate::{profile_span, profile_span_detail};
@@ -43,25 +43,19 @@ impl<'a> Parser<'a> {
             if count >= fence_len {
                 // A closing fence carries nothing but trailing whitespace
                 // (``` aaa is content, not a closer).
-                let line_end = match memchr(b'\n', &bytes[cursor..]) {
-                    Some(off) => cursor + off,
-                    None => bytes.len(),
-                };
+                let line_end = line_end(bytes, cursor);
                 let only_ws =
                     bytes[cursor..line_end].iter().all(|byte| matches!(byte, b' ' | b'\t' | b'\r'));
                 if only_ws {
                     // Body ends at `line_start`; the fence line ends at
                     // the next newline (inclusive) or EOF.
-                    let after_fence = if line_end < bytes.len() { line_end + 1 } else { line_end };
+                    let after_fence = line_terminator_end(bytes, line_end);
                     return (line_start, after_fence);
                 }
             }
 
             // Not a closing fence — move to the next line.
-            line_start = match memchr(b'\n', &bytes[line_start..]) {
-                Some(off) => line_start + off + 1,
-                None => bytes.len(),
-            };
+            line_start = next_line_start(bytes, line_start);
         }
 
         // No closing fence; consume everything as body.
@@ -92,7 +86,7 @@ impl<'a> Parser<'a> {
         self.skip_whitespace();
         let info_start = self.position;
         while let Some(ch) = self.peek() {
-            if ch == '\n' {
+            if matches!(ch, '\n' | '\r') {
                 break;
             }
             self.advance();
@@ -108,10 +102,8 @@ impl<'a> Parser<'a> {
         // Backslash escapes and entity references apply in info strings.
         let lang = lang.map(|lang| self.unescape_link_component(lang));
 
-        // Skip newline after info string
-        if self.peek() == Some('\n') {
-            self.advance();
-        }
+        let bytes = self.source.as_bytes();
+        self.position = next_line_start(bytes, self.position);
 
         // Fast path: when the opening fence has no indentation, the body
         // lines need no indent stripping — we can find the closing fence
@@ -170,8 +162,8 @@ impl<'a> Parser<'a> {
                     if closing_fence_len >= fence_len {
                         // Skip rest of line
                         while let Some(ch) = self.peek() {
-                            if ch == '\n' {
-                                self.advance();
+                            if matches!(ch, '\n' | '\r') {
+                                self.position = next_line_start(bytes, self.position);
                                 break;
                             }
                             self.advance();
@@ -185,7 +177,7 @@ impl<'a> Parser<'a> {
                 let next_line = self.next_line_start(line_start);
                 let stripped = Self::strip_indent_columns(line, opening_indent);
                 value.push_str(stripped);
-                if self.source.as_bytes().get(line_start + line.len()) == Some(&b'\n') {
+                if line_start + line.len() < bytes.len() {
                     value.push('\n');
                 }
                 self.position = next_line;

--- a/crates/ox_content_parser/src/parser/footnote.rs
+++ b/crates/ox_content_parser/src/parser/footnote.rs
@@ -17,6 +17,7 @@ use ox_content_ast::{FootnoteDefinition, Node, Span};
 use rustc_hash::FxHashSet;
 
 use super::Parser;
+use super::line_scan::{line_end, next_line_start};
 use super::spans::SourceMap;
 use crate::error::ParseResult;
 #[allow(unused_imports)]
@@ -44,7 +45,7 @@ pub(super) fn parse_footnote_opener(text: &str) -> Option<(&str, usize)> {
     loop {
         match bytes.get(j)? {
             b']' => break,
-            b'[' | b'\n' => return None,
+            b'[' | b'\n' | b'\r' => return None,
             byte if byte.is_ascii_whitespace() => return None,
             _ => j += 1,
         }
@@ -66,20 +67,19 @@ pub(super) fn normalize_footnote_label(label: &str) -> CompactString {
 /// the remainder of the opening line plus indented continuation lines.
 fn definition_body_len(source: &str, content_start: usize) -> usize {
     let bytes = source.as_bytes();
-    let mut cursor = memchr::memchr(b'\n', &bytes[content_start..])
-        .map_or(source.len(), |offset| content_start + offset + 1);
+    let mut cursor = next_line_start(bytes, content_start);
     // Trailing blank lines only belong to the definition when an indented
     // line follows, so remember where the last real content ended.
     let mut end = cursor;
 
     while cursor < source.len() {
-        let line_end =
-            memchr::memchr(b'\n', &bytes[cursor..]).map_or(source.len(), |o| cursor + o + 1);
-        let line = &source[cursor..line_end];
+        let current_line_end = line_end(bytes, cursor);
+        let next_line = next_line_start(bytes, cursor);
+        let line = &source[cursor..current_line_end];
         let trimmed = line.trim_start_matches([' ', '\t']);
 
         if trimmed.trim_end().is_empty() {
-            cursor = line_end;
+            cursor = next_line;
             continue;
         }
         // Four columns of indent continue the definition; anything less
@@ -87,8 +87,8 @@ fn definition_body_len(source: &str, content_start: usize) -> usize {
         if indent_columns(line) < 4 {
             break;
         }
-        cursor = line_end;
-        end = line_end;
+        cursor = next_line;
+        end = next_line;
     }
 
     end - content_start
@@ -122,21 +122,30 @@ fn dedent_body<'a>(
     // dedented copy lives as long as the AST that borrows from it.
     let mut out = ox_content_allocator::String::with_capacity_in(body.len(), allocator.bump());
     let mut source_map = SourceMap::default();
-    let mut generated_start = 0usize;
-    let mut source_line_start = source_offset;
+    let bytes = body.as_bytes();
+    let mut line_start = 0usize;
+    let mut index = 0usize;
 
-    for (index, line) in body.split_inclusive('\n').enumerate() {
+    while line_start < body.len() {
+        let current_line_end = line_end(bytes, line_start);
+        let next_line = next_line_start(bytes, line_start);
+        let line = &body[line_start..current_line_end];
         let consumed = if index == 0 { first_line_indent_len(line) } else { dedent_len(line) };
         let dedented = &line[consumed..];
+        let generated_start = out.len();
         out.push_str(dedented);
+        if current_line_end < body.len() {
+            out.push('\n');
+        }
         source_map.push_line(
             generated_start,
-            dedented.len(),
-            source_line_start + consumed,
-            dedented.len(),
+            dedented.len() + usize::from(current_line_end < body.len()),
+            source_offset + line_start + consumed,
+            current_line_end.saturating_sub(line_start + consumed)
+                + next_line.saturating_sub(current_line_end),
         );
-        generated_start += dedented.len();
-        source_line_start += line.len();
+        line_start = next_line;
+        index += 1;
     }
 
     DedentedBody { text: out.into_bump_str(), source_map }

--- a/crates/ox_content_parser/src/parser/html.rs
+++ b/crates/ox_content_parser/src/parser/html.rs
@@ -2,6 +2,7 @@ use memchr::{memchr, memmem};
 use ox_content_ast::{Html, Node, Span};
 
 use super::Parser;
+use super::line_scan::{line_end, next_line_start};
 use crate::error::ParseResult;
 #[allow(unused_imports)]
 use crate::profile_span;
@@ -74,16 +75,19 @@ impl<'a> Parser<'a> {
     /// check unless it actually starts with whitespace.
     fn advance_html_block_until_blank(&mut self) {
         let bytes = self.source.as_bytes();
-        let start = self.position;
-        let mut line_start = start;
+        let mut line_start = self.position;
 
-        for newline_off in memchr::memchr_iter(b'\n', &bytes[start..]) {
-            let newline = start + newline_off;
-            if is_blank_line(&bytes[line_start..newline]) {
+        while line_start < bytes.len() {
+            let current_line_end = line_end(bytes, line_start);
+            if is_blank_line(&bytes[line_start..current_line_end]) {
                 self.position = line_start;
                 return;
             }
-            line_start = newline + 1;
+            let next_line = next_line_start(bytes, line_start);
+            if next_line == line_start {
+                break;
+            }
+            line_start = next_line;
         }
 
         // Trailing line without a newline: a whitespace-only remainder
@@ -126,5 +130,5 @@ fn is_blank_line(line: &[u8]) -> bool {
 /// Byte offset just past the newline of the line containing `at` (or EOF).
 #[inline]
 fn end_of_line_after(bytes: &[u8], at: usize) -> usize {
-    memchr(b'\n', &bytes[at..]).map_or(bytes.len(), |off| at + off + 1)
+    next_line_start(bytes, at)
 }

--- a/crates/ox_content_parser/src/parser/inline.rs
+++ b/crates/ox_content_parser/src/parser/inline.rs
@@ -21,6 +21,7 @@ mod smart_punctuation;
 
 use self::marker_scan::InlineMarkerScan;
 use self::script_span::same_marker_neighbor;
+use super::line_scan::{is_line_ending_byte, line_terminator_end};
 
 pub(in crate::parser) use self::autolink::autolink_end;
 pub(in crate::parser) use self::link_target::{
@@ -146,16 +147,19 @@ impl<'a> Parser<'a> {
     ) -> ParseResult<()> {
         let bytes = content.as_bytes();
         match bytes[*pos] {
-            b'\\' if *pos + 1 < content.len() && bytes[*pos + 1] == b'\n' => {
-                let span = Span::new((offset + *pos) as u32, (offset + *pos + 2) as u32);
+            b'\\' if *pos + 1 < content.len() && is_line_ending_byte(bytes[*pos + 1]) => {
+                let end = line_terminator_end(bytes, *pos + 1);
+                let span = Span::new((offset + *pos) as u32, (offset + end) as u32);
                 children.push(Node::Break(ox_content_ast::Break { span }));
-                *pos += 2;
+                *pos = end;
                 // Leading whitespace of the next line is not content.
                 while *pos < content.len() && matches!(bytes[*pos], b' ' | b'\t') {
                     *pos += 1;
                 }
             }
-            b'\n' => Self::parse_line_break(content, offset, children, pos),
+            byte if is_line_ending_byte(byte) => {
+                Self::parse_line_break(content, offset, children, pos)
+            }
             b'&' => {
                 profile_span_detail!("parser::inline_entity");
                 // Entity / numeric character references decode to literal

--- a/crates/ox_content_parser/src/parser/inline.rs
+++ b/crates/ox_content_parser/src/parser/inline.rs
@@ -158,7 +158,7 @@ impl<'a> Parser<'a> {
                 }
             }
             byte if is_line_ending_byte(byte) => {
-                Self::parse_line_break(content, offset, children, pos)
+                Self::parse_line_break(content, offset, children, pos);
             }
             b'&' => {
                 profile_span_detail!("parser::inline_entity");

--- a/crates/ox_content_parser/src/parser/inline/code_span.rs
+++ b/crates/ox_content_parser/src/parser/inline/code_span.rs
@@ -5,11 +5,12 @@
 //! few inline constructs that can be skipped over in bulk rather than
 //! walked byte by byte.
 
-use memchr::memchr2;
+use memchr::memchr3;
 use ox_content_allocator::Vec;
 use ox_content_ast::{Node, Span};
 
 use super::super::Parser;
+use super::super::line_scan::{is_line_ending_byte, line_terminator_end};
 #[allow(unused_imports)]
 use crate::profile_span_detail;
 
@@ -28,18 +29,18 @@ impl<'a> Parser<'a> {
 
         // The closer is the next backtick run of exactly the opener's
         // length (CommonMark "Code spans"). memchr jumps between runs, and
-        // searching for the newline in the same pass answers the question
+        // searching for the line ending in the same pass answers the question
         // `normalize_code_span` would otherwise re-scan the whole span for.
         let mut cursor = code_start;
         let mut has_newline = false;
         while cursor < bytes.len() {
-            let Some(off) = memchr2(b'`', b'\n', &bytes[cursor..]) else {
+            let Some(off) = memchr3(b'`', b'\n', b'\r', &bytes[cursor..]) else {
                 break;
             };
             cursor += off;
-            if bytes[cursor] == b'\n' {
+            if is_line_ending_byte(bytes[cursor]) {
                 has_newline = true;
-                cursor += 1;
+                cursor = line_terminator_end(bytes, cursor);
                 continue;
             }
             let run = Self::marker_run_len(bytes, cursor, b'`');
@@ -70,8 +71,21 @@ impl<'a> Parser<'a> {
     fn normalize_code_span(&self, raw: &'a str, has_newline: bool) -> &'a str {
         let value: &'a str = if has_newline {
             let mut converted = self.allocator.new_string();
+            let mut skip_lf = false;
             for ch in raw.chars() {
-                converted.push(if ch == '\n' { ' ' } else { ch });
+                if skip_lf && ch == '\n' {
+                    skip_lf = false;
+                    continue;
+                }
+                skip_lf = false;
+                if ch == '\r' {
+                    converted.push(' ');
+                    skip_lf = true;
+                } else if ch == '\n' {
+                    converted.push(' ');
+                } else {
+                    converted.push(ch);
+                }
             }
             converted.into_bump_str()
         } else {

--- a/crates/ox_content_parser/src/parser/inline/line_break.rs
+++ b/crates/ox_content_parser/src/parser/inline/line_break.rs
@@ -1,6 +1,7 @@
 use ox_content_allocator::Vec;
 use ox_content_ast::{Node, Span};
 
+use super::super::line_scan::line_terminator_end;
 use super::Parser;
 #[allow(unused_imports)]
 use crate::profile_span_detail;
@@ -35,12 +36,13 @@ impl<'a> Parser<'a> {
         }
 
         let newline_pos = *pos;
-        *pos += 1;
+        let newline_end = line_terminator_end(bytes, newline_pos);
+        *pos = newline_end;
         while *pos < content.len() && matches!(bytes[*pos], b' ' | b'\t') {
             *pos += 1;
         }
 
-        let span = Span::new((offset + newline_pos) as u32, (offset + newline_pos + 1) as u32);
+        let span = Span::new((offset + newline_pos) as u32, (offset + newline_end) as u32);
         if hard {
             children.push(Node::Break(ox_content_ast::Break { span }));
         } else {

--- a/crates/ox_content_parser/src/parser/inline/scan.rs
+++ b/crates/ox_content_parser/src/parser/inline/scan.rs
@@ -35,6 +35,7 @@ static INLINE_SPECIAL: [u8; 256] = {
     t[b'\\' as usize] = 1;
     t[b'<' as usize] = 1;
     t[b'\n' as usize] = 1;
+    t[b'\r' as usize] = 1;
     t[b'&' as usize] = 1;
     t
 };
@@ -48,7 +49,7 @@ const SHORT_RUN_PREFIX: usize = 8;
 /// Nibble-pair classifier tables for the vectorized paths.
 ///
 /// A byte is special iff `LOW[b & 0x0F] & HIGH[b >> 4]` is nonzero. The ten
-/// markers fall into six (high nibble, low-nibble set) groups — `\n`;
+/// markers fall into six (high nibble, low-nibble set) groups — line endings;
 /// `!`/`&`/`*`; `<`; `[`/`\`/`_`; `` ` ``; `~` — and each group owns one
 /// bit, so the AND is exact: it admits no byte outside the set, and every
 /// byte >= 0x80 maps to a zero high-nibble entry.
@@ -58,7 +59,7 @@ const SHORT_RUN_PREFIX: usize = 8;
 /// instruction, where the flag table needs sixteen loads.
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 const LOW_NIBBLE: [u8; 16] =
-    [0x10, 0x02, 0, 0, 0, 0, 0x02, 0, 0, 0, 0x03, 0x08, 0x0C, 0, 0x20, 0x08];
+    [0x10, 0x02, 0, 0, 0, 0, 0x02, 0, 0, 0, 0x03, 0x08, 0x0C, 0x01, 0x20, 0x08];
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 const HIGH_NIBBLE: [u8; 16] = [0x01, 0, 0x02, 0x04, 0, 0x08, 0x10, 0x20, 0, 0, 0, 0, 0, 0, 0, 0];
 

--- a/crates/ox_content_parser/src/parser/leaf.rs
+++ b/crates/ox_content_parser/src/parser/leaf.rs
@@ -1,7 +1,7 @@
-use memchr::memchr;
 use ox_content_ast::{Node, Span};
 
 use super::Parser;
+use super::line_scan::{line_end, next_line_start};
 use crate::error::ParseResult;
 #[allow(unused_imports)]
 use crate::profile_span;
@@ -99,9 +99,8 @@ impl<'a> Parser<'a> {
         let content_start = self.position;
         // The heading content runs to the end of the line; find it in one
         // memchr scan rather than a per-char peek/advance walk.
-        let content_end = memchr(b'\n', &bytes[content_start..])
-            .map_or(self.source.len(), |off| content_start + off);
-        self.position = content_end;
+        let content_end = line_end(bytes, content_start);
+        self.position = next_line_start(bytes, content_start);
 
         // A closing hash sequence only counts when preceded by a space or
         // tab (or when the heading is nothing but hashes); an escaped
@@ -117,11 +116,6 @@ impl<'a> Parser<'a> {
         } else {
             line
         };
-
-        // Consume newline
-        if self.peek() == Some('\n') {
-            self.advance();
-        }
 
         let span = Span::new(start as u32, self.position as u32);
 
@@ -166,5 +160,5 @@ fn is_atx_heading_prefix(bytes: &[u8]) -> bool {
     if hashes == 0 {
         return false;
     }
-    matches!(bytes.get(hashes), None | Some(b' ' | b'\t' | b'\n'))
+    matches!(bytes.get(hashes), None | Some(b' ' | b'\t' | b'\n' | b'\r'))
 }

--- a/crates/ox_content_parser/src/parser/line_scan.rs
+++ b/crates/ox_content_parser/src/parser/line_scan.rs
@@ -258,19 +258,19 @@ mod tests {
 
     #[test]
     fn recognizes_crlf_and_lone_cr_line_endings() {
-        for (source, expected) in [
-            ("a\r\nb\nc\rd", Vec::from(["a", "b", "c", "d"])),
-            ("\r\n\n\r", Vec::from(["", "", ""])),
-        ] {
+        for (source, expected) in
+            [("a\r\nb\nc\rd", &["a", "b", "c", "d"][..]), ("\r\n\n\r", &["", "", ""][..])]
+        {
             let bytes = source.as_bytes();
             let mut pos = 0;
-            let mut lines = Vec::new();
+            let mut line_index = 0;
             while pos < bytes.len() {
                 let end = line_end(bytes, pos);
-                lines.push(&source[pos..end]);
+                assert_eq!(&source[pos..end], expected[line_index]);
+                line_index += 1;
                 pos = next_line_start(bytes, pos);
             }
-            assert_eq!(lines, expected);
+            assert_eq!(line_index, expected.len());
         }
     }
 }

--- a/crates/ox_content_parser/src/parser/line_scan.rs
+++ b/crates/ox_content_parser/src/parser/line_scan.rs
@@ -21,6 +21,7 @@
 const ONES: u64 = 0x0101_0101_0101_0101;
 const HIGH: u64 = 0x8080_8080_8080_8080;
 const NEWLINES: u64 = (b'\n' as u64) * ONES;
+const RETURNS: u64 = (b'\r' as u64) * ONES;
 
 /// Sets `0x80` in every byte lane of `word` that is zero.
 ///
@@ -33,8 +34,8 @@ const fn has_zero(word: u64) -> u64 {
     word.wrapping_sub(ONES) & !word & HIGH
 }
 
-/// Byte offset of the newline ending the line that starts at `from`, or
-/// `bytes.len()` when the last line is unterminated.
+/// Byte offset of the line terminator that starts at `from`, or `bytes.len()`
+/// when the last line is unterminated.
 #[inline]
 pub(in crate::parser) fn line_end(bytes: &[u8], from: usize) -> usize {
     #[cfg(target_arch = "aarch64")]
@@ -58,8 +59,9 @@ fn line_end_neon(bytes: &[u8], from: usize) -> usize {
     let mut i = from;
     unsafe {
         let nl = vdupq_n_u8(b'\n');
+        let cr = vdupq_n_u8(b'\r');
         let classify = |v: uint8x16_t| {
-            let m = vceqq_u8(v, nl);
+            let m = vorrq_u8(vceqq_u8(v, nl), vceqq_u8(v, cr));
             vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(m), 4)), 0)
         };
         while i + 32 <= end {
@@ -92,7 +94,7 @@ fn line_end_neon(bytes: &[u8], from: usize) -> usize {
             return end;
         }
     }
-    while i < end && bytes[i] != b'\n' {
+    while i < end && !is_line_ending_byte(bytes[i]) {
         i += 1;
     }
     i
@@ -106,25 +108,42 @@ fn line_end_swar(bytes: &[u8], from: usize) -> usize {
 
     while i + 8 <= end {
         let word = u64::from_le_bytes(copy_eight(bytes, i));
-        let mask = has_zero(word ^ NEWLINES);
+        let mask = has_zero(word ^ NEWLINES) | has_zero(word ^ RETURNS);
         if mask != 0 {
             return i + (mask.trailing_zeros() / 8) as usize;
         }
         i += 8;
     }
 
-    while i < end && bytes[i] != b'\n' {
+    while i < end && !is_line_ending_byte(bytes[i]) {
         i += 1;
     }
     i
 }
 
-/// Byte offset of the next line's start — just past the newline, or `bytes.len()`
-/// at end of input.
+/// Byte offset of the next line's start — just past LF, CRLF, or CR, or
+/// `bytes.len()` at end of input.
 #[inline]
 pub(in crate::parser) fn next_line_start(bytes: &[u8], from: usize) -> usize {
     let end = line_end(bytes, from);
-    if end < bytes.len() { end + 1 } else { end }
+    line_terminator_end(bytes, end)
+}
+
+#[inline]
+pub(in crate::parser) fn line_terminator_end(bytes: &[u8], line_end: usize) -> usize {
+    if line_end >= bytes.len() {
+        return line_end;
+    }
+    if bytes[line_end] == b'\r' && bytes.get(line_end + 1) == Some(&b'\n') {
+        line_end + 2
+    } else {
+        line_end + 1
+    }
+}
+
+#[inline]
+pub(in crate::parser) fn is_line_ending_byte(byte: u8) -> bool {
+    matches!(byte, b'\n' | b'\r')
 }
 
 #[inline]
@@ -149,13 +168,13 @@ mod tests {
                 let bytes = &buffer[..len];
                 for from in 0..=len {
                     let expected =
-                        memchr::memchr(b'\n', &bytes[from..]).map_or(len, |off| from + off);
+                        memchr::memchr2(b'\n', b'\r', &bytes[from..]).map_or(len, |off| from + off);
                     assert_eq!(
                         line_end(bytes, from),
                         expected,
                         "len {len}, newline at {newline_at}, from {from}"
                     );
-                    let expected_start = if expected < len { expected + 1 } else { expected };
+                    let expected_start = line_terminator_end(bytes, expected);
                     assert_eq!(next_line_start(bytes, from), expected_start);
                 }
             }
@@ -183,7 +202,7 @@ mod tests {
                 let mut buffer = [filler; 40];
                 buffer[lead] = b'\n';
                 let bytes = &buffer[..];
-                let expected = memchr::memchr(b'\n', bytes).unwrap_or(bytes.len());
+                let expected = memchr::memchr2(b'\n', b'\r', bytes).unwrap_or(bytes.len());
                 assert_eq!(line_end(bytes, 0), expected, "filler {filler:#x}, newline at {lead}");
             }
         }
@@ -200,7 +219,7 @@ mod tests {
                 let bytes = &buffer[..len];
                 for from in 0..=len {
                     let expected =
-                        memchr::memchr(b'\n', &bytes[from..]).map_or(len, |off| from + off);
+                        memchr::memchr2(b'\n', b'\r', &bytes[from..]).map_or(len, |off| from + off);
                     assert_eq!(
                         line_end(bytes, from),
                         expected,
@@ -226,14 +245,32 @@ mod tests {
         let mut expected_pos = 0;
         let mut lines = 0;
         while expected_pos < bytes.len() {
-            let expected = memchr::memchr(b'\n', &bytes[expected_pos..])
+            let expected = memchr::memchr2(b'\n', b'\r', &bytes[expected_pos..])
                 .map_or(bytes.len(), |off| expected_pos + off);
             assert_eq!(line_end(bytes, pos), expected, "line {lines}");
             pos = next_line_start(bytes, pos);
-            expected_pos = if expected < bytes.len() { expected + 1 } else { expected };
+            expected_pos = line_terminator_end(bytes, expected);
             assert_eq!(pos, expected_pos, "line {lines}");
             lines += 1;
         }
         assert_eq!(lines, 6);
+    }
+
+    #[test]
+    fn recognizes_crlf_and_lone_cr_line_endings() {
+        for (source, expected) in [
+            ("a\r\nb\nc\rd", Vec::from(["a", "b", "c", "d"])),
+            ("\r\n\n\r", Vec::from(["", "", ""])),
+        ] {
+            let bytes = source.as_bytes();
+            let mut pos = 0;
+            let mut lines = Vec::new();
+            while pos < bytes.len() {
+                let end = line_end(bytes, pos);
+                lines.push(&source[pos..end]);
+                pos = next_line_start(bytes, pos);
+            }
+            assert_eq!(lines, expected);
+        }
     }
 }

--- a/crates/ox_content_parser/src/parser/math.rs
+++ b/crates/ox_content_parser/src/parser/math.rs
@@ -5,6 +5,7 @@ use ox_content_allocator::Vec;
 use ox_content_ast::{InlineMath, MathBlock, Node, Span};
 
 use super::Parser;
+use super::line_scan::{is_line_ending_byte, next_line_start};
 use crate::error::ParseResult;
 #[allow(unused_imports)]
 use crate::profile_span_detail;
@@ -32,8 +33,7 @@ impl<'a> Parser<'a> {
             return self.parse_paragraph(start, None);
         };
         let close_end = close + 2;
-        let line_end = line_end_after(self.source.as_bytes(), close_end);
-        self.position = if line_end < self.source.len() { line_end + 1 } else { line_end };
+        self.position = next_line_start(self.source.as_bytes(), close_end);
         let value = &self.source[open + 2..close];
         Ok(Some(Node::MathBlock(
             self.allocator
@@ -179,10 +179,13 @@ fn is_escaped_marker(bytes: &[u8], pos: usize) -> bool {
 }
 
 fn is_line_end(bytes: &[u8], index: usize) -> bool {
-    index >= bytes.len()
-        || bytes[index..].iter().take_while(|byte| **byte != b'\n').all(u8::is_ascii_whitespace)
-}
-
-fn line_end_after(bytes: &[u8], index: usize) -> usize {
-    memchr(b'\n', &bytes[index..]).map_or(bytes.len(), |relative| index + relative)
+    let mut cursor = index;
+    while let Some(&byte) = bytes.get(cursor) {
+        match byte {
+            b' ' | b'\t' => cursor += 1,
+            byte if is_line_ending_byte(byte) => return true,
+            _ => return false,
+        }
+    }
+    true
 }

--- a/crates/ox_content_parser/src/parser/mdx_esm.rs
+++ b/crates/ox_content_parser/src/parser/mdx_esm.rs
@@ -10,6 +10,7 @@
 use ox_content_ast::{MdxjsEsm, Node, Span};
 
 use super::Parser;
+use super::line_scan::{is_line_ending_byte, line_terminator_end};
 
 #[inline]
 pub(super) fn looks_like_esm(bytes: &[u8], at: usize) -> bool {
@@ -104,7 +105,9 @@ fn scan_esm_statement(source: &str, start: usize) -> usize {
                 b';' if brace == 0 && paren == 0 && bracket == 0 => {
                     return after_trailing_line_ws(bytes, i + 1);
                 }
-                b'\n' if brace == 0 && paren == 0 && bracket == 0 => return i + 1,
+                b if is_line_ending_byte(b) && brace == 0 && paren == 0 && bracket == 0 => {
+                    return line_terminator_end(bytes, i);
+                }
                 _ => i += 1,
             },
             Scan::Squote => {
@@ -138,9 +141,9 @@ fn scan_esm_statement(source: &str, start: usize) -> usize {
                 }
             }
             Scan::LineComment => {
-                if b == b'\n' {
+                if is_line_ending_byte(b) {
                     if brace == 0 && paren == 0 && bracket == 0 {
-                        return i + 1;
+                        return line_terminator_end(bytes, i);
                     }
                     state = Scan::Normal;
                 }
@@ -160,10 +163,14 @@ fn scan_esm_statement(source: &str, start: usize) -> usize {
 }
 
 fn after_trailing_line_ws(bytes: &[u8], mut cursor: usize) -> usize {
-    while cursor < bytes.len() && matches!(bytes[cursor], b' ' | b'\t' | b'\r') {
+    while cursor < bytes.len() && matches!(bytes[cursor], b' ' | b'\t') {
         cursor += 1;
     }
-    if cursor < bytes.len() && bytes[cursor] == b'\n' { cursor + 1 } else { cursor }
+    if cursor < bytes.len() && is_line_ending_byte(bytes[cursor]) {
+        line_terminator_end(bytes, cursor)
+    } else {
+        cursor
+    }
 }
 
 impl<'a> Parser<'a> {

--- a/crates/ox_content_parser/src/parser/mdx_jsx/braces.rs
+++ b/crates/ox_content_parser/src/parser/mdx_jsx/braces.rs
@@ -79,7 +79,7 @@ pub(super) fn skip_backticks(bytes: &[u8], start: usize) -> Option<usize> {
 
 fn skip_line_comment(bytes: &[u8], start: usize) -> usize {
     let mut cursor = start + 2;
-    while cursor < bytes.len() && bytes[cursor] != b'\n' {
+    while cursor < bytes.len() && !matches!(bytes[cursor], b'\n' | b'\r') {
         cursor += 1;
     }
     cursor

--- a/crates/ox_content_parser/src/parser/mdx_jsx/children.rs
+++ b/crates/ox_content_parser/src/parser/mdx_jsx/children.rs
@@ -1,6 +1,7 @@
-use memchr::memchr;
 use ox_content_allocator::{Allocator, Vec};
 use ox_content_ast::{Node, Span};
+
+use super::super::line_scan::{line_end, next_line_start};
 
 pub(super) struct JsxChildSource<'a> {
     pub source: &'a str,
@@ -191,10 +192,7 @@ fn common_line_indent(source: &str) -> usize {
 }
 
 fn line_bounds(bytes: &[u8], line_start: usize) -> (usize, usize) {
-    let line_end =
-        memchr(b'\n', &bytes[line_start..]).map_or(bytes.len(), |offset| line_start + offset);
-    let next_line = if line_end < bytes.len() { line_end + 1 } else { line_end };
-    (line_end, next_line)
+    (line_end(bytes, line_start), next_line_start(bytes, line_start))
 }
 
 fn first_non_whitespace(bytes: &[u8], line_start: usize, line_end: usize) -> Option<usize> {

--- a/crates/ox_content_parser/src/parser/mdx_jsx/scan.rs
+++ b/crates/ox_content_parser/src/parser/mdx_jsx/scan.rs
@@ -6,6 +6,7 @@ use ox_content_ast::{
     MdxJsxExpressionAttribute, Span,
 };
 
+use super::super::line_scan::{is_line_ending_byte, line_terminator_end};
 use super::braces::{skip_backticks, skip_braces, skip_quoted};
 
 /// Opening tag accepted by this slice.
@@ -36,8 +37,8 @@ pub(super) fn looks_like_jsx_open(bytes: &[u8], at: usize) -> bool {
 pub(super) fn only_ws_until_eol(bytes: &[u8], mut cursor: usize) -> bool {
     while cursor < bytes.len() {
         match bytes[cursor] {
-            b' ' | b'\t' | b'\r' => cursor += 1,
-            b'\n' => return true,
+            b' ' | b'\t' => cursor += 1,
+            byte if is_line_ending_byte(byte) => return true,
             _ => return false,
         }
     }
@@ -45,10 +46,14 @@ pub(super) fn only_ws_until_eol(bytes: &[u8], mut cursor: usize) -> bool {
 }
 
 pub(super) fn after_trailing_line_ws(bytes: &[u8], mut cursor: usize) -> usize {
-    while cursor < bytes.len() && matches!(bytes[cursor], b' ' | b'\t' | b'\r') {
+    while cursor < bytes.len() && matches!(bytes[cursor], b' ' | b'\t') {
         cursor += 1;
     }
-    if cursor < bytes.len() && bytes[cursor] == b'\n' { cursor + 1 } else { cursor }
+    if cursor < bytes.len() && is_line_ending_byte(bytes[cursor]) {
+        line_terminator_end(bytes, cursor)
+    } else {
+        cursor
+    }
 }
 
 pub(super) fn scan_jsx_open<'a>(

--- a/crates/ox_content_parser/src/parser/prepass.rs
+++ b/crates/ox_content_parser/src/parser/prepass.rs
@@ -17,11 +17,11 @@
 use std::rc::Rc;
 use std::sync::LazyLock;
 
-use memchr::{memchr, memmem, memrchr};
+use memchr::{memchr, memmem, memrchr2};
 
 use super::Parser;
 use super::footnote::{FootnoteLabels, normalize_footnote_label, parse_footnote_opener};
-use super::line_scan::{line_end as scan_line_end, next_line_start};
+use super::line_scan::{line_end as scan_line_end, line_terminator_end, next_line_start};
 use super::reference::{
     ReferenceDef, ReferenceMap, closes_paragraph_context, fence_open, is_fence_close,
     strip_quote_markers,
@@ -49,7 +49,7 @@ fn next_fence_run_line(bytes: &[u8], from: usize, fence_byte: u8) -> Option<usiz
     let finder = if fence_byte == b'`' { &*BACKTICK_RUN } else { &*TILDE_RUN };
     let at = from + finder.find(&bytes[from..])?;
     // `from` is a line start, so the match's line starts at or after it.
-    Some(memrchr(b'\n', &bytes[from..at]).map_or(from, |off| from + off + 1))
+    Some(memrchr2(b'\n', b'\r', &bytes[from..at]).map_or(from, |off| from + off + 1))
 }
 
 /// Whether the source contains the minimum shape of a definition opener.
@@ -70,14 +70,14 @@ fn has_definition_candidate(source: &str, footnotes: bool) -> bool {
         return false;
     }
 
-    let mut line_start = memrchr(b'\n', &bytes[..open]).map_or(0, |off| off + 1);
+    let mut line_start = previous_line_start(bytes, open);
     loop {
         let prefix = strip_quote_markers(&source[line_start..open]);
         if prefix.len() <= 3 && prefix.as_bytes().iter().all(|&byte| byte == b' ') {
             let candidate_end = if footnotes && bytes.get(open + 1) == Some(&b'^') {
                 // Footnote labels cannot span lines, but unlike reference
                 // labels their parser deliberately has no length cap.
-                memchr(b'\n', &bytes[open + 2..]).map_or(bytes.len(), |off| open + 2 + off)
+                scan_line_end(bytes, open + 2)
             } else {
                 // label_start..=closing bracket spans at most 1,001 bytes,
                 // with one final byte needed for the colon after it.
@@ -93,10 +93,14 @@ fn has_definition_candidate(source: &str, footnotes: bool) -> bool {
             return false;
         };
         open = search_start + next;
-        if let Some(newline) = memrchr(b'\n', &bytes[search_start..open]) {
-            line_start = search_start + newline + 1;
+        if memrchr2(b'\n', b'\r', &bytes[search_start..open]).is_some() {
+            line_start = previous_line_start(bytes, open);
         }
     }
+}
+
+fn previous_line_start(bytes: &[u8], before: usize) -> usize {
+    memrchr2(b'\n', b'\r', &bytes[..before]).map_or(0, |off| off + 1)
 }
 
 impl<'a> Parser<'a> {
@@ -133,11 +137,11 @@ impl<'a> Parser<'a> {
 
             // Blank line: closes any open paragraph and is invisible to
             // both fence trackers and both collectors.
-            if first == b'\n' {
+            if matches!(first, b'\n' | b'\r') {
                 if def_fence.is_none() {
                     paragraph_open = false;
                 }
-                pos += 1;
+                pos = line_terminator_end(bytes, pos);
                 continue;
             }
 
@@ -182,7 +186,7 @@ impl<'a> Parser<'a> {
             if let Some((fence_byte, fence_len)) = def_fence {
                 if is_fence_close(trimmed, fence_byte, fence_len) {
                     def_fence = None;
-                    pos = line_end + 1;
+                    pos = line_terminator_end(bytes, line_end);
                     continue;
                 }
                 // Nothing inside a fence is collected and `paragraph_open`
@@ -198,10 +202,10 @@ impl<'a> Parser<'a> {
                 // `[^` at all, so the skip still applies to almost every
                 // real document.
                 if collect_footnotes {
-                    pos = line_end + 1;
+                    pos = line_terminator_end(bytes, line_end);
                     continue;
                 }
-                match next_fence_run_line(bytes, line_end + 1, fence_byte) {
+                match next_fence_run_line(bytes, line_terminator_end(bytes, line_end), fence_byte) {
                     Some(next) => pos = next,
                     // An unterminated fence swallows the rest of the
                     // document, so there is nothing left to collect.
@@ -212,12 +216,12 @@ impl<'a> Parser<'a> {
             if let Some(open) = fence_open(trimmed) {
                 def_fence = Some(open);
                 paragraph_open = false;
-                pos = line_end + 1;
+                pos = line_terminator_end(bytes, line_end);
                 continue;
             }
             if trimmed.is_empty() {
                 paragraph_open = false;
-                pos = line_end + 1;
+                pos = line_terminator_end(bytes, line_end);
                 continue;
             }
 
@@ -242,7 +246,7 @@ impl<'a> Parser<'a> {
                     // it must still see the definition's continuation lines
                     // the reference side jumps over.
                     if collect_footnotes {
-                        let mut foot_pos = line_end + 1;
+                        let mut foot_pos = line_terminator_end(bytes, line_end);
                         while foot_pos < next_pos {
                             let foot_line_end = scan_line_end(bytes, foot_pos);
                             footnote_scan_line(
@@ -251,7 +255,7 @@ impl<'a> Parser<'a> {
                                 &mut foot_fence,
                                 &mut labels,
                             );
-                            foot_pos = foot_line_end + 1;
+                            foot_pos = line_terminator_end(bytes, foot_line_end);
                         }
                     }
                     pos = next_pos;
@@ -260,7 +264,7 @@ impl<'a> Parser<'a> {
             }
 
             paragraph_open = !closes_paragraph_context(trimmed);
-            pos = line_end + 1;
+            pos = line_terminator_end(bytes, line_end);
         }
 
         (

--- a/crates/ox_content_parser/src/parser/reference.rs
+++ b/crates/ox_content_parser/src/parser/reference.rs
@@ -14,6 +14,7 @@ use ox_content_ast::{Definition, Node, Span};
 use rustc_hash::FxHashMap;
 
 use super::Parser;
+use super::line_scan::{is_line_ending_byte, line_end as scan_line_end, line_terminator_end};
 #[allow(unused_imports)]
 use crate::{profile_span, profile_span_detail};
 
@@ -132,9 +133,9 @@ impl<'a> Parser<'a> {
             k += 1;
             ws_between = true;
         }
-        let title_on_next_line = bytes.get(k) == Some(&b'\n');
+        let title_on_next_line = bytes.get(k).is_some_and(|byte| is_line_ending_byte(*byte));
         if title_on_next_line {
-            k += 1;
+            k = line_terminator_end(bytes, k);
             ws_between = true;
             while matches!(bytes.get(k), Some(b' ' | b'\t')) {
                 k += 1;
@@ -218,7 +219,7 @@ impl<'a> Parser<'a> {
         let mut joined = self.allocator.new_string();
         let mut line_starts = self.allocator.new_vec();
         while pos < bytes.len() {
-            let line_end = memchr::memchr(b'\n', &bytes[pos..]).map_or(bytes.len(), |o| pos + o);
+            let line_end = scan_line_end(bytes, pos);
             let line = &self.source[pos..line_end];
             let stripped = strip_quote_markers(line);
             if stripped.trim().is_empty() {
@@ -227,7 +228,7 @@ impl<'a> Parser<'a> {
             line_starts.push(pos);
             joined.push_str(stripped);
             joined.push('\n');
-            pos = line_end + 1;
+            pos = line_terminator_end(bytes, line_end);
         }
         line_starts.push(pos.min(bytes.len()));
         (joined.into_bump_str(), line_starts)

--- a/crates/ox_content_parser/src/parser/reference/scan.rs
+++ b/crates/ox_content_parser/src/parser/reference/scan.rs
@@ -4,17 +4,19 @@
 //! locate line boundaries, strip block quote markers, and recognize the
 //! fence and paragraph-closing markers the collection pre-pass needs.
 
+use super::super::line_scan::{is_line_ending_byte, line_end, line_terminator_end};
+
 pub(super) fn skip_ws_one_newline(bytes: &[u8], mut i: usize) -> Option<usize> {
     let mut newlines = 0;
     while let Some(&byte) = bytes.get(i) {
         match byte {
             b' ' | b'\t' => i += 1,
-            b'\n' => {
+            byte if is_line_ending_byte(byte) => {
                 newlines += 1;
                 if newlines > 1 {
                     return None;
                 }
-                i += 1;
+                i = line_terminator_end(bytes, i);
             }
             _ => break,
         }
@@ -28,7 +30,7 @@ pub(super) fn line_end_if_blank_after(bytes: &[u8], mut i: usize) -> Option<usiz
     while let Some(&byte) = bytes.get(i) {
         match byte {
             b' ' | b'\t' => i += 1,
-            b'\n' => return Some(i + 1),
+            byte if is_line_ending_byte(byte) => return Some(line_terminator_end(bytes, i)),
             _ => return None,
         }
     }
@@ -37,11 +39,11 @@ pub(super) fn line_end_if_blank_after(bytes: &[u8], mut i: usize) -> Option<usiz
 
 pub(super) fn next_blank_line(bytes: &[u8], mut pos: usize) -> usize {
     while pos < bytes.len() {
-        let line_end = memchr::memchr(b'\n', &bytes[pos..]).map_or(bytes.len(), |o| pos + o);
+        let line_end = line_end(bytes, pos);
         if bytes[pos..line_end].iter().all(|byte| matches!(byte, b' ' | b'\t')) {
             return pos;
         }
-        pos = line_end + 1;
+        pos = line_terminator_end(bytes, line_end);
     }
     bytes.len()
 }

--- a/crates/ox_content_parser/src/parser/table.rs
+++ b/crates/ox_content_parser/src/parser/table.rs
@@ -3,6 +3,7 @@ use ox_content_allocator::Vec;
 use ox_content_ast::{AlignKind, Node, Span, Table, TableCell, TableRow};
 
 use super::Parser;
+use super::line_scan::{line_end, next_line_start};
 use crate::error::ParseResult;
 #[allow(unused_imports)]
 use crate::{profile_span, profile_span_detail};
@@ -18,15 +19,15 @@ impl<'a> Parser<'a> {
         profile_span_detail!("parser::table_probe");
         let bytes = self.source.as_bytes();
         let p0 = self.position;
-        let nl0 = match memchr(b'\n', &bytes[p0..]) {
-            Some(off) => p0 + off,
-            None => return false,
-        };
-        let p1 = nl0 + 1;
+        let nl0 = line_end(bytes, p0);
+        if nl0 == bytes.len() {
+            return false;
+        }
+        let p1 = next_line_start(bytes, p0);
         if p1 >= bytes.len() {
             return false;
         }
-        let nl1 = memchr(b'\n', &bytes[p1..]).map_or(bytes.len(), |off| p1 + off);
+        let nl1 = line_end(bytes, p1);
 
         let first_line = self.source[p0..nl0].trim();
         if memchr(b'|', first_line.as_bytes()).is_none() {

--- a/crates/ox_content_parser/tests/edge_cases/blocks.rs
+++ b/crates/ox_content_parser/tests/edge_cases/blocks.rs
@@ -46,6 +46,21 @@ fn thematic_break_accepts_spaces() {
 }
 
 #[test]
+fn crlf_and_lone_cr_parse_as_line_endings() {
+    for source in [
+        "Paragraph.\n\n---\n\nAfter.\n",
+        "Paragraph.\r\n\r\n---\r\n\r\nAfter.\r\n",
+        "Paragraph.\r\r---\r\rAfter.\r",
+    ] {
+        let allocator = Allocator::new();
+        let doc = parse_with_options(&allocator, source, ParserOptions::default());
+        assert!(matches!(&doc.children[0], Node::Paragraph(_)), "{source:?}");
+        assert!(matches!(&doc.children[1], Node::ThematicBreak(_)), "{source:?}");
+        assert!(matches!(&doc.children[2], Node::Paragraph(_)), "{source:?}");
+    }
+}
+
+#[test]
 fn mixed_thematic_break_is_not_recognized() {
     let allocator = Allocator::new();
     let doc = parse_with_options(&allocator, "- * -", ParserOptions::default());

--- a/crates/ox_content_parser/tests/edge_cases/prepass.rs
+++ b/crates/ox_content_parser/tests/edge_cases/prepass.rs
@@ -144,12 +144,9 @@ fn definition_without_trailing_newline_resolves() {
 }
 
 #[test]
-fn crlf_definition_does_not_resolve() {
-    // Parity pin, not an endorsement: the standalone passes never
-    // recognized definitions in CRLF sources (the trailing `\r` defeats
-    // the `]:` check and the `\r`-only blank line keeps the paragraph
-    // open), and the fused pass preserves that.
-    assert!(!resolves_reference("[a]\r\n\r\n[a]: /url"));
+fn crlf_definition_resolves() {
+    assert!(resolves_reference("[a]\r\n\r\n[a]: /url"));
+    assert!(resolves_reference("[a]\r\r[a]: /url"));
 }
 
 #[test]

--- a/crates/ox_content_renderer/tests/edge_blocks.rs
+++ b/crates/ox_content_renderer/tests/edge_blocks.rs
@@ -57,6 +57,17 @@ fn hard_breaks_render_inside_paragraphs() {
 }
 
 #[test]
+fn crlf_and_lone_cr_render_like_lf_line_endings() {
+    let lf = "Paragraph.\n\n---\n\nAfter.\n";
+    let expected = render(lf, ParserOptions::default(), HtmlRendererOptions::default());
+
+    for source in [lf.replace('\n', "\r\n"), lf.replace('\n', "\r")] {
+        let html = render(&source, ParserOptions::default(), HtmlRendererOptions::default());
+        assert_eq!(html, expected);
+    }
+}
+
+#[test]
 fn inline_raw_html_renders_without_extra_newline() {
     let html = render(
         "- <input type=\"checkbox\"> task",


### PR DESCRIPTION
## Triage
- Valid bug: CommonMark line endings are LF, CRLF, or CR, but several parser paths treated only LF as a line boundary.
- Scope kept to parser line-boundary handling and renderer parity coverage.

## Changes
- Recognize CRLF and lone CR in shared line scanning, block parsing, inline breaks/code spans, reference/footnote prepasses, math, tables, HTML, and MDX scanners.
- Preserve source spans by advancing over CRLF as one terminator without normalizing the input buffer.
- Replace the old CRLF reference-definition parity pin with positive coverage.

## Validation
- rtk cargo fmt --all -- --check
- rtk git diff --check
- rtk cargo test -p ox_content_parser line_scan
- rtk cargo test -p ox_content_parser --test edge_cases crlf
- rtk cargo test -p ox_content_parser
- rtk cargo test -p ox_content_renderer --test edge_blocks

Closes #1324.

Co-authored-by: Λlisue <546312+lambdalisue@users.noreply.github.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791344088&installation_model_id=422833&pr_number=1334&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1334&signature=985a9a9ff7fcdcc46e0a1c60926c72ecff919c9621eb13bee059d3b05320b2e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->