### PR TITLE
feat(custom-host): share collection asset manifest context

### DIFF
--- a/docs/content/built-in/custom-host.md
+++ b/docs/content/built-in/custom-host.md
@@ -209,6 +209,23 @@ replace the last successful manifest. In production, collection assets are
 written with the coordinated output files unless `collectionAssets.write` is
 `false`.
 
+Route, render, and output hooks can read the same configured snapshot through
+`ctx.assets.collectionManifest()`. Use it when the host needs the manifest for
+HTML rewriting or structured page-data aliases; the writer and development
+middleware reuse that resolved manifest instead of calling
+`collectionAssets.manifest` again.
+
+```ts
+const manifest = await ctx.assets.collectionManifest();
+const body = manifest
+  ? rewriteCollectionAssetUrls({
+      html,
+      base: ctx.base,
+      manifest,
+    }).html
+  : html;
+```
+
 Solid HTML-string hosts can generate their browser island registry from that
 same selected route/document set. Use `createSolidHtmlHostIslandRegistry()` from
 `@ox-content/vite-plugin-solid` and import

--- a/docs/content/ja/built-in/custom-host.md
+++ b/docs/content/ja/built-in/custom-host.md
@@ -132,6 +132,55 @@ route の出力 path が重複すると、どの route 同士が衝突したか�
 失敗させます。公開対象の選択はホストが持ち、Ox Content はホストが返した route
 だけを書きます。
 
+## Collection asset
+
+collection に付随する project image や download file を host が所有し、それを同じ manifest で
+Ox Content に dev 配信 / build 書き出しさせたい場合は `collectionAssets` を使います。
+
+```ts
+oxContentCustomHost({
+  host: "./src/site-host.ts",
+  collectionAssets: {
+    manifest: async (ctx) =>
+      planCollectionAssets({
+        root: ctx.root,
+        assets: [
+          {
+            sourcePath: "content/projects/cover.jpg",
+            publicPath: "/projects/cover.jpg",
+          },
+        ],
+      }),
+    watch: [{ path: "content/projects", kind: "directory" }],
+    ownedPrefixes: ["/assets/content"],
+  },
+});
+```
+
+development では middleware が route rendering より前に alias と content-addressed target を
+配信します。owned prefix 配下で file が見つからない URL は host router に fallthrough せず
+404 になります。watch 対象 file や manifest source file が変わると、Ox Content は manifest を
+re-plan し、成功した plan のあとで cached route response を消して reload します。失敗した
+re-plan は retry 可能で、最後に成功した manifest を置き換えません。production では
+`collectionAssets.write` が `false` でない限り、collection asset は協調 output file と一緒に
+書き出されます。
+
+route、render、output hook は、同じ configured snapshot を
+`ctx.assets.collectionManifest()` から読めます。HTML rewrite や structured page data の alias
+解決が必要な場合に使います。writer と development middleware はその resolved manifest を
+再利用するため、`collectionAssets.manifest` を二度呼びません。
+
+```ts
+const manifest = await ctx.assets.collectionManifest();
+const body = manifest
+  ? rewriteCollectionAssetUrls({
+      html,
+      base: ctx.base,
+      manifest,
+    }).html
+  : html;
+```
+
 Solid HTML-string host は、同じ選択済み route / document set から browser island registry を
 生成できます。`@ox-content/vite-plugin-solid` の
 `createSolidHtmlHostIslandRegistry()` を使い、client entry では directory 全体の

--- a/npm/vite-plugin-ox-content/src/custom-host-assets.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-assets.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { Connect } from "vite";
 import { resolveSelfHostedAssetManifest } from "./assets";
