### PR TITLE
feat(custom-host): plan collection assets from documents

### DIFF
--- a/docs/content/built-in/custom-host.md
+++ b/docs/content/built-in/custom-host.md
@@ -220,11 +220,41 @@ const manifest = await ctx.assets.collectionManifest();
 const body = manifest
   ? rewriteCollectionAssetUrls({
       html,
-      base: ctx.base,
+      pagePath: ctx.url.pathname,
       manifest,
     }).html
   : html;
 ```
+
+When the host already knows the public Markdown or MDX documents, use
+`planCollectionAssetsFromDocuments()` instead of globbing media extensions. It
+discovers relative Markdown image/link URLs plus literal HTML and MDX JSX
+`href`, `src`, and `poster` attributes from only those selected documents,
+resolves files against the real document path, and returns the same
+`CollectionAssetManifest`.
+
+```ts
+collectionAssets: {
+  manifest: async (ctx) => {
+    const result = await planCollectionAssetsFromDocuments({
+      root: ctx.root,
+      contentRoot: "content",
+      documents: [{ documentPath: "content/posts/hello.mdx", pagePath: "/posts/hello" }],
+      extraAssets: [{ sourcePath: "content/posts/og.png", publicPath: "/og/hello.png" }],
+      publicPath: (reference) => [reference.publicPath, `/legacy${reference.publicPath}`],
+    });
+    if (result.diagnostics.length > 0) {
+      throw new Error(result.diagnostics.map((diagnostic) => diagnostic.message).join("\n"));
+    }
+    return result.manifest;
+  },
+}
+```
+
+External, root-absolute, data/blob, fragment-only, and other non-local URLs are
+ignored. Missing files and references outside `contentRoot` are reported as
+document-scoped diagnostics, while query strings and fragments stay on the
+reported references and are preserved later by `rewriteCollectionAssetUrls()`.
 
 Solid HTML-string hosts can generate their browser island registry from that
 same selected route/document set. Use `createSolidHtmlHostIslandRegistry()` from

--- a/docs/content/built-in/ssg-output.md
+++ b/docs/content/built-in/ssg-output.md
@@ -79,6 +79,7 @@ aliases safely, and keeps the same manifest for production and development.
 import {
   createCollectionAssetsMiddleware,
   planCollectionAssets,
+  planCollectionAssetsFromDocuments,
   rewriteCollectionAssetUrls,
   writeCollectionAssets,
 } from "@ox-content/vite-plugin";
@@ -117,6 +118,13 @@ external origins, fragment-only links, non-HTTP schemes such as `data:`,
 `origin` to treat same-origin absolute URLs like root-relative paths; rewritten
 values are still emitted as URL paths. Pass `document: true` when the input is a
 full HTML document.
+
+When the host has a selected set of public Markdown/MDX documents, use
+`planCollectionAssetsFromDocuments()` to build the same manifest from those
+documents' local references. It follows relative Markdown images and links plus
+literal HTML/MDX `href`, `src`, and `poster` attributes, emits diagnostics for
+missing or out-of-`contentRoot` files, and still allows `extraAssets` and custom
+alias mapping.
 
 ## External feeds in a custom host
 

--- a/docs/content/ja/built-in/custom-host.md
+++ b/docs/content/ja/built-in/custom-host.md
@@ -132,7 +132,7 @@ route の出力 path が重複すると、どの route 同士が衝突したか�
 失敗させます。公開対象の選択はホストが持ち、Ox Content はホストが返した route
 だけを書きます。
 
-## Collection asset
+## コレクションアセット
 
 collection に付随する project image や download file を host が所有し、それを同じ manifest で
 Ox Content に dev 配信 / build 書き出しさせたい場合は `collectionAssets` を使います。
@@ -175,11 +175,39 @@ const manifest = await ctx.assets.collectionManifest();
 const body = manifest
   ? rewriteCollectionAssetUrls({
       html,
-      base: ctx.base,
+      pagePath: ctx.url.pathname,
       manifest,
     }).html
   : html;
 ```
+
+既に公開する Markdown / MDX document の集合が決まっているなら、拡張子 allowlist や広い glob
+ではなく `planCollectionAssetsFromDocuments()` を使えます。
+
+```ts
+collectionAssets: {
+  manifest: async (ctx) => {
+    const result = await planCollectionAssetsFromDocuments({
+      root: ctx.root,
+      contentRoot: "content",
+      documents: [{ documentPath: "content/posts/hello.mdx", pagePath: "/posts/hello" }],
+      extraAssets: [{ sourcePath: "content/posts/og.png", publicPath: "/og/hello.png" }],
+      publicPath: (reference) => [reference.publicPath, `/legacy${reference.publicPath}`],
+    });
+    if (result.diagnostics.length > 0) {
+      throw new Error(result.diagnostics.map((diagnostic) => diagnostic.message).join("\n"));
+    }
+    return result.manifest;
+  },
+}
+```
+
+この helper は選択された document だけから、relative な Markdown image/link URL と、
+literal な HTML / MDX JSX の `href`、`src`、`poster` 属性を見つけます。file は実際の
+document path から解決し、既存の `CollectionAssetManifest` を返します。外部 URL、
+root-absolute URL、data/blob、fragment-only link などの non-local URL は対象外です。
+missing file と `contentRoot` 外への参照は document-scoped diagnostic になり、query
+string と fragment は後続の `rewriteCollectionAssetUrls()` で保持できます。
 
 Solid HTML-string host は、同じ選択済み route / document set から browser island registry を
 生成できます。`@ox-content/vite-plugin-solid` の

--- a/docs/content/ja/built-in/ssg-output.md
+++ b/docs/content/ja/built-in/ssg-output.md
@@ -79,6 +79,7 @@ hash 化・重複排除と、alias の安全な URL encoding もこの API が�
 import {
   createCollectionAssetsMiddleware,
   planCollectionAssets,
+  planCollectionAssetsFromDocuments,
   rewriteCollectionAssetUrls,
   writeCollectionAssets,
 } from "@ox-content/vite-plugin";
