### PR TITLE
fix(types): publish virtual collections declarations

### DIFF
--- a/docs/content/built-in/collections.md
+++ b/docs/content/built-in/collections.md
@@ -87,6 +87,19 @@ const total = await queryCollection("content").count();
 The module also exports `getCollection(name)` (all entries as a plain array)
 and `collectionNames`.
 
+If a TypeScript program imports only the virtual module, include the package
+ambient declarations once in `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "types": ["@ox-content/vite-plugin"]
+  }
+}
+```
+
+No local `declare module "virtual:ox-content/collections"` shim is needed.
+
 ### Builder API
 
 | Method                                     | Behavior                                                     |

--- a/docs/content/ja/built-in/collections.md
+++ b/docs/content/ja/built-in/collections.md
@@ -76,6 +76,18 @@ const total = await queryCollection("content").count();
 
 モジュールは `getCollection(name)`（全エントリのプレーン配列）と `collectionNames` も export します。
 
+TypeScript プログラムが仮想モジュールだけを import する場合は、package の ambient declarations を一度 `tsconfig.json` で読ませます。
+
+```json
+{
+  "compilerOptions": {
+    "types": ["@ox-content/vite-plugin"]
+  }
+}
+```
+
+ローカルの `declare module "virtual:ox-content/collections"` shim は不要です。
+
 ### ビルダ API
 
 | メソッド                                   | 挙動                                              |

--- a/docs/content/ja/packages/vite-plugin-ox-content.md
+++ b/docs/content/ja/packages/vite-plugin-ox-content.md
@@ -593,6 +593,8 @@ const posts = await queryCollection("blog")
 const page = await queryCollection("docs").path("/docs/getting-started").first();
 ```
 
+アプリケーションのソースが `virtual:ox-content/collections` だけを import する場合は、TypeScript が公開済みの仮想モジュール宣言を読むように `compilerOptions` に `"types": ["@ox-content/vite-plugin"]` を足してください。
+
 大きなサイトでは `include` は意図して明示です。
 
 | フィールド | コスト                                              |

--- a/docs/content/packages/vite-plugin-ox-content.md
+++ b/docs/content/packages/vite-plugin-ox-content.md
@@ -608,6 +608,10 @@ const posts = await queryCollection("blog")
 const page = await queryCollection("docs").path("/docs/getting-started").first();
 ```
 
+When application source files import only `virtual:ox-content/collections`, add
+`"types": ["@ox-content/vite-plugin"]` to `compilerOptions` so TypeScript loads
+the published virtual module declarations.
+
 `include` is intentionally explicit for large sites:
 
 | Field  | Cost                                                   |

--- a/npm/vite-plugin-ox-content/package.json
+++ b/npm/vite-plugin-ox-content/package.json
@@ -175,7 +175,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "vp pack && node ../../tools/scripts/stabilize-public-declaration-exports.mjs @ox-content/vite-plugin && node scripts/build-reader-chrome-types.mjs && node scripts/build-standalone-entries.mjs && node scripts/build-reader-chrome-client.mjs && node scripts/build-theme-transition-client.mjs && node scripts/build-twitter-client.mjs && node scripts/copy-component-styles.mjs",
+    "build": "vp pack && node ../../tools/scripts/stabilize-public-declaration-exports.mjs @ox-content/vite-plugin && node ../../tools/scripts/write-vite-plugin-virtual-declarations.mjs && node scripts/build-reader-chrome-types.mjs && node scripts/build-standalone-entries.mjs && node scripts/build-reader-chrome-client.mjs && node scripts/build-theme-transition-client.mjs && node scripts/build-twitter-client.mjs && node scripts/copy-component-styles.mjs",
     "build:styles": "node scripts/copy-component-styles.mjs",
     "dev": "vp pack --watch",
     "typecheck": "tsgo --noEmit",

