### PR TITLE
feat(custom-host): serve feed outputs in dev

### DIFF
--- a/docs/content/built-in/custom-host.md
+++ b/docs/content/built-in/custom-host.md
@@ -126,12 +126,18 @@ response, while
 `dev.routeDependencies` also clears and reloads the route catalogue.
 Modules loaded through `ctx.loadModule()` and CSS returned by
 `ctx.assets.stylesheets()` are tracked automatically in development.
+Set `dev.feedOutputs: true` to serve configured RSS, Atom, and JSON feed files
+from `outputs(ctx)` in development. Explicit host routes win when they use the
+same path. Missing feed paths fall through to the host `notFound()` handler or
+Vite, and failed feed renders are not cached so the next matching request can
+retry after the source or module error is fixed.
 
 In production, the plugin runs once from `closeBundle`, after Vite has emitted
 client assets and `.vite/manifest.json`. It opens a temporary middleware-mode
 Vite server only to SSR-load the host and site modules, passes `ctx.loadModule`
 instead of the raw server, and closes the temporary server in `finally`.
-`outputs(ctx)` is build-only and is called only when `feeds` is enabled.
+`outputs(ctx)` is called only when `feeds` is enabled. It is build-only unless
+the development server opts into `dev.feedOutputs`.
 
 `ctx.memo(key, load)` shares one expensive route-catalogue load inside a build
 or development route-catalogue pass. Use the same key from `routes(ctx)` and
@@ -157,6 +163,10 @@ describe that HTML page. Site-output data that is not itself a page belongs in
 `collectionNames`, and `siteDescription`. Ox Content passes that data through
 `planSsgOutputs()` and the existing feed writers, so publish-state filtering,
 validation, output paths, and diagnostics stay shared with the built-in SSG.
+With `dev.feedOutputs: true`, the same feed channels and `outputs(ctx)` data
+are rendered on demand without writing files. The development server still does
+not render every page to serve one feed; hosts should return feed collections or
+programmatic `items` from `outputs(ctx)` for feed-only data.
 
 Set `ssg.minifyHtml: true` for built-in SSG pages or
 `build.minifyHtml: true` on the custom-host plugin to minify production HTML.

--- a/docs/content/built-in/feeds.md
+++ b/docs/content/built-in/feeds.md
@@ -121,10 +121,12 @@ Programmatic items support `title`, `url` or `loc`, optional `id`, `date`,
 format supports.
 
 Custom hosts that already load feed data while planning routes can return that
-data from the build-only `outputs(ctx)` lifecycle instead of reloading it from
+data from the normally build-only `outputs(ctx)` lifecycle instead of reloading it from
 `feeds.items`. Return default `items`, named `collections`, and optional
 `collectionNames`; Ox Content still uses the same `writeFeedFiles()` path and
 publish-state filtering. See [Custom host lifecycle](./custom-host.md).
+Set `dev.feedOutputs: true` on `oxContentCustomHost()` to serve those coordinated
+feed files during Vite development without adding duplicate feed routes.
 
 ## Custom dev servers
 

--- a/docs/content/ja/built-in/custom-host.md
+++ b/docs/content/ja/built-in/custom-host.md
@@ -97,12 +97,19 @@ production では Vite が client asset と `.vite/manifest.json` を出した�
 `closeBundle` から一度だけ走ります。host と site module を SSR load するためだけに
 一時的な middleware-mode Vite server を開き、raw server ではなく `ctx.loadModule` を
 渡し、`finally` で必ず閉じます。
-`outputs(ctx)` は build 専用で、`feeds` が有効なときだけ呼ばれます。
+`outputs(ctx)` は `feeds` が有効なときだけ呼ばれます。開発 server が
+`dev.feedOutputs` に opt-in しない限り build 専用です。
 
 `ctx.memo(key, load)` は、1 回の build または development route catalogue 生成中に
 高価な読み込みを共有します。`routes(ctx)` と `outputs(ctx)` で同じ key を使えば、
 module-global mutable state なしで host-owned content artifact を再利用できます。
 失敗した loader は memo から消えるので次回 retry できます。