@@ -116,6 +117,12 @@ origin、fragment-only link、`data:`、`mailto:`、`javascript:` のような
 非 HTTP scheme、壊れた属性値はそのままです。`origin` を渡すと same-origin の
 absolute URL は root-relative path と同じように扱います。書き換え後の値は URL
 path として出力されます。入力が HTML document 全体なら `document: true` を渡します。
+
+公開する Markdown / MDX document の集合をホストが既に選んでいる場合は、
+`planCollectionAssetsFromDocuments()` でそれらの local reference から同じ manifest
+を作れます。relative な Markdown image/link と literal な HTML / MDX の `href`、
+`src`、`poster` を辿り、missing file や `contentRoot` 外への参照は diagnostic にし、
+`extraAssets` と独自 alias mapping も併用できます。
 
 ## 独自ホストで外部フィードを読む
 

--- a/npm/vite-plugin-ox-content/src/collection-asset-document-paths.ts
+++ b/npm/vite-plugin-ox-content/src/collection-asset-document-paths.ts
@@ -1,0 +1,47 @@
+import * as path from "node:path";
+
+export function normalizePublicPath(value: string): string {
+  if (!value.startsWith("/") || value.startsWith("//") || value.includes("\0")) {
+    throw new Error(
+      `Collection asset public path ${JSON.stringify(value)} must be an absolute URL path.`,
+    );
+  }
+  const segments = value.slice(1).split("/");
+  if (segments.length === 0 || segments.some((segment) => !segment)) {
+    throw new Error(
+      `Collection asset public path ${JSON.stringify(value)} must not contain empty segments.`,
+    );
+  }
+  return `/${segments.map((segment) => encodePublicSegment(segment, value)).join("/")}`;
+}
+
+export function isWithinOrEqual(root: string, file: string): boolean {
+  const relative = path.relative(root, file);
+  return (
+    relative === "" ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative))
+  );
+}
+
+function encodePublicSegment(segment: string, publicPath: string): string {
+  const decoded = decodeURIComponent(segment);
+  if (
+    !decoded ||
+    decoded === "." ||
+    decoded === ".." ||
+    decoded.includes("/") ||
+    decoded.includes("\\") ||
+    hasControlCharacter(decoded)
+  ) {
+    throw new Error(`Collection asset public path ${JSON.stringify(publicPath)} is unsafe.`);
+  }
+  return encodeURIComponent(decoded);
+}
+
+function hasControlCharacter(value: string): boolean {
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if (code < 32 || code === 127) return true;
+  }
+  return false;
+}