--- a/tools/scripts/package-dry-run-vite-plugin.mjs
+++ b/tools/scripts/package-dry-run-vite-plugin.mjs
@@ -1,3 +1,8 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 const publicValues = [
   "resolveGitLastmods",
   "resolveSelfHostedAssetManifest",
@@ -11,9 +16,16 @@ const publicTypes = [
   "WriteSelfHostedAssetsInput",
   "WriteSelfHostedAssetsResult",
 ];
-const virtualModules = ["virtual:ox-content/assets.css", "virtual:ox-content/asset-manifest"];
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const tscBin = join("node_modules", ".bin", process.platform === "win32" ? "tsc.cmd" : "tsc");
+const virtualReference = '/// <reference path="./virtual.d.ts" />';
+const virtualModules = [
+  "virtual:ox-content/collections",
+  "virtual:ox-content/assets.css",
+  "virtual:ox-content/asset-manifest",
+];
 
-export function checkVitePluginDeclarations({ pkg, tarball, failures, readPackedFile }) {
+export function checkVitePluginDeclarations({ pkg, tarball, packDir, failures, readPackedFile }) {
   for (const extension of ["mts", "cts"]) {
     const declaration = readPackedFile(tarball, `dist/index.d.${extension}`);
 
@@ -23,10 +35,166 @@ export function checkVitePluginDeclarations({ pkg, tarball, failures, readPacked
       }
     }
 
-    for (const moduleId of virtualModules) {
-      if (!declaration.includes(`declare module "${moduleId}"`)) {
-        failures.push(`${pkg.name} index.d.${extension} is missing ${moduleId}`);
-      }
+    if (!declaration.startsWith(virtualReference)) {
+      failures.push(`${pkg.name} index.d.${extension} is missing ${virtualReference}`);
     }
   }
+
+  const virtualDeclaration = readPackedFile(tarball, "dist/virtual.d.ts");
+  for (const moduleId of virtualModules) {
+    if (!virtualDeclaration.includes(`declare module "${moduleId}"`)) {
+      failures.push(`${pkg.name} virtual.d.ts is missing ${moduleId}`);
+    }
+  }
+  if (!virtualDeclaration.includes('import("@ox-content/vite-plugin").CollectionEntry')) {
+    failures.push(`${pkg.name} virtual.d.ts does not reference public collection types`);
+  }
+
+  for (const mode of ["bundler", "nodenext", "node16"]) {
+    checkVirtualCollectionsConsumer({ pkg, tarball, packDir, failures, mode });
+  }
+}
+
+function checkVirtualCollectionsConsumer({ pkg, tarball, packDir, failures, mode }) {
+  const consumerRoot = mkdtempSync(join(packDir, `vite-plugin-virtual-${mode}-`));
+  const packageRoot = join(consumerRoot, "node_modules", "@ox-content", "vite-plugin");
+  mkdirSync(packageRoot, { recursive: true });
+
+  const extract = spawnSync("tar", ["-xzf", tarball, "-C", packageRoot, "--strip-components=1"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (extract.error) throw extract.error;
+  if (extract.status !== 0) {
+    throw new Error(extract.stderr || `Failed to extract ${pkg.name} into ${consumerRoot}`);
+  }
+
+  for (const dependency of [
+    "@types/node",
+    "@ox-content/napi",
+    "glob",
+    "rehype-parse",
+    "rehype-stringify",
+    "unified",
+    "vite",
+  ]) {
+    linkPackageDependency(consumerRoot, "npm/vite-plugin-ox-content", dependency);
+  }
+
+  writeFileSync(join(consumerRoot, "package.json"), JSON.stringify({ type: "module" }));
+  writeFileSync(join(consumerRoot, "collections-fixture.ts"), collectionsFixture());
+  writeFileSync(join(consumerRoot, "collections-fixture.cts"), cjsCollectionsFixture());
+  writeFileSync(join(consumerRoot, "tsconfig.json"), tsconfig(mode));
+
+  const result = spawnSync(tscBin, ["-p", join(consumerRoot, "tsconfig.json")], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    failures.push(
+      `${pkg.name} virtual collections ${mode} consumer failed:\n${result.stdout}${result.stderr}`,
+    );
+  }
+}
+
+function linkPackageDependency(consumerRoot, packageDir, dependency) {
+  const source = resolve(root, packageDir, "node_modules", ...dependency.split("/"));
+  if (!existsSync(source)) return;
+  const target = join(consumerRoot, "node_modules", ...dependency.split("/"));
+  mkdirSync(dirname(target), { recursive: true });
+  try {
+    symlinkSync(source, target, "junction");
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+}
+
+function collectionsFixture() {
+  return [
+    'import api, { collectionNames, collections, getCollection, queryCollection } from "virtual:ox-content/collections";',
+    'import type { CollectionEntry, CollectionQueryBuilder } from "@ox-content/vite-plugin";',
+    "",
+    "interface PostEntry extends CollectionEntry {",
+    "  title: string;",
+    "  frontmatter: { draft?: boolean; rank: number };",
+    "}",
+    "",
+    'const rows: CollectionEntry[] = collections.content ?? getCollection("content");',
+    "const names: string[] = collectionNames;",
+    'const builder: CollectionQueryBuilder<PostEntry> = queryCollection<PostEntry>("blog")',
+    '  .path("/posts/hello")',
+    '  .where("frontmatter.rank", ">=", 1);',
+    'const selected = builder.select("title", "frontmatter");',
+    "async function useTypedQuery(): Promise<number> {",
+    "  const first = await selected.first();",
+    "  return first?.frontmatter.rank ?? 0;",
+    "}",
+    "",
+    "void api;",
+    "void names;",
+    "void rows;",
+    "void useTypedQuery;",
+  ].join("\n");
+}
+
+function cjsCollectionsFixture() {
+  return [
+    'import collectionsApi = require("virtual:ox-content/collections");',
+    'type CollectionEntry = import("@ox-content/vite-plugin").CollectionEntry;',
+    'type CollectionQueryBuilder<T extends CollectionEntry = CollectionEntry> = import("@ox-content/vite-plugin").CollectionQueryBuilder<T>;',
+    "",
+    "interface PostEntry extends CollectionEntry {",
+    "  title: string;",
+    "  frontmatter: { draft?: boolean; rank: number };",
+    "}",
+    "",
+    "const names: string[] = collectionsApi.collectionNames;",
+    'const builder: CollectionQueryBuilder<PostEntry> = collectionsApi.queryCollection<PostEntry>("blog");',
+    "async function useTypedQuery(): Promise<boolean> {",
+    '  const entries = await builder.where("frontmatter.draft", false).all();',
+    "  return entries.some((entry) => entry.frontmatter.draft === false);",
+    "}",
+    "",
+    "void collectionsApi.default;",
+    "void names;",
+    "void useTypedQuery;",
+  ].join("\n");
+}
+
+function tsconfig(mode) {
+  const compilerOptions =
+    mode === "bundler"
+      ? {
+          target: "ES2022",
+          module: "ESNext",
+          moduleResolution: "Bundler",
+          lib: ["ES2022", "DOM"],
+          strict: true,
+          skipLibCheck: true,
+          noEmit: true,
+          types: ["@ox-content/vite-plugin"],
+        }
+      : {
+          target: "ES2022",
+          module: mode === "nodenext" ? "NodeNext" : "Node16",
+          moduleResolution: mode === "nodenext" ? "NodeNext" : "Node16",
+          lib: ["ES2022", "DOM"],
+          strict: true,
+          skipLibCheck: true,
+          noEmit: true,
+          types: ["@ox-content/vite-plugin"],
+        };
+
+  return JSON.stringify(
+    {
+      compilerOptions,
+      files:
+        mode === "bundler"
+          ? ["collections-fixture.ts"]
+          : ["collections-fixture.ts", "collections-fixture.cts"],
+    },
+    null,
+    2,
+  );
 }

--- a/tools/scripts/package-dry-run.mjs
+++ b/tools/scripts/package-dry-run.mjs
@@ -82,6 +82,7 @@ function checkPackage(packageDir) {
     checkVitePluginDeclarations({
       pkg,
       tarball: packed.filename,
+      packDir,
       failures,
       readPackedFile,
     });

--- a/tools/scripts/write-vite-plugin-virtual-declarations.mjs
+++ b/tools/scripts/write-vite-plugin-virtual-declarations.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+import { rm, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const packageRoot = join(root, "npm", "vite-plugin-ox-content");
+const dist = join(packageRoot, "dist");
+const reference = '/// <reference path="./virtual.d.ts" />';
+
+const virtualSource = await readFile(join(packageRoot, "src", "virtual.ts"), "utf8");
+const virtualDeclaration = virtualSource
+  .replaceAll('import("./types")', 'import("@ox-content/vite-plugin")')
+  .trimEnd();
+
+await writeFile(join(dist, "virtual.d.ts"), `${virtualDeclaration}\n`);
+
+for (const extension of ["mts", "cts"]) {
+  const declarationFile = join(dist, `index.d.${extension}`);
+  let declaration = await readFile(declarationFile, "utf8");
+  declaration = declaration
+    .replace(new RegExp(`\\n//# sourceMappingURL=index\\.d\\.${extension}\\.map\\s*$`, "u"), "")
+    .trimStart();
+  if (!declaration.startsWith(reference)) {
+    declaration = `${reference}\n${declaration}`;
+  }
+  await writeFile(declarationFile, `${declaration.trimEnd()}\n`);
+  await rm(`${declarationFile}.map`, { force: true });
+}


### PR DESCRIPTION
## Triage

Issue is valid. The package source declared `virtual:ox-content/collections`, but consumers that only import the virtual module still need TypeScript to load the package ambient declarations from the packed output. The previous packaging kept the virtual declaration in a place that did not reliably register as a global ambient module for fresh consumers.

## Changes

- Generate `dist/virtual.d.ts` for `@ox-content/vite-plugin` and reference it from `dist/index.d.mts` / `dist/index.d.cts`.
- Reuse the source virtual declarations while rewriting collection type imports to the public package types.
- Extend package dry-run to unpack the tarball and run consumer `tsc` checks for Bundler, NodeNext, and Node16 resolution.
- Document the `compilerOptions.types` setup so downstream projects can remove local virtual module shims.

## Validation

- `rtk node tools/scripts/check-file-lines.ts`
- `rtk vp exec --filter @ox-content/vite-plugin -- vp run build`
- `rtk vp run workspace:build`
- `rtk node tools/scripts/package-dry-run.mjs`
- `rtk vp run check:ts` (passes with existing warnings)
- `rtk vp test tools/scripts/verify-publish-targets.test.ts`

Closes #1321

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791345753&installation_model_id=422833&pr_number=1336&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1336&signature=b7883649bf69c9ba02403a170da9ef51625f87560955728fe540e7ed3d7894e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->