+
+`dev.feedOutputs: true` を設定すると、開発中も `outputs(ctx)` から設定済みの
+RSS、Atom、JSON feed file を配信します。同じ path の明示 route がある場合は host
+route が優先されます。存在しない feed path は host の `notFound()` か Vite へ fall
+through し、失敗した feed render は cache しないため、source や module error を
+直したあとの次の一致リクエストで再試行できます。
 
 ## 協調する出力
 
@@ -121,6 +128,10 @@ programmatic default `items`、名前付き feed `collections`、`collectionName
 `siteDescription` がそれです。Ox Content はその data を `planSsgOutputs()` と既存の
 feed writer に流すので、publish-state filtering、validation、output path、diagnostic は
 組み込み SSG と共有されます。
+`dev.feedOutputs: true` のときは、同じ feed channel と `outputs(ctx)` の data を
+file へ書かずにオンデマンドで render します。1 つの feed を配信するために全 page
+を render することはありません。feed 専用の data は、host が `outputs(ctx)` から
+feed collection か programmatic `items` として返してください。
 
 組み込み SSG page には `ssg.minifyHtml: true`、独自ホスト plugin には
 `build.minifyHtml: true` を指定すると production HTML を minify します。独自ホストの

--- a/docs/content/ja/built-in/feeds.md
+++ b/docs/content/ja/built-in/feeds.md
@@ -114,10 +114,12 @@ oxContent({
 JSON Feed の各 renderer は、その形式が対応する field を出力します。
 
 独自ホストが route planning の時点で feed data をすでに読み込んでいる場合は、
-`feeds.items` でもう一度読み込む代わりに、build 専用の `outputs(ctx)` lifecycle
+`feeds.items` でもう一度読み込む代わりに、通常は build 専用の `outputs(ctx)` lifecycle
 から返せます。default `items`、名前付き `collections`、任意の `collectionNames`
 を返してください。Ox Content は同じ `writeFeedFiles()` path と publish-state filtering
 を使います。[独自ホスト lifecycle](./custom-host.md) も見てください。
+`oxContentCustomHost()` に `dev.feedOutputs: true` を設定すると、重複した feed
+route を足さずに、Vite 開発中もその coordinated feed file を配信できます。
 
 ## 独自 dev server
 

--- a/npm/vite-plugin-ox-content/src/custom-host-dev-feeds.test.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-dev-feeds.test.ts
@@ -1,0 +1,252 @@
+import * as fs from "node:fs/promises";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { build as viteBuild, createServer, type InlineConfig, type ViteDevServer } from "vite";
+import { oxContentCustomHost, type FeedsOptions, type OxContentCustomHostOptions } from ".";
+
+const tempDirs: string[] = [];
+const activeServers: ViteDevServer[] = [];
+const activeListeners: http.Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(activeListeners.splice(0).map((server) => closeHttpServer(server)));
+  await Promise.all(activeServers.splice(0).map((server) => server.close().catch(() => {})));
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("custom host dev feeds", () => {
+  it("serves coordinated feed outputs before custom notFound without rendering pages", async () => {
+    const root = await createProject("ox-custom-host-dev-feeds-");
+    await fs.writeFile(path.join(root, "src", "feed-data.ts"), feedDataModule("First Post"));
+    await fs.writeFile(path.join(root, "src", "host.ts"), coordinatedFeedHostModule());
+    const server = await trackDevServer(
+      createServer(config(root, { dev: { feedOutputs: true, reloadDebounceMs: 1 } })),
+    );
+    const listener = await listen(server);
+
+    const blogFeed = await text(listener.port, "/blog/feed.xml");
+    expect(blogFeed.status).toBe(200);
+    expect(blogFeed.contentType).toContain("application/rss+xml");
+    expect(blogFeed.text).toContain("<title>First Post</title>");
+    expect(blogFeed.text).not.toContain("Guest appearance");
+
+    const mediaFeed = await text(listener.port, "/works/media/feed.json");
+    expect(mediaFeed.status).toBe(200);
+    expect(mediaFeed.contentType).toContain("application/feed+json");
+    expect(mediaFeed.text).toContain('"title": "Guest appearance"');
+    expect(mediaFeed.text).not.toContain("First Post");
+
+    expect(await text(listener.port, "/missing/feed.xml")).toMatchObject({
+      status: 404,
+      text: "custom 404",
+    });
+    expect(await text(listener.port, "/")).toMatchObject({ status: 200 });
+    expect((await text(listener.port, "/")).text).toContain("renders:1");
+
+    await viteBuild(config(root, { dev: { feedOutputs: true } }));
+    await expect(fs.readFile(path.join(root, "dist", "blog", "feed.xml"), "utf8")).resolves.toBe(
+      blogFeed.text,
+    );
+  });
+
+  it("retries failed output renders and invalidates tracked feed data", async () => {
+    const root = await createProject("ox-custom-host-dev-feeds-retry-");
+    const dataPath = path.join(root, "src", "feed-data.ts");
+    await fs.writeFile(dataPath, retryFeedDataModule("Initial title"));
+    await fs.writeFile(path.join(root, "src", "host.ts"), retryingFeedHostModule());
+    const server = await trackDevServer(
+      createServer(
+        config(root, {
+          dev: { feedOutputs: true, reloadDebounceMs: 1 },
+          feeds: { formats: ["rss"], path: "/" },
+        }),
+      ),
+    );
+    const listener = await listen(server);
+
+    expect((await text(listener.port, "/feed.xml")).status).toBe(500);
+    expect(await text(listener.port, "/feed.xml")).toMatchObject({
+      status: 200,
+      contentType: expect.stringContaining("application/rss+xml"),
+    });
+
+    await fs.writeFile(dataPath, retryFeedDataModule("Updated title"));
+    server.watcher.emit("change", dataPath);
+    await wait(30);
+
+    const updated = await text(listener.port, "/feed.xml");
+    expect(updated.text).toContain("<title>Updated title</title>");
+    expect(updated.text).not.toContain("Initial title");
+  });
+});
+
+function config(
+  root: string,
+  input: {
+    dev?: NonNullable<OxContentCustomHostOptions["dev"]>;
+    feeds?: boolean | FeedsOptions;
+  } = {},
+): InlineConfig {
+  return {
+    root,
+    configFile: false,
+    appType: "custom",
+    logLevel: "silent",
+    plugins: [
+      ...oxContentCustomHost({
+        host: "./src/host.ts",
+        dev: input.dev,
+        oxContent: {
+          srcDir: "content",
+          outDir: "dist",
+          resources: false,
+          docs: false,
+          search: false,
+          ogViewer: false,
+          feeds:
+            input.feeds ??
+            ({
+              blog: { formats: ["rss"], collection: "blog", path: "/blog" },
+              media: { formats: ["json"], collection: "media", path: "/works/media" },
+            } satisfies FeedsOptions),
+          siteMaps: false,
+          ssg: { siteUrl: "https://example.com", siteName: "Example" },
+        },
+      }),
+    ],
+    build: {
+      outDir: "dist",
+      emptyOutDir: true,
+      manifest: true,
+      rollupOptions: { input: path.join(root, "src", "main.ts") },
+    },
+  };
+}
+
+async function createProject(prefix: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(root);
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.mkdir(path.join(root, "content"), { recursive: true });
+  await fs.writeFile(path.join(root, "package.json"), '{"type":"module"}\n');
+  await fs.writeFile(path.join(root, "src", "main.ts"), "export {};\n");
+  return root;
+}
+
+function feedDataModule(title: string): string {
+  return `
+export const siteDescription = "Programmatic output data";
+export const blog = [{ title: ${JSON.stringify(title)}, path: "/blog/first", date: "2026-09-01" }];
+export const media = [{
+  title: "Guest appearance",
+  loc: "https://media.example.com/episode",
+  date: "2026-09-02",
+}];
+`;
+}
+
+function retryFeedDataModule(title: string): string {
+  return `export const title = ${JSON.stringify(title)};\n`;
+}
+
+function coordinatedFeedHostModule(): string {
+  return `
+let pageRenders = 0;
+let loadCalls = 0;
+let latestRouteLoad = 0;
+
+async function content(ctx) {
+  return ctx.memo("content", async () => {
+    loadCalls += 1;
+    const data = await ctx.loadModule("/src/feed-data.ts");
+    return { ...data, loadCalls };
+  });
+}
+
+export default {
+  async routes(ctx) {
+    const data = await content(ctx);
+    latestRouteLoad = data.loadCalls;
+    return [
+      {
+        path: "/",
+        render() {
+          pageRenders += 1;
+          return { html: "<!doctype html><html><body><h1>renders:" + pageRenders + "</h1></body></html>" };
+        },
+      },
+    ];
+  },
+  async outputs(ctx) {
+    const data = await content(ctx);
+    if (data.loadCalls !== latestRouteLoad) {
+      throw new Error("dev feed outputs did not share route memo");
+    }
+    return {
+      siteDescription: data.siteDescription,
+      collectionNames: ["blog", "media"],
+      collections: { blog: data.blog, media: data.media },
+    };
+  },
+  notFound() {
+    return { text: "custom 404", status: 404, contentType: "text/plain" };
+  },
+};
+`;
+}
+
+function retryingFeedHostModule(): string {
+  return `
+let attempts = 0;
+
+export default {
+  routes: [{ path: "/", render: () => ({ html: "<h1>Home</h1>" }) }],
+  async outputs(ctx) {
+    attempts += 1;
+    if (attempts === 1) {
+      throw new Error("transient feed output failure");
+    }
+    const data = await ctx.memo("feed-data", () => ctx.loadModule("/src/feed-data.ts"));
+    return {
+      items: [{ title: data.title, path: "/updates", date: "2026-09-03" }],
+    };
+  },
+};
+`;
+}
+
+async function trackDevServer(serverPromise: Promise<ViteDevServer>): Promise<ViteDevServer> {
+  const server = await serverPromise;
+  activeServers.push(server);
+  return server;
+}
+
+async function listen(server: ViteDevServer): Promise<{ server: http.Server; port: number }> {
+  const listener = http.createServer(server.middlewares);
+  activeListeners.push(listener);
+  await new Promise<void>((resolve) => listener.listen(0, "127.0.0.1", resolve));
+  const address = listener.address() as AddressInfo;
+  return { server: listener, port: address.port };
+}
+
+async function text(port: number, requestPath: string) {
+  const response = await fetch(`http://127.0.0.1:${port}${requestPath}`);
+  return {
+    status: response.status,
+    contentType: response.headers.get("content-type") ?? "",
+    text: await response.text(),
+  };
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function closeHttpServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}