--- a/npm/vite-plugin-ox-content/src/collection-asset-document-references.ts
+++ b/npm/vite-plugin-ox-content/src/collection-asset-document-references.ts
@@ -1,0 +1,341 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { Element, Root } from "hast";
+import rehypeParse from "rehype-parse";
+import { unified } from "unified";
+import { isWithinOrEqual, normalizePublicPath } from "./collection-asset-document-paths";
+import type {
+  CollectionAssetDocumentDiagnostic,
+  CollectionAssetResolvedDocumentReference,
+  PlanCollectionAssetsFromDocumentsInput,
+} from "./collection-asset-documents";
+import type { MarkdownNode } from "./types";
+
+const URL_SCHEME = /^[a-zA-Z][a-zA-Z\d+.-]*:/u;
+
+export interface ResolvedCollectionAssetDocument {
+  documentPath: string;
+  pagePath: string;
+  source?: string;
+  ast?: MarkdownNode;
+}
+
+export interface RawCollectionAssetDocumentReference {
+  original: string;
+  nodeType: string;
+  attribute?: string;
+}
+
+interface ParsedReference {
+  pathname: string;
+  search: string;
+  hash: string;
+}
+
+export function collectDocumentReferences(
+  ast: MarkdownNode,
+  attributes: ReadonlySet<string>,
+): RawCollectionAssetDocumentReference[] {
+  const references: RawCollectionAssetDocumentReference[] = [];
+  walkMarkdown(ast, (node) => {
+    const url = typeof node.url === "string" ? node.url : undefined;
+    if (url && (node.type === "image" || node.type === "link" || node.type === "definition")) {
+      references.push({ original: url, nodeType: node.type, attribute: "url" });
+    }
+    if (node.type === "html" && typeof node.value === "string") {
+      references.push(...collectHtmlReferences(node.value, attributes));
+    }
+    if (node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement") {
+      references.push(...collectMdxJsxReferences(node, attributes));
+    }
+  });
+  return references;
+}
+
+export async function resolveDocumentReference(
+  document: ResolvedCollectionAssetDocument,
+  rawReference: RawCollectionAssetDocumentReference,
+  contentRoot: string,
+  diagnostics: CollectionAssetDocumentDiagnostic[],
+): Promise<CollectionAssetResolvedDocumentReference | undefined> {
+  const parsed = parseLocalReference(rawReference.original, document, diagnostics);
+  if (!parsed) return undefined;
+
+  const relativePath = decodeReferencePath(parsed.pathname, document, rawReference, diagnostics);
+  if (!relativePath) return undefined;
+
+  const candidate = path.resolve(path.dirname(document.documentPath), relativePath);
+  if (!isWithinOrEqual(contentRoot, candidate)) {
+    diagnostics.push(
+      referenceDiagnostic("outside-content-root", document, rawReference, candidate),
+    );
+    return undefined;
+  }
+
+  let sourcePath: string;
+  try {
+    sourcePath = await fs.realpath(candidate);
+  } catch {
+    diagnostics.push(referenceDiagnostic("missing-file", document, rawReference, candidate));
+    return undefined;
+  }
+
+  const stats = await fs.stat(sourcePath);
+  if (!stats.isFile()) {
+    diagnostics.push({
+      code: "invalid-reference",
+      documentPath: document.documentPath,
+      pagePath: document.pagePath,
+      reference: rawReference.original,
+      sourcePath,
+      message: `Collection asset reference ${JSON.stringify(rawReference.original)} is not a file.`,
+    });
+    return undefined;
+  }
+
+  if (!isWithinOrEqual(contentRoot, sourcePath)) {
+    diagnostics.push(
+      referenceDiagnostic("outside-content-root", document, rawReference, sourcePath),
+    );
+    return undefined;
+  }
+
+  return {
+    ...rawReference,
+    documentPath: document.documentPath,
+    pagePath: document.pagePath,
+    sourcePath,
+    publicPath: publicPathFor(document.pagePath, parsed.pathname),
+    pathname: parsed.pathname,
+    search: parsed.search,
+    hash: parsed.hash,
+  };
+}
+
+export async function resolvePublicPaths(
+  reference: CollectionAssetResolvedDocumentReference,
+  publicPath: PlanCollectionAssetsFromDocumentsInput["publicPath"] | undefined,
+  diagnostics: CollectionAssetDocumentDiagnostic[],
+): Promise<string[]> {
+  let value: string | readonly string[] | undefined;
+  try {
+    value = await publicPath?.(reference);
+  } catch (error) {
+    diagnostics.push(
+      publicPathDiagnostic(reference, error instanceof Error ? error.message : String(error)),
+    );
+    return [];
+  }
+
+  const publicPaths = value === undefined ? [reference.publicPath] : valuesToArray(value);
+  if (publicPaths.length === 0) {
+    diagnostics.push(
+      publicPathDiagnostic(
+        reference,
+        "Collection asset publicPath must contain at least one URL path.",
+      ),
+    );
+    return [];
+  }
+
+  const normalized = new Set<string>();
+  for (const candidate of publicPaths) {
+    try {
+      normalized.add(normalizePublicPath(candidate));
+    } catch (error) {
+      diagnostics.push(
+        publicPathDiagnostic(reference, error instanceof Error ? error.message : String(error)),
+      );
+    }
+  }
+  return [...normalized];
+}
+
+function walkMarkdown(node: MarkdownNode, visit: (node: MarkdownNode) => void): void {
+  visit(node);
+  if (!Array.isArray(node.children)) return;
+  for (const child of node.children) walkMarkdown(child, visit);
+}
+
+function collectHtmlReferences(
+  html: string,
+  attributes: ReadonlySet<string>,
+): RawCollectionAssetDocumentReference[] {
+  const tree = unified().use(rehypeParse, { fragment: true }).parse(html) as Root;
+  const references: RawCollectionAssetDocumentReference[] = [];
+  visitElements(tree, (node) => {
+    for (const attribute of attributes) {
+      const value = node.properties?.[attribute];
+      if (typeof value === "string") {
+        references.push({ original: value, nodeType: "html", attribute });
+      }
+    }
+  });
+  return references;
+}
+
+function visitElements(node: Root | Element, visit: (node: Element) => void): void {
+  if (node.type === "element") visit(node);
+  if (!("children" in node)) return;
+  for (const child of node.children) {
+    if (child.type === "element") visitElements(child, visit);
+  }
+}
+
+function collectMdxJsxReferences(
+  node: MarkdownNode,
+  attributes: ReadonlySet<string>,
+): RawCollectionAssetDocumentReference[] {
+  const entries = Array.isArray(node.attributes) ? node.attributes : [];
+  const references: RawCollectionAssetDocumentReference[] = [];
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") continue;
+    const attribute = entry as { type?: unknown; name?: unknown; value?: unknown };
+    if (
+      attribute.type === "mdxJsxAttribute" &&
+      typeof attribute.name === "string" &&
+      attributes.has(attribute.name) &&
+      typeof attribute.value === "string"
+    ) {
+      references.push({
+        original: attribute.value,
+        nodeType: node.type,
+        attribute: attribute.name,
+      });
+    }
+  }
+  return references;
+}
+
+function parseLocalReference(
+  value: string,
+  document: ResolvedCollectionAssetDocument,
+  diagnostics: CollectionAssetDocumentDiagnostic[],
+): ParsedReference | undefined {
+  const reference = value.trim();
+  if (
+    !reference ||
+    reference.startsWith("#") ||
+    reference.startsWith("?") ||
+    reference.startsWith("/") ||
+    reference.startsWith("//") ||
+    URL_SCHEME.test(reference)
+  ) {
+    return undefined;
+  }
+
+  const hashIndex = reference.indexOf("#");
+  const queryIndex = reference.indexOf("?");
+  const endIndex = minPositive(hashIndex, queryIndex) ?? reference.length;
+  const pathname = reference.slice(0, endIndex);
+  if (!pathname) return undefined;
+  if (pathname.includes("\0")) {
+    diagnostics.push({
+      code: "invalid-reference",
+      documentPath: document.documentPath,
+      pagePath: document.pagePath,
+      reference: value,
+      message: `Collection asset reference ${JSON.stringify(value)} contains an invalid path.`,
+    });
+    return undefined;
+  }
+
+  return {
+    pathname,
+    search:
+      queryIndex >= 0 && (hashIndex < 0 || queryIndex < hashIndex)
+        ? reference.slice(queryIndex, hashIndex >= 0 ? hashIndex : undefined)
+        : "",
+    hash: hashIndex >= 0 ? reference.slice(hashIndex) : "",
+  };
+}
+
+function minPositive(first: number, second: number): number | undefined {
+  const values = [first, second].filter((value) => value >= 0);
+  return values.length === 0 ? undefined : Math.min(...values);
+}
+
+function decodeReferencePath(
+  pathname: string,
+  document: ResolvedCollectionAssetDocument,
+  rawReference: RawCollectionAssetDocumentReference,
+  diagnostics: CollectionAssetDocumentDiagnostic[],
+): string | undefined {
+  try {
+    return pathname
+      .split("/")
+      .map((segment) => decodeReferenceSegment(segment, rawReference.original))
+      .join(path.sep);
+  } catch (error) {
+    diagnostics.push({
+      code: "invalid-reference",
+      documentPath: document.documentPath,
+      pagePath: document.pagePath,
+      reference: rawReference.original,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+}
+
+function decodeReferenceSegment(segment: string, reference: string): string {
+  const decoded = decodeURIComponent(segment);
+  if (decoded.includes("/") || decoded.includes("\\") || hasControlCharacter(decoded)) {
+    throw new Error(
+      `Collection asset reference ${JSON.stringify(reference)} contains an unsafe path segment.`,
+    );
+  }
+  return decoded;
+}
+
+function publicPathFor(pagePath: string, pathname: string): string {
+  const pageBase = pagePath.startsWith("/") ? pagePath : `/${pagePath}`;
+  const basePath = pageBase.endsWith("/") ? pageBase : `${pageBase}/`;
+  const url = new URL(pathname, `https://ox-content.local${basePath}`);
+  return normalizePublicPath(url.pathname);
+}
+
+function valuesToArray(value: string | readonly string[]): string[] {
+  return typeof value === "string" ? [value] : [...value];
+}
+
+function publicPathDiagnostic(
+  reference: CollectionAssetResolvedDocumentReference,
+  message: string,
+): CollectionAssetDocumentDiagnostic {
+  return {
+    code: "invalid-public-path",
+    documentPath: reference.documentPath,
+    pagePath: reference.pagePath,
+    reference: reference.original,
+    sourcePath: reference.sourcePath,
+    message,
+  };
+}
+
+function referenceDiagnostic(
+  code: "missing-file" | "outside-content-root",
+  document: ResolvedCollectionAssetDocument,
+  reference: RawCollectionAssetDocumentReference,
+  sourcePath: string,
+): CollectionAssetDocumentDiagnostic {
+  return {
+    code,
+    documentPath: document.documentPath,
+    pagePath: document.pagePath,
+    reference: reference.original,
+    sourcePath,
+    message:
+      code === "missing-file"
+        ? `Collection asset reference ${JSON.stringify(reference.original)} does not exist.`
+        : `Collection asset reference ${JSON.stringify(reference.original)} must stay within contentRoot.`,
+  };
+}
+
+function hasControlCharacter(value: string): boolean {
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if (code < 32 || code === 127) return true;
+  }
+  return false;
+}

--- a/npm/vite-plugin-ox-content/src/collection-asset-documents.test.ts
+++ b/npm/vite-plugin-ox-content/src/collection-asset-documents.test.ts
@@ -1,0 +1,233 @@
+import * as fs from "node:fs/promises";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { build as viteBuild, createServer, type InlineConfig, type ViteDevServer } from "vite";
+import { oxContentCustomHost } from ".";
+import type { CollectionAssetManifest } from "./collection-assets";
+import {
+  planCollectionAssetsFromDocuments,
+  type CollectionAssetDocumentInput,
+} from "./collection-asset-documents";
+import { rewriteCollectionAssetUrls } from "./collection-asset-html";
+
+const tempDirs: string[] = [];
+const activeServers: ViteDevServer[] = [];
+const activeListeners: http.Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(activeListeners.splice(0).map(closeHttpServer));
+  await Promise.all(activeServers.splice(0).map((server) => server.close().catch(() => {})));
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("planCollectionAssetsFromDocuments", () => {
+  it("plans selected Markdown and MDX local references without extension allowlists", async () => {
+    const root = await createProject("ox-collection-asset-documents-");
+    await writeContentFiles(root);
+
+    const result = await planCollectionAssetsFromDocuments({
+      root,
+      contentRoot: "content",
+      documents: [{ documentPath: "content/posts/post.mdx", pagePath: "/posts/post" }],
+      extraAssets: [{ sourcePath: "content/metadata/opengraph.png", publicPath: "/og/post.png" }],
+      publicPath: (reference) =>
+        reference.pathname === "./cover.avif"
+          ? [reference.publicPath, "/legacy/post-cover.avif"]
+          : undefined,
+    });
+
+    const sourceNames = result.manifest.assets.map((asset) => path.basename(asset.sourcePath));
+    expect(sourceNames).toEqual(["opengraph.png", "cover.avif", "guide.pdf", "poster.png"]);
+    expect(
+      result.manifest.assets.some((asset) => asset.sourcePath.endsWith("draft-secret.png")),
+    ).toBe(false);
+    expect(result.manifest.assets.some((asset) => asset.sourcePath.endsWith("unused.png"))).toBe(
+      false,
+    );
+
+    const cover = result.manifest.assets.find((asset) => asset.sourcePath.endsWith("cover.avif"));
+    expect(cover?.publicPaths).toEqual(["/posts/post/cover.avif", "/legacy/post-cover.avif"]);
+    expect(
+      result.references.find((reference) => reference.original.startsWith("./cover.avif")),
+    ).toMatchObject({ search: "?size=large", hash: "#hero" });
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({ code: "missing-file", reference: "./missing.png" }),
+      expect.objectContaining({ code: "outside-content-root", reference: "../../private.txt" }),
+    ]);
+
+    const rewritten = rewriteCollectionAssetUrls({
+      html: '<img src="./cover.avif?size=large#hero">',
+      pagePath: "/posts/post/",
+      manifest: result.manifest,
+    });
+    expect(rewritten.rewrites[0]?.replacement).toMatch(
+      /^\/assets\/content\/[a-f0-9]{64}\.avif\?size=large#hero$/u,
+    );
+  });
+
+  it("accepts structured mdast input and deduplicates repeated references", async () => {
+    const root = await createProject("ox-collection-asset-documents-ast-");
+    await fs.mkdir(path.join(root, "content", "docs"), { recursive: true });
+    await fs.writeFile(path.join(root, "content", "docs", "chart.svg"), "<svg/>");
+    await fs.writeFile(path.join(root, "content", "docs", "entry.md"), "");
+
+    const document: CollectionAssetDocumentInput = {
+      documentPath: "content/docs/entry.md",
+      pagePath: "/docs/entry",
+      ast: {
+        type: "root",
+        children: [
+          { type: "image", url: "./chart.svg" },
+          { type: "link", url: "./chart.svg" },
+          {
+            type: "mdxJsxFlowElement",
+            attributes: [{ type: "mdxJsxAttribute", name: "src", value: "./chart.svg" }],
+          },
+        ],
+      },
+    };
+
+    const result = await planCollectionAssetsFromDocuments({
+      root,
+      contentRoot: "content",
+      documents: [document],
+    });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.manifest.assets).toHaveLength(1);
+    expect(result.manifest.assets[0]?.publicPaths).toEqual(["/docs/entry/chart.svg"]);
+  });
+
+  it("integrates with custom-host build writer and development middleware", async () => {
+    const root = await createProject("ox-collection-asset-documents-custom-host-");
+    await fs.writeFile(path.join(root, "content", "posts", "cover.png"), "cover");
+    await fs.writeFile(path.join(root, "content", "posts", "post.md"), "![cover](./cover.png)");
+    await fs.writeFile(path.join(root, "src", "host.ts"), hostSource());
+    await fs.writeFile(path.join(root, "src", "main.ts"), "export {};\n");
+
+    await viteBuild(config(root, () => documentManifest(root)));
+    await expect(
+      fs.readFile(path.join(root, "dist", "posts", "post", "cover.png"), "utf8"),
+    ).resolves.toBe("cover");
+
+    const server = await trackDevServer(createServer(config(root, () => documentManifest(root))));
+    const listener = await listen(server);
+    await expect(text(listener.port, "/posts/post/cover.png")).resolves.toMatchObject({
+      status: 200,
+      text: "cover",
+    });
+  });
+});
+
+async function writeContentFiles(root: string): Promise<void> {
+  await fs.writeFile(path.join(root, "content", "posts", "cover.avif"), "cover");
+  await fs.writeFile(path.join(root, "content", "downloads", "guide.pdf"), "guide");
+  await fs.writeFile(path.join(root, "content", "posts", "poster.png"), "poster");
+  await fs.writeFile(path.join(root, "content", "metadata", "opengraph.png"), "og");
+  await fs.writeFile(path.join(root, "content", "posts", "unused.png"), "unused");
+  await fs.writeFile(path.join(root, "content", "drafts", "draft-secret.png"), "secret");
+  await fs.writeFile(path.join(root, "private.txt"), "private");
+  await fs.writeFile(
+    path.join(root, "content", "drafts", "draft.mdx"),
+    "![secret](./draft-secret.png)",
+  );
+  await fs.writeFile(
+    path.join(root, "content", "posts", "post.mdx"),
+    [
+      "![cover](./cover.avif?size=large#hero)",
+      "[download](../downloads/guide.pdf#page=2)",
+      '<video poster="./poster.png?fit=cover"></video>',
+      '<img src="/absolute.png">',
+      '<img src="data:image/png;base64,aaa">',
+      '<a href="https://example.com/file.pdf">external</a>',
+      '<img src="./missing.png">',
+      '<img src="../../private.txt">',
+      "<Image src={dynamic} />",
+      '<Image src="./cover.avif" />',
+    ].join("\n"),
+  );
+}
+
+async function createProject(prefix: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(root);
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.mkdir(path.join(root, "content", "posts"), { recursive: true });
+  await fs.mkdir(path.join(root, "content", "downloads"), { recursive: true });
+  await fs.mkdir(path.join(root, "content", "drafts"), { recursive: true });
+  await fs.mkdir(path.join(root, "content", "metadata"), { recursive: true });
+  await fs.writeFile(path.join(root, "package.json"), '{"type":"module"}\n');
+  return root;
+}
+
+async function documentManifest(root: string): Promise<CollectionAssetManifest> {
+  const result = await planCollectionAssetsFromDocuments({
+    root,
+    contentRoot: "content",
+    documents: [{ documentPath: "content/posts/post.md", pagePath: "/posts/post" }],
+  });
+  expect(result.diagnostics).toEqual([]);
+  return result.manifest;
+}
+
+function config(root: string, manifest: () => Promise<CollectionAssetManifest>): InlineConfig {
+  return {
+    root,
+    configFile: false,
+    appType: "custom",
+    logLevel: "silent",
+    plugins: [
+      ...oxContentCustomHost({
+        host: "./src/host.ts",
+        oxContent: { srcDir: "content", outDir: "dist", docs: false, search: false },
+        collectionAssets: {
+          manifest,
+          watch: [{ path: "content", kind: "directory" }],
+          ownedPrefixes: ["/assets/content"],
+        },
+      }),
+    ],
+    build: {
+      outDir: "dist",
+      emptyOutDir: true,
+      manifest: true,
+      rollupOptions: { input: path.join(root, "src", "main.ts") },
+    },
+  };
+}
+
+function hostSource(): string {
+  return `
+export default {
+  routes: [{ path: "/posts/post", render: () => ({ html: '<img src="/posts/post/cover.png">' }) }],
+};
+`;
+}
+
+async function trackDevServer(serverPromise: Promise<ViteDevServer>): Promise<ViteDevServer> {
+  const server = await serverPromise;
+  activeServers.push(server);
+  return server;
+}
+
+async function listen(server: ViteDevServer): Promise<{ server: http.Server; port: number }> {
+  const listener = http.createServer(server.middlewares);
+  activeListeners.push(listener);
+  await new Promise<void>((resolve) => listener.listen(0, "127.0.0.1", resolve));
+  const address = listener.address() as AddressInfo;
+  return { server: listener, port: address.port };
+}
+
+async function text(port: number, requestPath: string) {
+  const response = await fetch(`http://127.0.0.1:${port}${requestPath}`);
+  return { status: response.status, text: await response.text() };
+}
+
+function closeHttpServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}