+import type { CollectionAssetManifest } from "./collection-assets";
 import { DEFAULT_THEME_TOKEN_HREF } from "./custom-host-constants";
 import { resolveCustomHostStylesheetContent } from "./custom-host-stylesheet-content";
 import {
@@ -29,12 +30,14 @@ export function createAssetsContext(
   themeTokens: ResolvedThemeTokens | undefined,
   moduleGraph?: CustomHostDevModuleGraph,
   root?: string,
+  collectionManifest: () => Promise<CollectionAssetManifest | undefined> = async () => undefined,
 ): OxContentCustomHostAssetsContext {
   const selfHosted = resolveSelfHostedAssetManifest(options);
   return {
     selfHosted,
     clientManifest,
     themeTokens,
+    collectionManifest,
     stylesheets(input) {
       return resolveCustomHostStylesheets({
         ...input,

--- a/npm/vite-plugin-ox-content/src/custom-host-build.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-build.ts
@@ -2,8 +2,9 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { ResolvedConfig, ViteDevServer } from "vite";
 import { writeSelfHostedAssets } from "./assets";
+import type { CollectionAssetManifest } from "./collection-assets";
 import { createAssetsContext, readClientManifest, writeThemeTokens } from "./custom-host-assets";
-import { writeCustomHostCollectionAssets } from "./custom-host-collection-assets";
+import { createCustomHostCollectionAssetsBuildController } from "./custom-host-collection-assets-build";
 import {
   createBaseContext,
   createContextMemo,
@@ -59,11 +60,26 @@ export async function runCustomHostBuild(
   const outDir = resolveOutDir(config, options, root);
   const loaderServer = await createHostLoaderServer(config);
   const clientManifest = await readClientManifest(outDir);
-  const assets = createAssetsContext(options, outDir, clientManifest, themeTokens, undefined, root);
+  let loadCollectionManifest: () => Promise<CollectionAssetManifest | undefined> = async () =>
+    undefined;
+  const assets = createAssetsContext(
+    options,
+    outDir,
+    clientManifest,
+    themeTokens,
+    undefined,
+    root,
+    () => loadCollectionManifest(),
+  );
   const loadModule = (moduleId: string) => loaderServer.ssrLoadModule(moduleId);
 
   try {
     const baseContext = createBaseContext("build", root, outDir, options, loadModule, assets);
+    const collectionAssets = createCustomHostCollectionAssetsBuildController({
+      options: input.collectionAssets,
+      context: baseContext,
+    });
+    loadCollectionManifest = () => collectionAssets.manifest();
     const host = await loadHost(input.host, loadModule, root);
     const memo = createContextMemo();
     const routes = await loadRoutes(host, createRoutesContext(baseContext, memo));
@@ -73,17 +89,14 @@ export async function runCustomHostBuild(
     const rendered = await renderBuildRoutes(host, routes, baseContext, input, loaderServer);
 
     await writeThemeTokens(outDir, themeTokens);
-    const collectionAssets = await writeCustomHostCollectionAssets(
-      input.collectionAssets,
-      baseContext,
-    );
+    const collectionAssetFiles = await collectionAssets.write();
     await writeCoordinatedOutputs(
       rendered,
       options,
       rawOptions,
       root,
       outDir,
-      collectionAssets,
+      collectionAssetFiles,
       outputData,
       input.build?.minifyHtml ?? options.ssg.minifyHtml,
     );

--- a/npm/vite-plugin-ox-content/src/custom-host-collection-assets-build.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-collection-assets-build.ts
@@ -1,0 +1,50 @@
+import type { CollectionAssetManifest, WriteCollectionAssetsResult } from "./collection-assets";
+import { writeCollectionAssets } from "./collection-assets";
+import { resolveCollectionAssetManifest } from "./custom-host-collection-assets";
+import type {
+  OxContentCustomHostBaseContext,
+  OxContentCustomHostCollectionAssetsOptions,
+} from "./custom-host-types";
+
+export interface CustomHostCollectionAssetsBuildController {
+  manifest(): Promise<CollectionAssetManifest | undefined>;
+  write(): Promise<WriteCollectionAssetsResult>;
+}
+
+export function createCustomHostCollectionAssetsBuildController(input: {
+  options: false | OxContentCustomHostCollectionAssetsOptions | undefined;
+  context: OxContentCustomHostBaseContext;
+}): CustomHostCollectionAssetsBuildController {
+  if (!input.options) {
+    return {
+      manifest: async () => undefined,
+      write: async () => ({ files: [] }),
+    };
+  }
+
+  const options = input.options;
+  let manifestPromise: Promise<CollectionAssetManifest> | undefined;
+  const loadManifest = () => {
+    if (!manifestPromise) {
+      const current = resolveCollectionAssetManifest(options, input.context).catch((error) => {
+        if (manifestPromise === current) {
+          manifestPromise = undefined;
+        }
+        throw error;
+      });
+      manifestPromise = current;
+    }
+    return manifestPromise;
+  };
+
+  return {
+    manifest: loadManifest,
+    async write() {
+      if (options.write === false) {
+        return { files: [] };
+      }
+      const manifest = await loadManifest();
+      return writeCollectionAssets({ manifest, outDir: input.context.outDir });
+    },
+  };
+}

--- a/npm/vite-plugin-ox-content/src/custom-host-collection-assets-context.test.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-collection-assets-context.test.ts
@@ -1,0 +1,257 @@
+import * as fs from "node:fs/promises";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { build as viteBuild, createServer, type InlineConfig, type ViteDevServer } from "vite";
+import {
+  oxContentCustomHost,
+  planCollectionAssets,
+  type CollectionAssetManifest,
+  type OxContentCustomHostCollectionAssetsContext,
+} from ".";
+
+const tempDirs: string[] = [];
+const activeServers: ViteDevServer[] = [];
+const activeListeners: http.Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(activeListeners.splice(0).map(closeHttpServer));
+  await Promise.all(activeServers.splice(0).map((server) => server.close().catch(() => {})));
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("custom host collection asset manifest context", () => {
+  it("shares the configured manifest with build route rendering and the writer", async () => {
+    const root = await createProject("ox-custom-host-collection-assets-build-");
+    await fs.writeFile(path.join(root, "content", "logo.txt"), "first");
+    await fs.writeFile(path.join(root, "src", "host.ts"), manifestRouteHostSource());
+    let manifestLoads = 0;
+
+    await viteBuild(
+      config(root, {
+        manifest: async (ctx) => {
+          manifestLoads += 1;
+          return collectionManifest(ctx.root);
+        },
+      }),
+    );
+
+    const manifest = await collectionManifest(root);
+    const asset = manifest.assets[0]!;
+    const html = await fs.readFile(path.join(root, "dist", "index.html"), "utf8");
+
+    expect(html).toContain(asset.contentPath);
+    expect(html).toContain("/media/logo.txt");
+    expect(await fs.readFile(path.join(root, "dist", "media", "logo.txt"), "utf8")).toBe("first");
+    await expect(
+      fs.readFile(path.join(root, "dist", asset.contentPath.slice(1)), "utf8"),
+    ).resolves.toBe("first");
+    expect(manifestLoads).toBe(1);
+  });
+
+  it("shares successful dev replans with route rendering and middleware", async () => {
+    const root = await createProject("ox-custom-host-collection-assets-dev-");
+    const sourcePath = path.join(root, "content", "logo.txt");
+    const gatePath = path.join(root, "content", "manifest-gate.txt");
+    await fs.writeFile(sourcePath, "first");
+    await fs.writeFile(gatePath, "ok\n");
+    await fs.writeFile(path.join(root, "src", "host.ts"), manifestRouteHostSource());
+    let manifestLoads = 0;
+
+    const server = await trackDevServer(
+      createServer(
+        config(root, {
+          dev: { reloadDebounceMs: 1 },
+          manifest: async (ctx) => {
+            manifestLoads += 1;
+            const gate = await fs.readFile(gatePath, "utf8");
+            if (gate.includes("fail")) {
+              throw new Error("manifest failed");
+            }
+            return collectionManifest(ctx.root);
+          },
+        }),
+      ),
+    );
+    const listener = await listen(server);
+
+    const firstManifest = await collectionManifest(root);
+    const firstAsset = firstManifest.assets[0]!;
+    expect(await text(listener.port, "/")).toMatchObject({ status: 200 });
+    expect((await text(listener.port, "/")).text).toContain(firstAsset.contentPath);
+    expect(await text(listener.port, firstAsset.contentPath)).toMatchObject({
+      status: 200,
+      text: "first",
+    });
+    const initialLoads = manifestLoads;
+    expect(initialLoads).toBeGreaterThanOrEqual(1);
+
+    await fs.writeFile(sourcePath, "second");
+    server.watcher.emit("change", sourcePath);
+
+    const secondManifest = await collectionManifest(root);
+    const secondAsset = secondManifest.assets[0]!;
+    const routeAfterChange = await waitForResponse(listener.port, "/", (response) =>
+      response.text.includes(secondAsset.contentPath),
+    );
+    expect(routeAfterChange).toMatchObject({ status: 200 });
+    expect(await text(listener.port, secondAsset.contentPath)).toMatchObject({
+      status: 200,
+      text: "second",
+    });
+    expect(manifestLoads).toBeGreaterThan(initialLoads);
+
+    await fs.writeFile(sourcePath, "third");
+    await fs.writeFile(gatePath, "fail\n");
+    const loadsBeforeFailedReplan = manifestLoads;
+    server.watcher.emit("change", sourcePath);
+    await waitFor(() => manifestLoads > loadsBeforeFailedReplan);
+
+    const routeAfterFailedReplan = await text(listener.port, "/");
+    expect(routeAfterFailedReplan).toMatchObject({ status: 200 });
+    expect(routeAfterFailedReplan.text).toContain(secondAsset.contentPath);
+    const failedLoads = manifestLoads;
+
+    await fs.writeFile(gatePath, "ok\n");
+    server.watcher.emit("change", gatePath);
+
+    const thirdManifest = await collectionManifest(root);
+    const thirdAsset = thirdManifest.assets[0]!;
+    const recoveredRoute = await waitForResponse(listener.port, "/", (response) =>
+      response.text.includes(thirdAsset.contentPath),
+    );
+    expect(recoveredRoute).toMatchObject({ status: 200 });
+    expect(await text(listener.port, thirdAsset.contentPath)).toMatchObject({
+      status: 200,
+      text: "third",
+    });
+    expect(manifestLoads).toBeGreaterThan(failedLoads);
+  });
+});
+
+function config(
+  root: string,
+  input: {
+    manifest(context: OxContentCustomHostCollectionAssetsContext): Promise<CollectionAssetManifest>;
+    dev?: { reloadDebounceMs?: number };
+  },
+): InlineConfig {
+  return {
+    root,
+    configFile: false,
+    appType: "custom",
+    logLevel: "silent",
+    plugins: [
+      ...oxContentCustomHost({
+        host: "./src/host.ts",
+        dev: input.dev,
+        oxContent: { srcDir: "content", outDir: "dist", docs: false, search: false },
+        collectionAssets: {
+          manifest: (ctx) => input.manifest(ctx),
+          watch: [{ path: "content", kind: "directory" }],
+          ownedPrefixes: ["/assets/content"],
+        },
+      }),
+    ],
+    build: {
+      outDir: "dist",
+      emptyOutDir: true,
+      manifest: true,
+      rollupOptions: { input: path.join(root, "src", "main.ts") },
+    },
+  };
+}
+
+async function createProject(prefix: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(root);
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.mkdir(path.join(root, "content"), { recursive: true });
+  await fs.writeFile(path.join(root, "package.json"), '{"type":"module"}\n');
+  await fs.writeFile(path.join(root, "src", "main.ts"), "export {};\n");
+  return root;
+}
+
+function collectionManifest(root: string): Promise<CollectionAssetManifest> {
+  return planCollectionAssets({
+    root,
+    assets: [{ sourcePath: "content/logo.txt", publicPath: "/media/logo.txt" }],
+  });
+}
+
+function manifestRouteHostSource(): string {
+  return `
+export default {
+  routes: [
+    {
+      path: "/",
+      async render(ctx) {
+        const manifest = await ctx.assets.collectionManifest();
+        const asset = manifest?.assets[0];
+        return {
+          html: "<pre>" + JSON.stringify({
+            contentPath: asset?.contentPath,
+            publicPaths: asset?.publicPaths ?? [],
+          }) + "</pre>",
+        };
+      },
+    },
+  ],
+};
+`;
+}
+
+async function trackDevServer(serverPromise: Promise<ViteDevServer>): Promise<ViteDevServer> {
+  const server = await serverPromise;
+  activeServers.push(server);
+  return server;
+}
+
+async function listen(server: ViteDevServer): Promise<{ server: http.Server; port: number }> {
+  const listener = http.createServer(server.middlewares);
+  activeListeners.push(listener);
+  await new Promise<void>((resolve) => listener.listen(0, "127.0.0.1", resolve));
+  const address = listener.address() as AddressInfo;
+  return { server: listener, port: address.port };
+}
+
+async function text(port: number, requestPath: string) {
+  const response = await fetch(`http://127.0.0.1:${port}${requestPath}`);
+  return { status: response.status, text: await response.text() };
+}
+
+async function waitForResponse(
+  port: number,
+  requestPath: string,
+  predicate: (response: Awaited<ReturnType<typeof text>>) => boolean,
+) {
+  let lastResponse: Awaited<ReturnType<typeof text>> | undefined;
+  await waitFor(async () => {
+    lastResponse = await text(port, requestPath);
+    return predicate(lastResponse);
+  });
+  return lastResponse!;
+}
+
+async function waitFor(predicate: () => boolean | Promise<boolean>): Promise<void> {
+  const deadline = Date.now() + 1000;
+  while (Date.now() < deadline) {
+    if (await predicate()) {
+      return;
+    }
+    await wait(20);
+  }
+  throw new Error("Timed out waiting for custom host collection asset replan.");
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function closeHttpServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}

--- a/npm/vite-plugin-ox-content/src/custom-host-collection-assets.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-collection-assets.ts
@@ -2,8 +2,7 @@ import * as fs from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import * as path from "node:path";
 import type { Connect, ViteDevServer } from "vite";
-import type { CollectionAssetManifest, WriteCollectionAssetsResult } from "./collection-assets";
-import { writeCollectionAssets } from "./collection-assets";
+import type { CollectionAssetManifest } from "./collection-assets";
 import type {
   OxContentCustomHostBaseContext,
   OxContentCustomHostCollectionAssetsOptions,
@@ -18,25 +17,16 @@ import {
 
 export interface CustomHostCollectionAssetsDevController {
   middleware: Connect.NextHandleFunction;
+  manifest(): Promise<CollectionAssetManifest | undefined>;
   invalidate(file: string): boolean;
   close(): void;
 }
 
 interface CollectionAssetsSnapshot {
+  manifest: CollectionAssetManifest;
   sources: Map<string, string>;
   ownedPrefixes: string[];
   sourceDependencies: NormalizedCustomHostDependency[];
-}
-
-export async function writeCustomHostCollectionAssets(
-  options: false | OxContentCustomHostCollectionAssetsOptions | undefined,
-  context: OxContentCustomHostBaseContext,
-): Promise<WriteCollectionAssetsResult> {
-  if (!options || options.write === false) {
-    return { files: [] };
-  }
-  const manifest = await resolveCollectionAssetManifest(options, context);
-  return writeCollectionAssets({ manifest, outDir: context.outDir });
 }
 
 export function createCustomHostCollectionAssetsDevController(input: {
@@ -106,6 +96,9 @@ export function createCustomHostCollectionAssetsDevController(input: {
   };
 
   return {
+    async manifest() {
+      return (await loadSnapshot()).manifest;
+    },
     middleware: async (req, res, next) => {
       if (req.method !== "GET" && req.method !== "HEAD") {
         next();
@@ -168,7 +161,7 @@ function planSnapshot(input: {
   return promise;
 }
 
-async function resolveCollectionAssetManifest(
+export async function resolveCollectionAssetManifest(
   options: OxContentCustomHostCollectionAssetsOptions,
   context: OxContentCustomHostBaseContext,
 ): Promise<CollectionAssetManifest> {
@@ -199,6 +192,7 @@ function createSnapshot(
   }
 
   return {
+    manifest,
     sources,
     ownedPrefixes: [...ownedPrefixes],
     sourceDependencies: normalizeCustomHostDependencies(root, sourceDependencies),

--- a/npm/vite-plugin-ox-content/src/custom-host-dev.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-dev.ts
@@ -1,6 +1,9 @@
 import type { ViteDevServer } from "vite";
 import { createAssetsContext, themeTokenMiddleware } from "./custom-host-assets";
-import { createCustomHostCollectionAssetsDevController } from "./custom-host-collection-assets";
+import {
+  createCustomHostCollectionAssetsDevController,
+  type CustomHostCollectionAssetsDevController,
+} from "./custom-host-collection-assets";
 import {
   createBaseContext,
   createContextMemo,
@@ -46,6 +49,7 @@ export function configureDevServer(
 ): void {
   const root = server.config.root;
   const outDir = resolveOutDir(server.config, options, root);
+  let collectionAssets: CustomHostCollectionAssetsDevController | undefined;
   const assets = createAssetsContext(
     options,
     outDir,
@@ -53,6 +57,7 @@ export function configureDevServer(
     themeTokens,
     server.moduleGraph,
     root,
+    async () => collectionAssets?.manifest(),
   );
   let ssrVersion = 0;
   const loadModule = (moduleId: string) =>
@@ -189,7 +194,7 @@ export function configureDevServer(
     return routesPromise;
   };
 
-  const collectionAssets = createCustomHostCollectionAssetsDevController({
+  collectionAssets = createCustomHostCollectionAssetsDevController({
     server,
     options: input.collectionAssets,
     context: baseContext,
@@ -228,11 +233,11 @@ export function configureDevServer(
       clearResponses();
       invalidated = true;
     }
-    for (const key of [...(depKeys.get(changed) ?? [])]) {
+    for (const key of Array.from(depKeys.get(changed) ?? [])) {
       clearKey(key);
       invalidated = true;
     }
-    for (const [key, dependencies] of [...keyBroadDeps]) {
+    for (const [key, dependencies] of Array.from(keyBroadDeps)) {
       if (
         dependencies.some((dependency) => anyCustomHostDependencyMatches([dependency], changed))
       ) {

--- a/npm/vite-plugin-ox-content/src/custom-host-types.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-types.ts
@@ -170,6 +170,12 @@ export interface OxContentCustomHostAssetsContext {
   selfHosted: OxContentAssetManifest;
   clientManifest?: DocumentAssetManifest;
   themeTokens?: ResolvedThemeTokens;
+  /**
+   * Configured custom-host collection asset manifest, when collection assets
+   * are enabled. The build writer and development middleware consume this same
+   * lifecycle snapshot.
+   */
+  collectionManifest(): Promise<CollectionAssetManifest | undefined>;
   stylesheets(input: OxContentCustomHostStylesheetsInput): OxContentCustomHostStylesheetsResult;
   stylesheetContent(
     input: OxContentCustomHostStylesheetContentInput,

--- a/tools/scripts/package-dry-run-public-declarations.mjs
+++ b/tools/scripts/package-dry-run-public-declarations.mjs
@@ -241,6 +241,7 @@ function valueUsage(entry, prefix) {
       `const customPlugin = ${prefix}createOxContentCustomHostPlugin(customOptions);`,
       `const customOxOptions = ${prefix}customHostOxContentOptions();`,
       `const customStyles = customAssets.stylesheets({ modules: ["/src/Island.ts"] });`,
+      "void customAssets.collectionManifest();",
       "void customAssets.stylesheetContent({ stylesheets: customStyles.stylesheets });",
       'const customDependency: OxContentCustomHostDependency = { path: "content/guide", kind: "directory" };',
       'const customCollectionAssets: OxContentCustomHostCollectionAssetsOptions = { manifest: { assets: [] }, watch: [customDependency], ownedPrefixes: ["/assets/content"] };',


### PR DESCRIPTION
## Triage

#1318 is a valid enhancement request. The existing collection asset manifest can be configured for build writing and dev middleware, but route rendering cannot reuse that lifecycle snapshot without a second host-owned call. This PR intentionally does not implement #1316 reference discovery; it only shares the configured manifest once it exists.

## Changes

- add `ctx.assets.collectionManifest()` for route/render/output hooks
- reuse the same build manifest for route rendering and `writeCollectionAssets()`
- expose the dev controller snapshot through the asset context so routes and middleware share successful replans
- document retry semantics for failed dev replans and add packed declaration coverage

## Validation

- `rtk vp check --fix npm/vite-plugin-ox-content/src/custom-host-types.ts npm/vite-plugin-ox-content/src/custom-host-assets.ts npm/vite-plugin-ox-content/src/custom-host-collection-assets.ts npm/vite-plugin-ox-content/src/custom-host-collection-assets-build.ts npm/vite-plugin-ox-content/src/custom-host-build.ts npm/vite-plugin-ox-content/src/custom-host-dev.ts npm/vite-plugin-ox-content/src/custom-host-collection-assets-context.test.ts tools/scripts/package-dry-run-public-declarations.mjs docs/content/built-in/custom-host.md docs/content/ja/built-in/custom-host.md`
- `rtk node tools/scripts/check-file-lines.ts`
- `rtk vp test npm/vite-plugin-ox-content/src/custom-host-collection-assets-context.test.ts`
- `rtk vp run check:ts`
- `rtk vp run build:npm`
- `rtk node tools/scripts/package-dry-run.mjs`
- `rtk git diff --check`

Closes #1318

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791348662&installation_model_id=422833&pr_number=1339&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1339&signature=a68a8f4928d35e2bb0f64a058256b4dea856380abf957c9ad3d9f82ec37b97b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->