--- a/npm/vite-plugin-ox-content/src/custom-host-dev-feeds.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-dev-feeds.ts
@@ -1,0 +1,186 @@
+import * as path from "node:path";
+import type { ViteDevServer } from "vite";
+import { createTrackedContext } from "./custom-host-dev-response";
+import { createOutputsContext, loadOutputs } from "./custom-host-loader";
+import type {
+  DevCacheEntry,
+  OxContentCustomHostBaseContext,
+  OxContentCustomHostDependency,
+  OxContentCustomHostMemo,
+  OxContentCustomHostModule,
+  OxContentCustomHostOptions,
+  OxContentCustomHostRoute,
+} from "./custom-host-types";
+import {
+  deserializeResponse,
+  normalizeRoutePath,
+  serializeResponse,
+  stripBasePathname,
+} from "./custom-host-utils";
+import { feedOutputFileName, feedOutputPath, feedOutputWarning } from "./feeds-output";
+import { renderFeedFiles } from "./feeds";
+import { planSsgOutputs } from "./ssg-output";
+import type { OxContentOptions, ResolvedFeedChannel, ResolvedOptions } from "./types";
+
+type DevRoutesState = {
+  routes: readonly OxContentCustomHostRoute[];
+  memo: OxContentCustomHostMemo;
+};
+
+type FeedMatch = {
+  path: string;
+  warning?: string;
+};
+
+export const CUSTOM_HOST_DEV_FEED_CACHE_PREFIX = "feed\0";
+
+export function createCustomHostDevFeedResponder(input: {
+  server: ViteDevServer;
+  hostOptions: OxContentCustomHostOptions;
+  rawOptions: OxContentOptions;
+  context: OxContentCustomHostBaseContext;
+  loadHost(): Promise<OxContentCustomHostModule>;
+  loadRoutesState(): Promise<DevRoutesState>;
+  cache: Map<string, DevCacheEntry>;
+  rememberDeps(key: string, dependencies: readonly OxContentCustomHostDependency[]): void;
+}): (request: Request) => Promise<Response | undefined> {
+  return async (request) => {
+    if (input.hostOptions.dev?.feedOutputs !== true) {
+      return undefined;
+    }
+    const match = matchFeedRequest(request, input.context.options);
+    if (!match) {
+      return undefined;
+    }
+    if (match.warning) {
+      input.server.config.logger.warn(match.warning);
+      return undefined;
+    }
+
+    const routesState = await input.loadRoutesState();
+    if (hasExplicitRoute(routesState.routes, match.path)) {
+      return undefined;
+    }
+
+    const key = `${CUSTOM_HOST_DEV_FEED_CACHE_PREFIX}${match.path}`;
+    let entry = input.cache.get(key);
+    if (!entry) {
+      const current: DevCacheEntry = {
+        promise: renderDevFeedResponse(input, routesState, match.path)
+          .then((serialized) => {
+            if (serialized && input.cache.get(key) === current) {
+              input.rememberDeps(key, serialized.dependencies);
+            }
+            return serialized;
+          })
+          .catch((error) => {
+            if (input.cache.get(key) === current) {
+              input.cache.delete(key);
+            }
+            throw error;
+          }),
+      };
+      entry = current;
+      input.cache.set(key, entry);
+    }
+
+    const serialized = await entry.promise;
+    if (!serialized) {
+      return undefined;
+    }
+    return deserializeResponse(serialized, request.method === "HEAD");
+  };
+}
+
+async function renderDevFeedResponse(
+  input: {
+    server: ViteDevServer;
+    hostOptions: OxContentCustomHostOptions;
+    rawOptions: OxContentOptions;
+    context: OxContentCustomHostBaseContext;
+    loadHost(): Promise<OxContentCustomHostModule>;
+  },
+  routesState: DevRoutesState,
+  requestedPath: string,
+) {
+  const host = await input.loadHost();
+  const trackedDependencies = new Set<OxContentCustomHostDependency>();
+  const outputContext = createTrackedContext(
+    createOutputsContext(input.context, routesState.routes, routesState.memo),
+    input.server,
+    trackedDependencies,
+  );
+  const outputData = await loadOutputs(host, outputContext);
+  const plan = planSsgOutputs({
+    pages: [],
+    root: input.context.root,
+    outDir: input.context.outDir,
+    srcDir: path.resolve(input.context.root, input.context.options.srcDir),
+    options: input.rawOptions,
+    siteDescription: outputData?.siteDescription,
+    collections: outputData?.collections,
+    collectionNames: outputData?.collectionNames,
+    items: outputData?.items,
+  });
+  const rendered = await renderFeedFiles(plan.feeds);
+  if (rendered.warning) {
+    input.server.config.logger.warn(rendered.warning);
+    return undefined;
+  }
+  const file = rendered.files.find((candidate) => candidate.path === requestedPath);
+  if (!file) {
+    return undefined;
+  }
+  return serializeResponse(
+    new Response(file.content, {
+      headers: { "content-type": file.contentType },
+      status: 200,
+    }),
+    [...trackedDependencies, ...(input.hostOptions.dev?.dependencies ?? [])],
+  );
+}
+
+function matchFeedRequest(request: Request, options: ResolvedOptions): FeedMatch | undefined {
+  if (!options.feeds?.enabled) {
+    return undefined;
+  }
+  const url = new URL(request.url);
+  const pathname = stripBasePathname(url.pathname, options.base);
+  if (!pathname) {
+    return undefined;
+  }
+  const requestedPath = pathname.replace(/^\/+/u, "");
+  if (!requestedPath) {
+    return undefined;
+  }
+
+  const channels = feedChannels(options.feeds);
+  const candidates = new Set<string>();
+  for (const channel of channels) {
+    for (const format of channel.formats) {
+      const outputPath = feedOutputPath(channel.path, feedOutputFileName(format));
+      if (outputPath) {
+        candidates.add(outputPath);
+      }
+    }
+  }
+  if (!candidates.has(requestedPath)) {
+    return undefined;
+  }
+  return { path: requestedPath, warning: feedOutputWarning(undefined, channels) };
+}
+
+function hasExplicitRoute(
+  routes: readonly OxContentCustomHostRoute[],
+  requestedPath: string,
+): boolean {
+  const routePath = normalizeRoutePath(`/${requestedPath}`);
+  return routes.some((route) => normalizeRoutePath(route.path) === routePath);
+}
+
+function feedChannels(options: ResolvedOptions["feeds"]): ResolvedFeedChannel[] {
+  if (!options?.enabled) {
+    return [];
+  }
+  return options.feeds?.length ? options.feeds : [options];
+}