--- a/npm/vite-plugin-ox-content/src/collection-asset-documents.ts
+++ b/npm/vite-plugin-ox-content/src/collection-asset-documents.ts
@@ -1,0 +1,251 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+  planCollectionAssets,
+  type CollectionAssetInput,
+  type CollectionAssetManifest,
+} from "./collection-assets";
+import {
+  collectDocumentReferences,
+  resolveDocumentReference,
+  resolvePublicPaths,
+  type ResolvedCollectionAssetDocument,
+} from "./collection-asset-document-references";
+import { isWithinOrEqual } from "./collection-asset-document-paths";
+import { importNapiModule } from "./napi";
+import type { MarkdownNode } from "./types";
+
+const DEFAULT_REFERENCE_ATTRIBUTES = ["href", "src", "poster"] as const;
+
+type MaybePromise<T> = T | Promise<T>;
+
+/** One public Markdown or MDX document whose local references may publish files. */
+export interface CollectionAssetDocumentInput {
+  /** Markdown/MDX document path, relative to `root` or absolute within it. */
+  documentPath: string;
+  /** Public page path for resolving relative aliases such as `./cover.png`. */
+  pagePath: string;
+  /** Markdown/MDX source. When omitted, `documentPath` is read from disk. */
+  source?: string;
+  /** Parsed mdast-compatible tree. Takes precedence over `source` when present. */
+  ast?: MarkdownNode;
+}
+
+/** A local document reference after resolving its source file and default alias. */
+export interface CollectionAssetResolvedDocumentReference {
+  documentPath: string;
+  pagePath: string;
+  sourcePath: string;
+  publicPath: string;
+  original: string;
+  pathname: string;
+  search: string;
+  hash: string;
+  nodeType: string;
+  attribute?: string;
+}
+
+/** A local document reference included in the resulting asset plan. */
+export interface CollectionAssetDocumentReference extends CollectionAssetResolvedDocumentReference {
+  publicPaths: string[];
+}
+
+export type CollectionAssetDocumentDiagnosticCode =
+  | "invalid-document"
+  | "invalid-public-path"
+  | "invalid-reference"
+  | "missing-document"
+  | "missing-file"
+  | "outside-content-root"
+  | "parse-error";
+
+/** Actionable diagnostic scoped to one selected document and, when relevant, one reference. */
+export interface CollectionAssetDocumentDiagnostic {
+  code: CollectionAssetDocumentDiagnosticCode;
+  documentPath: string;
+  pagePath?: string;
+  reference?: string;
+  sourcePath?: string;
+  message: string;
+}
+
+export interface PlanCollectionAssetsFromDocumentsInput {
+  documents: readonly CollectionAssetDocumentInput[];
+  root?: string;
+  /** Containment root for selected documents and resolved local files. Defaults to `root`. */
+  contentRoot?: string;
+  /** Content-addressed public output directory. Defaults to `/assets/content`. */
+  contentDir?: string;
+  /** Extra assets that are not referenced by selected document bodies. */
+  extraAssets?: readonly CollectionAssetInput[];
+  /** HTML and MDX JSX attributes to inspect. Defaults to `href`, `src`, and `poster`. */
+  attributes?: readonly string[];
+  /** Override or add public aliases for a resolved document reference. */
+  publicPath?: (
+    reference: CollectionAssetResolvedDocumentReference,
+  ) => MaybePromise<string | readonly string[] | undefined>;
+}
+
+export interface PlanCollectionAssetsFromDocumentsResult {
+  manifest: CollectionAssetManifest;
+  references: CollectionAssetDocumentReference[];
+  diagnostics: CollectionAssetDocumentDiagnostic[];
+}
+
+/**
+ * Plan content-addressed collection assets by following local references from
+ * host-selected Markdown/MDX documents.
+ */
+export async function planCollectionAssetsFromDocuments(
+  input: PlanCollectionAssetsFromDocumentsInput,
+): Promise<PlanCollectionAssetsFromDocumentsResult> {
+  const root = await fs.realpath(path.resolve(input.root ?? process.cwd()));
+  const contentRoot = await resolveContentRoot(root, input.contentRoot);
+  const attributes = new Set(input.attributes ?? DEFAULT_REFERENCE_ATTRIBUTES);
+  const diagnostics: CollectionAssetDocumentDiagnostic[] = [];
+  const references: CollectionAssetDocumentReference[] = [];
+  const referenceKeys = new Set<string>();
+  const groupedAssets = new Map<string, Set<string>>();
+
+  for (const documentInput of input.documents) {
+    const document = await resolveDocument(root, contentRoot, documentInput, diagnostics);
+    if (!document) continue;
+
+    const ast = document.ast ?? (await parseDocumentAst(document, diagnostics));
+    if (!ast) continue;
+
+    for (const rawReference of collectDocumentReferences(ast, attributes)) {
+      const resolved = await resolveDocumentReference(
+        document,
+        rawReference,
+        contentRoot,
+        diagnostics,
+      );
+      if (!resolved) continue;
+
+      const publicPaths = await resolvePublicPaths(resolved, input.publicPath, diagnostics);
+      if (publicPaths.length === 0) continue;
+
+      const referenceKey = `${resolved.sourcePath}\0${resolved.original}\0${publicPaths.join("\0")}`;
+      if (!referenceKeys.has(referenceKey)) {
+        references.push({ ...resolved, publicPaths });
+        referenceKeys.add(referenceKey);
+      }
+      const sourceAssets = groupedAssets.get(resolved.sourcePath) ?? new Set<string>();
+      for (const publicPath of publicPaths) sourceAssets.add(publicPath);
+      groupedAssets.set(resolved.sourcePath, sourceAssets);
+    }
+  }
+
+  const assets: CollectionAssetInput[] = [...(input.extraAssets ?? [])];
+  for (const [sourcePath, publicPaths] of groupedAssets) {
+    assets.push({ sourcePath, publicPath: [...publicPaths] });
+  }
+
+  return {
+    manifest: await planCollectionAssets({ root, contentDir: input.contentDir, assets }),
+    references,
+    diagnostics,
+  };
+}
+
+async function resolveContentRoot(root: string, contentRoot: string | undefined): Promise<string> {
+  const candidate = path.resolve(root, contentRoot ?? ".");
+  const resolved = await fs.realpath(candidate);
+  if (!isWithinOrEqual(root, resolved)) {
+    throw new Error(
+      `Collection asset contentRoot ${JSON.stringify(contentRoot)} must stay within root.`,
+    );
+  }
+  return resolved;
+}
+
+async function resolveDocument(
+  root: string,
+  contentRoot: string,
+  input: CollectionAssetDocumentInput,
+  diagnostics: CollectionAssetDocumentDiagnostic[],
+): Promise<ResolvedCollectionAssetDocument | undefined> {
+  if (!input.documentPath || input.documentPath.includes("\0")) {
+    diagnostics.push({
+      code: "invalid-document",
+      documentPath: input.documentPath,
+      pagePath: input.pagePath,
+      message: "Collection asset documentPath must be a non-empty file path.",
+    });
+    return undefined;
+  }
+
+  const candidate = path.resolve(root, input.documentPath);
+  if (!isWithinOrEqual(contentRoot, candidate)) {
+    diagnostics.push(outsideRootDiagnostic(input, candidate));
+    return undefined;
+  }
+
+  let documentPath: string;
+  try {
+    documentPath = await fs.realpath(candidate);
+  } catch {
+    diagnostics.push({
+      code: "missing-document",
+      documentPath: candidate,
+      pagePath: input.pagePath,
+      message: `Collection asset document ${JSON.stringify(input.documentPath)} does not exist.`,
+    });
+    return undefined;
+  }
+
+  if (!isWithinOrEqual(contentRoot, documentPath)) {
+    diagnostics.push(outsideRootDiagnostic(input, documentPath));
+    return undefined;
+  }
+
+  return { documentPath, pagePath: input.pagePath, source: input.source, ast: input.ast };
+}
+
+function outsideRootDiagnostic(
+  input: CollectionAssetDocumentInput,
+  sourcePath: string,
+): CollectionAssetDocumentDiagnostic {
+  return {
+    code: "outside-content-root",
+    documentPath: input.documentPath,
+    pagePath: input.pagePath,
+    sourcePath,
+    message: `Collection asset document ${JSON.stringify(input.documentPath)} must stay within contentRoot.`,
+  };
+}
+
+async function parseDocumentAst(
+  document: ResolvedCollectionAssetDocument,
+  diagnostics: CollectionAssetDocumentDiagnostic[],
+): Promise<MarkdownNode | undefined> {
+  let source = document.source;
+  if (source === undefined) {
+    source = await fs.readFile(document.documentPath, "utf8");
+  }
+
+  try {
+    const napi = await importNapiModule();
+    const parsed = napi.parse(source, { mdx: true, gfm: true });
+    for (const error of parsed.errors) diagnostics.push(parseDiagnostic(document, error));
+    return parsed.ast ? (JSON.parse(parsed.ast) as MarkdownNode) : undefined;
+  } catch (error) {
+    diagnostics.push(
+      parseDiagnostic(document, error instanceof Error ? error.message : String(error)),
+    );
+    return undefined;
+  }
+}
+
+function parseDiagnostic(
+  document: ResolvedCollectionAssetDocument,
+  message: string,
+): CollectionAssetDocumentDiagnostic {
+  return {
+    code: "parse-error",
+    documentPath: document.documentPath,
+    pagePath: document.pagePath,
+    message,
+  };
+}

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -1114,6 +1114,16 @@ export {
   type WriteCollectionAssetsResult,
 } from "./collection-assets";
 export {
+  planCollectionAssetsFromDocuments,
+  type CollectionAssetDocumentDiagnostic,
+  type CollectionAssetDocumentDiagnosticCode,
+  type CollectionAssetDocumentInput,
+  type CollectionAssetDocumentReference,
+  type CollectionAssetResolvedDocumentReference,
+  type PlanCollectionAssetsFromDocumentsInput,
+  type PlanCollectionAssetsFromDocumentsResult,
+} from "./collection-asset-documents";
+export {
   rewriteCollectionAssetUrls,
   type CollectionAssetUrlRewrite,
   type RewriteCollectionAssetUrlsInput,

--- a/npm/vite-plugin-ox-content/src/public-exports.test.ts
+++ b/npm/vite-plugin-ox-content/src/public-exports.test.ts
@@ -46,6 +46,7 @@ describe("public export surface", () => {
       "oxContent",
       "oxContentCustomHost",
       "planCollectionAssets",
+      "planCollectionAssetsFromDocuments",
       "planRedirectOutputs",
       "planSsgOutputs",
       "createMarkdownProcessor",

--- a/tools/scripts/package-dry-run-vite-plugin.mjs
+++ b/tools/scripts/package-dry-run-vite-plugin.mjs
@@ -6,11 +6,19 @@ import { fileURLToPath } from "node:url";
 const publicValues = [
   "resolveGitLastmods",
   "resolveSelfHostedAssetManifest",
+  "planCollectionAssetsFromDocuments",
   "writeSelfHostedAssets",
 ];
 const publicTypes = [
+  "CollectionAssetDocumentDiagnostic",
+  "CollectionAssetDocumentDiagnosticCode",
+  "CollectionAssetDocumentInput",
+  "CollectionAssetDocumentReference",
+  "CollectionAssetResolvedDocumentReference",
   "OxContentAssetManifest",
   "OxContentAssetPreload",
+  "PlanCollectionAssetsFromDocumentsInput",
+  "PlanCollectionAssetsFromDocumentsResult",
   "SelfHostedAssetOptions",
   "SsgOutputPageInput",
   "WriteSelfHostedAssetsInput",
@@ -113,7 +121,8 @@ function linkPackageDependency(consumerRoot, packageDir, dependency) {
 function collectionsFixture() {
   return [
     'import api, { collectionNames, collections, getCollection, queryCollection } from "virtual:ox-content/collections";',
-    'import type { CollectionEntry, CollectionQueryBuilder } from "@ox-content/vite-plugin";',
+    'import { planCollectionAssetsFromDocuments } from "@ox-content/vite-plugin";',
+    'import type { CollectionAssetDocumentDiagnostic, CollectionEntry, CollectionQueryBuilder, PlanCollectionAssetsFromDocumentsInput } from "@ox-content/vite-plugin";',
     "",
     "interface PostEntry extends CollectionEntry {",
     "  title: string;",
@@ -130,19 +139,32 @@ function collectionsFixture() {
     "  const first = await selected.first();",
     "  return first?.frontmatter.rank ?? 0;",
     "}",
+    "async function useDocumentAssets(): Promise<CollectionAssetDocumentDiagnostic[]> {",
+    "  const input: PlanCollectionAssetsFromDocumentsInput = {",
+    '    contentRoot: "content",',
+    '    documents: [{ documentPath: "content/posts/hello.md", pagePath: "/posts/hello" }],',
+    "    publicPath: (reference) => [reference.publicPath],",
+    "  };",
+    "  const result = await planCollectionAssetsFromDocuments(input);",
+    "  return result.diagnostics;",
+    "}",
     "",
     "void api;",
     "void names;",
     "void rows;",
     "void useTypedQuery;",
+    "void useDocumentAssets;",
   ].join("\n");
 }
 
 function cjsCollectionsFixture() {
   return [
     'import collectionsApi = require("virtual:ox-content/collections");',
+    'import vitePlugin = require("@ox-content/vite-plugin");',
+    'type CollectionAssetDocumentDiagnostic = import("@ox-content/vite-plugin").CollectionAssetDocumentDiagnostic;',
     'type CollectionEntry = import("@ox-content/vite-plugin").CollectionEntry;',
     'type CollectionQueryBuilder<T extends CollectionEntry = CollectionEntry> = import("@ox-content/vite-plugin").CollectionQueryBuilder<T>;',
+    'type PlanCollectionAssetsFromDocumentsInput = import("@ox-content/vite-plugin").PlanCollectionAssetsFromDocumentsInput;',
     "",
     "interface PostEntry extends CollectionEntry {",
     "  title: string;",
@@ -155,10 +177,18 @@ function cjsCollectionsFixture() {
     '  const entries = await builder.where("frontmatter.draft", false).all();',
     "  return entries.some((entry) => entry.frontmatter.draft === false);",
     "}",
+    "async function useDocumentAssets(): Promise<CollectionAssetDocumentDiagnostic[]> {",
+    "  const input: PlanCollectionAssetsFromDocumentsInput = {",
+    '    documents: [{ documentPath: "content/posts/hello.md", pagePath: "/posts/hello" }],',
+    "  };",
+    "  const result = await vitePlugin.planCollectionAssetsFromDocuments(input);",
+    "  return result.diagnostics;",
+    "}",
     "",
     "void collectionsApi.default;",
     "void names;",
     "void useTypedQuery;",
+    "void useDocumentAssets;",
   ].join("\n");
 }
 


### PR DESCRIPTION
## Summary

- add a public document-reference-first helper for planning custom-host collection assets from selected Markdown/MDX documents
- resolve local Markdown/HTML/MDX src/href/poster references against the real document path, with diagnostics for missing or out-of-root files
- keep explicit extra assets, alias callbacks, build/dev integration, docs, and packed-package TypeScript coverage

## Triage

Issue #1316 is valid. The current public API only accepts explicit CollectionAssetInput entries, which forces hosts to reimplement Markdown/HTML reference discovery or maintain an extension allowlist that can leak unreferenced files and miss valid referenced assets. This PR keeps existing explicit callers supported while adding a narrower selected-document boundary.

Fixes #1316

## Validation

- rtk node tools/scripts/check-file-lines.ts
- rtk vp test npm/vite-plugin-ox-content/src/collection-asset-documents.test.ts npm/vite-plugin-ox-content/src/public-exports.test.ts
- rtk vp run check:ts
- rtk vp run build:npm
- rtk node tools/scripts/package-dry-run.mjs
- rtk git diff --check HEAD~1..HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791350557&installation_model_id=422833&pr_number=1340&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1340&signature=891d42e9c0338f5914c31bdd3638736679242a72b6e6a3c96e3bf3ff4e354297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `planCollectionAssetsFromDocuments()` to generate collection-asset manifests from selected Markdown and MDX documents.
  - Automatically discovers local images, links, and media references, including HTML/MDX attributes.
  - Supports additional assets, custom public-path aliases, URL filtering, and preservation of query strings and fragments.
  - Reports diagnostics for missing, invalid, unsafe, or out-of-scope references.

- **Documentation**
  - Added English and Japanese usage examples and guidance for document-based collection asset planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->