--- a/npm/vite-plugin-ox-content/src/custom-host-dev.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-dev.ts
@@ -16,11 +16,16 @@ import { createTrackedContext, devResponse } from "./custom-host-dev-response";
 import type {
   DevCacheEntry,
   OxContentCustomHostDependency,
+  OxContentCustomHostMemo,
   OxContentCustomHostModule,
   OxContentCustomHostOptions,
   OxContentCustomHostRoute,
   ResolvedThemeTokens,
 } from "./custom-host-types";
+import {
+  createCustomHostDevFeedResponder,
+  CUSTOM_HOST_DEV_FEED_CACHE_PREFIX,
+} from "./custom-host-dev-feeds";
 import {
   canonicalFilePath,
   clearKeyDeps,
@@ -31,7 +36,6 @@ import {
   versionedModuleId,
   writeConnectResponse,
 } from "./custom-host-utils";
-import type { ResolvedOptions } from "./types";
 import {
   anyCustomHostDependencyMatches,
   broadDependencies,
@@ -40,12 +44,19 @@ import {
   normalizeCustomHostDependencies,
   type NormalizedCustomHostDependency,
 } from "./custom-host-watch";
+import type { OxContentOptions, ResolvedOptions } from "./types";
+
+type DevRoutesState = {
+  routes: readonly OxContentCustomHostRoute[];
+  memo: OxContentCustomHostMemo;
+};
 
 export function configureDevServer(
   server: ViteDevServer,
   input: OxContentCustomHostOptions,
   options: ResolvedOptions,
   themeTokens: ResolvedThemeTokens | undefined,
+  rawOptions: OxContentOptions,
 ): void {
   const root = server.config.root;
   const outDir = resolveOutDir(server.config, options, root);
@@ -74,7 +85,7 @@ export function configureDevServer(
   );
   let routeCatalogueDependencies = [...configuredRouteDependencies];
   let hostPromise: Promise<OxContentCustomHostModule> | undefined;
-  let routesPromise: Promise<readonly OxContentCustomHostRoute[]> | undefined;
+  let routesStatePromise: Promise<DevRoutesState> | undefined;
   let routesGeneration = 0;
   let reloadTimer: ReturnType<typeof setTimeout> | undefined;
   const addedWatchPaths = new Set<string>();
@@ -137,17 +148,19 @@ export function configureDevServer(
 
   const clearHost = () => {
     hostPromise = undefined;
-    routesPromise = undefined;
-    routesGeneration += 1;
-    routeCatalogueDependencies = [...configuredRouteDependencies];
+    clearRouteState();
     clearResponses();
   };
 
   const clearRoutes = () => {
-    routesPromise = undefined;
+    clearRouteState();
+    clearResponses();
+  };
+
+  const clearRouteState = () => {
+    routesStatePromise = undefined;
     routesGeneration += 1;
     routeCatalogueDependencies = [...configuredRouteDependencies];
-    clearResponses();
   };
 
   const loadCachedHost = async () => {
@@ -163,8 +176,8 @@ export function configureDevServer(
     return hostPromise;
   };
 
-  const loadCachedRoutes = async () => {
-    if (!routesPromise) {
+  const loadCachedRoutesState = async (): Promise<DevRoutesState> => {
+    if (!routesStatePromise) {
       const generation = routesGeneration;
       const memo = createContextMemo();
       const trackedDependencies = new Set<OxContentCustomHostDependency>();
@@ -176,23 +189,25 @@ export function configureDevServer(
       const current = loadCachedHost()
         .then((host) => loadRoutes(host, context))
         .then((routes) => {
-          if (routesPromise === current && routesGeneration === generation) {
+          if (routesStatePromise === current && routesGeneration === generation) {
             const inferred = normalizeCustomHostDependencies(root, [...trackedDependencies]);
             routeCatalogueDependencies = [...configuredRouteDependencies, ...inferred];
             addWatchPaths(dependencyWatchPaths(routeCatalogueDependencies));
           }
-          return routes;
+          return { routes, memo };
         })
         .catch((error) => {
-          if (routesPromise === current) {
-            routesPromise = undefined;
+          if (routesStatePromise === current) {
+            routesStatePromise = undefined;
           }
           throw error;
         });
-      routesPromise = current;
+      routesStatePromise = current;
     }
-    return routesPromise;
+    return routesStatePromise;
   };
+
+  const loadCachedRoutes = async () => (await loadCachedRoutesState()).routes;
 
   collectionAssets = createCustomHostCollectionAssetsDevController({
     server,
@@ -206,6 +221,16 @@ export function configureDevServer(
       clearResponses();
       scheduleReload();
     },
+  });
+  const feedResponse = createCustomHostDevFeedResponder({
+    server,
+    hostOptions: input,
+    rawOptions,
+    context: baseContext,
+    loadHost: loadCachedHost,
+    loadRoutesState: loadCachedRoutesState,
+    cache,
+    rememberDeps,
   });
 
   const onChange = (_event: string, file: string) => {
@@ -233,7 +258,9 @@ export function configureDevServer(
       clearResponses();
       invalidated = true;
     }
+    let routeStateInvalidated = false;
     for (const key of Array.from(depKeys.get(changed) ?? [])) {
+      routeStateInvalidated ||= key.startsWith(CUSTOM_HOST_DEV_FEED_CACHE_PREFIX);
       clearKey(key);
       invalidated = true;
     }
@@ -241,11 +268,15 @@ export function configureDevServer(
       if (
         dependencies.some((dependency) => anyCustomHostDependencyMatches([dependency], changed))
       ) {
+        routeStateInvalidated ||= key.startsWith(CUSTOM_HOST_DEV_FEED_CACHE_PREFIX);
         clearKey(key);
         invalidated = true;
       }
     }
     if (invalidated) {
+      if (routeStateInvalidated) {
+        clearRouteState();
+      }
       ssrVersion += 1;
       invalidateViteModules(server, changed, true);
       scheduleReload();
@@ -271,16 +302,18 @@ export function configureDevServer(
     }
 
     try {
-      const response = await devResponse({
-        request,
-        server,
-        input,
-        context: baseContext,
-        loadHost: loadCachedHost,
-        loadRoutes: loadCachedRoutes,
-        cache,
-        rememberDeps,
-      });
+      const response =
+        (await feedResponse(request)) ??
+        (await devResponse({
+          request,
+          server,
+          input,
+          context: baseContext,
+          loadHost: loadCachedHost,
+          loadRoutes: loadCachedRoutes,
+          cache,
+          rememberDeps,
+        }));
       if (!response) {
         next();
         return;

--- a/npm/vite-plugin-ox-content/src/custom-host-types.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-types.ts
@@ -49,6 +49,8 @@ export interface OxContentCustomHostDevOptions {
   enabled?: boolean;
   /** Apply Vite `transformIndexHtml` to HTML responses. */
   transformHtml?: boolean;
+  /** Serve feed files from the host `outputs(ctx)` lifecycle in development. */
+  feedOutputs?: boolean;
   /** Debounce for full reloads after dependency invalidation. */
   reloadDebounceMs?: number;
   /** Dependencies that invalidate every cached route response in development. */

--- a/npm/vite-plugin-ox-content/src/custom-host.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host.ts
@@ -66,7 +66,7 @@ export function createOxContentCustomHostPlugin(input: OxContentCustomHostOption
       if (process.env[LOAD_ENV] === "1" || input.dev?.enabled === false) {
         return;
       }
-      configureDevServer(server, input, resolvedOptions, themeTokens);
+      configureDevServer(server, input, resolvedOptions, themeTokens, oxContentOptions);
     },
 
     async closeBundle() {


### PR DESCRIPTION
## Summary

- add `dev.feedOutputs` for opt-in custom-host development feed serving
- render configured RSS/Atom/JSON feed outputs on demand from the host `outputs(ctx)` data without rendering pages or writing files
- preserve explicit route priority, custom notFound fallthrough, retry-on-failure behavior, and tracked dependency invalidation

## Triage

Issue #1319 is valid. The production custom-host lifecycle can coordinate feed output data through `outputs(ctx)`, but development currently requires duplicate feed routes or a host-owned `renderFeedFiles()` adapter. This PR keeps existing consumers unchanged by making development feed serving opt-in.

Fixes #1319

## Validation

- rtk vp install
- rtk vp check --fix npm/vite-plugin-ox-content/src/custom-host.ts npm/vite-plugin-ox-content/src/custom-host-types.ts npm/vite-plugin-ox-content/src/custom-host-dev.ts npm/vite-plugin-ox-content/src/custom-host-dev-feeds.ts npm/vite-plugin-ox-content/src/custom-host-dev-feeds.test.ts docs/content/built-in/custom-host.md docs/content/built-in/feeds.md docs/content/ja/built-in/custom-host.md docs/content/ja/built-in/feeds.md
- rtk node tools/scripts/check-file-lines.ts
- rtk vp test npm/vite-plugin-ox-content/src/custom-host-dev-feeds.test.ts npm/vite-plugin-ox-content/src/custom-host-output-data.test.ts
- rtk vp run check:ts
- rtk vp run build:npm
- rtk node tools/scripts/package-dry-run.mjs
- rtk git diff --check HEAD~1..HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791351628&installation_model_id=422833&pr_number=1341&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1341&signature=8a4159021761c178779e65510cf4bdb4a4239cc2615b4276f336c9c049bf54d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom hosts can now serve configured RSS, Atom, and JSON feeds during development when feed outputs are enabled.
  * Feed responses are generated on demand without rendering every page or creating files.
  * Explicit host routes take priority, while missing feeds fall through to normal handling.
  * Failed feed renders are retried, and feed data updates are reflected after source changes.

* **Documentation**
  * Added guidance for enabling development feed outputs and using coordinated feed data in custom hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->