### PR TITLE
feat(solid): discover html host islands from collections

### DIFF
--- a/docs/content/ja/packages/vite-plugin-ox-content-solid.md
+++ b/docs/content/ja/packages/vite-plugin-ox-content-solid.md
@@ -124,12 +124,56 @@ hydration ではなく fresh mount の bridge です。既存の Ox Content isla
 authoring 時の slot HTML を読み、target を空にしてから caller の `@solidjs/web` renderer に
 渡します。SSR 済み self-closing island の rendered HTML は children として渡しません。
 
+production custom host では source directory 全体の `import.meta.glob()` ではなく、同じ
+公開ポリシーで選ばれた document だけから browser module map を作ります。page が Ox
+Content collection から来る場合は、registry に設定済み collection source を読ませ、公開
+ルールは `collectionDocuments.select` に残します。独自の catalogue を host が持つ場合は、
+従来通り明示 `documents` callback も使えます。
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import solid from "@solidjs/vite-plugin";
+import { oxContentCustomHost } from "@ox-content/vite-plugin";
+import { createSolidHtmlHostIslandRegistry } from "@ox-content/vite-plugin-solid";
+
+const oxContent = {
+  srcDir: "content",
+  collections: {
+    blog: "blog/**/*.mdx",
+  },
+};
+
+const solidIslands = createSolidHtmlHostIslandRegistry({
+  oxContent,
+  collectionDocuments: {
+    select(document, context) {
+      return context.command === "serve" || document.frontmatter.published === true;
+    },
+  },
+});
+
+export default defineConfig({
+  appType: "custom",
+  plugins: [
+    solidIslands.plugin,
+    oxContentCustomHost({ host: "./src/site-host.ts", oxContent }),
+    solid({ compiler: "native" }),
+  ],
+});
+```
+
+registry は各 file を `documentPath` として保持し、raw Markdown / MDX `source` を読むため、
+document-local import は renderer と同じ module identity になります。flat file と directory
+index を含む collection `source` pattern を再利用し、Vite config 中に
+`virtual:ox-content/collections` を import しません。development では設定済み content root
+配下の追加、変更、削除で registry が invalidation されます。
+
 ```tsx
 import { initIslands } from "@ox-content/islands";
 import { render } from "@solidjs/web";
 import { initSolidHtmlHost } from "@ox-content/vite-plugin-solid/html-host/client";
-
-const modules = import.meta.glob("./{docs,components}/**/*.tsx");
+import modules from "virtual:ox-content-solid/html-host/modules";
 
 initSolidHtmlHost({
   initIslands,

--- a/docs/content/packages/vite-plugin-ox-content-solid.md
+++ b/docs/content/packages/vite-plugin-ox-content-solid.md
@@ -229,10 +229,12 @@ slot HTML, clears the target, and lets the caller mount with `@solidjs/web`.
 When SSR produced HTML for a self-closing island, that rendered output is not
 passed back as children.
 
-For production custom hosts, generate the module map from the same
-site-selected document set instead of a broad source-directory glob. Keep the
-publication rule in your site code and share that selected list with both the
-custom host routes and the registry plugin.
+For production custom hosts, generate the module map from the same selected
+document policy instead of a broad source-directory glob. When selected pages
+come from configured Ox Content collections, let the registry read those
+collection sources and keep the publication rule in `collectionDocuments.select`.
+If a host already owns a separate catalogue, the explicit `documents` callback
+remains supported.
 
 ```ts
 // vite.config.ts
@@ -240,25 +242,40 @@ import { defineConfig } from "vite";
 import solid from "@solidjs/vite-plugin";
 import { oxContentCustomHost } from "@ox-content/vite-plugin";
 import { createSolidHtmlHostIslandRegistry } from "@ox-content/vite-plugin-solid";
-import { selectedDocuments } from "./src/site-content";
+
+const oxContent = {
+  srcDir: "content",
+  collections: {
+    blog: "blog/**/*.mdx",
+  },
+};
 
 const solidIslands = createSolidHtmlHostIslandRegistry({
-  documents: async () =>
-    (await selectedDocuments()).map((document) => ({
-      documentPath: document.file,
-      source: document.source,
-    })),
+  oxContent,
+  collectionDocuments: {
+    select(document, context) {
+      return context.command === "serve" || document.frontmatter.published === true;
+    },
+  },
 });
 
 export default defineConfig({
   appType: "custom",
   plugins: [
     solidIslands.plugin,
-    oxContentCustomHost({ host: "./src/site-host.ts" }),
+    oxContentCustomHost({ host: "./src/site-host.ts", oxContent }),
     solid({ compiler: "native" }),
   ],
 });
 ```
+
+The registry preserves each matched file as `documentPath` and reads the raw
+Markdown or MDX `source`, so document-local imports keep the same post-local
+module identity as the renderer. It reuses collection `source` patterns,
+including flat files and directory indexes, without importing
+`virtual:ox-content/collections` during Vite configuration. Development changes
+under the configured content root invalidate the registry, including source
+adds, edits, and deletes.
 
 ```ts
 // src/site-host.ts

--- a/npm/vite-plugin-ox-content-solid/src/html-host-collection-documents.test.ts
+++ b/npm/vite-plugin-ox-content-solid/src/html-host-collection-documents.test.ts
@@ -1,0 +1,293 @@
+import fs from "node:fs/promises";
+import * as os from "node:os";
+import path from "node:path";
+import solid from "@solidjs/vite-plugin";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { build as viteBuild, type Plugin, type ViteDevServer } from "vite";
+import {
+  SOLID_HTML_HOST_MODULES_VIRTUAL_ID,
+  createSolidHtmlHostIslandRegistry,
+  resolveSolidHtmlHostCollectionDocuments,
+  resolveSolidHtmlHostIslandRegistry,
+} from ".";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("Solid HTML host collection documents", () => {
+  it("resolves configured flat and directory-index collection sources through host policy", async () => {
+    const root = await createProject("ox-solid-collection-docs-");
+    const oxContent = collectionOptions();
+    const select = (
+      document: { frontmatter: Record<string, unknown> },
+      context: { command: string },
+    ) => context.command === "serve" || document.frontmatter.published === true;
+
+    const serveDocuments = await resolveSolidHtmlHostCollectionDocuments(
+      { oxContent, select },
+      { root, mode: "development", command: "serve" },
+    );
+    const buildDocuments = await resolveSolidHtmlHostCollectionDocuments(
+      { oxContent, select },
+      { root, mode: "production", command: "build" },
+    );
+
+    expect(relativeDocumentPaths(root, serveDocuments)).toEqual([
+      "content/blog/draft.mdx",
+      "content/blog/hidden.mdx",
+      "content/blog/published.mdx",
+      "content/docs/guide/index.mdx",
+    ]);
+    expect(relativeDocumentPaths(root, buildDocuments)).toEqual([
+      "content/blog/published.mdx",
+      "content/docs/guide/index.mdx",
+    ]);
+    expect(buildDocuments[0]?.source).toContain("import PublishedProbe");
+    expect(buildDocuments[1]?.source).toContain("import { DirectoryProbe }");
+  });
+
+  it("builds the browser registry from selected configured collection documents only", async () => {
+    const root = await createProject("ox-solid-collection-build-");
+    const registry = createSolidHtmlHostIslandRegistry({
+      root,
+      oxContent: collectionOptions(),
+      collectionDocuments: { select: selectedForBuild },
+    });
+    await fs.writeFile(
+      path.join(root, "src", "client.ts"),
+      [
+        `import modules, { clientModules } from "${SOLID_HTML_HOST_MODULES_VIRTUAL_ID}";`,
+        "globalThis.__oxModules = modules;",
+        "globalThis.__oxClientModules = clientModules;",
+      ].join("\n"),
+    );
+
+    await viteBuild({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [registry.plugin, solid({ compiler: "native" })],
+      build: {
+        outDir: "dist",
+        emptyOutDir: true,
+        minify: false,
+        rollupOptions: { input: path.join(root, "src", "client.ts") },
+      },
+    });
+
+    const resolved = await registry.resolve();
+    const output = await readDist(root);
+    expect(resolved.modules).toEqual([
+      {
+        name: "PublishedProbe",
+        moduleId: "/content/blog/PublishedProbe.tsx",
+        exportName: "default",
+      },
+      {
+        name: "DirectoryProbe",
+        moduleId: "/content/docs/guide/DirectoryProbe.tsx",
+        exportName: "DirectoryProbe",
+      },
+    ]);
+    expect(output).toContain("PUBLISHED_ISLAND_SENTINEL");
+    expect(output).toContain("DIRECTORY_INDEX_SENTINEL");
+    expect(output).not.toContain("DRAFT_ONLY_SENTINEL");
+    expect(output).not.toContain("HIDDEN_ONLY_SENTINEL");
+  });
+
+  it("invalidates collection-derived island modules for source change, add and delete in dev", async () => {
+    const root = await createProject("ox-solid-collection-dev-");
+    const registry = createSolidHtmlHostIslandRegistry({
+      root,
+      oxContent: collectionOptions(),
+      collectionDocuments: { select: selectedForBuild },
+    });
+    const plugin = registry.plugin as Plugin;
+    await runConfig(plugin, "serve");
+    await (plugin.configResolved as (config: unknown) => void | Promise<void>)({
+      root,
+      mode: "development",
+    });
+
+    const id = `\0${SOLID_HTML_HOST_MODULES_VIRTUAL_ID}`;
+    const first = await loadVirtual(plugin, id);
+    await writePublishedVariant(root, "ChangedProbe", "CHANGED_ISLAND_SENTINEL");
+    await invalidate(plugin, root, "content/blog/published.mdx");
+    const changed = await loadVirtual(plugin, id);
+    await writeIsland(root, "content/blog/NewProbe.tsx", "NewProbe", "NEW_ISLAND_SENTINEL");
+    await writeMdx(root, "content/blog/new.mdx", "NewProbe", "./NewProbe.tsx", true);
+    await invalidate(plugin, root, "content/blog/new.mdx");
+    const added = await loadVirtual(plugin, id);
+    await fs.rm(path.join(root, "content", "blog", "new.mdx"));
+    await invalidate(plugin, root, "content/blog/new.mdx");
+    const deleted = await loadVirtual(plugin, id);
+
+    expect(first).toContain("/content/blog/PublishedProbe.tsx");
+    expect(changed).toContain("/content/blog/ChangedProbe.tsx");
+    expect(changed).not.toContain("/content/blog/PublishedProbe.tsx");
+    expect(added).toContain("/content/blog/NewProbe.tsx");
+    expect(deleted).not.toContain("/content/blog/NewProbe.tsx");
+  });
+
+  it("keeps explicit documents supported beside collection documents", async () => {
+    const root = await createProject("ox-solid-collection-explicit-");
+    const result = await resolveSolidHtmlHostIslandRegistry(
+      {
+        oxContent: collectionOptions(),
+        collectionDocuments: { select: selectedForBuild },
+        documents: [
+          {
+            documentPath: path.join(root, "content", "extra.mdx"),
+            source: "import ExtraProbe from './blog/ExtraProbe.tsx'\n<ExtraProbe />\n",
+          },
+        ],
+      },
+      { root, mode: "production", command: "build" },
+    );
+
+    expect(result.modules.map((module) => module.name).sort()).toEqual([
+      "DirectoryProbe",
+      "ExtraProbe",
+      "PublishedProbe",
+    ]);
+  });
+});
+
+function collectionOptions() {
+  return {
+    srcDir: "content",
+    embeds: { github: false, openGraph: false },
+    collections: {
+      blog: "blog/*.mdx",
+      docs: "docs/**/index.mdx",
+    },
+  };
+}
+
+function selectedForBuild(
+  document: { frontmatter: Record<string, unknown> },
+  context: { command: string },
+) {
+  return context.command === "serve" || document.frontmatter.published === true;
+}
+
+async function createProject(prefix: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(root);
+  await fs.mkdir(path.join(root, "content", "blog"), { recursive: true });
+  await fs.mkdir(path.join(root, "content", "docs", "guide"), { recursive: true });
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.writeFile(path.join(root, "package.json"), '{"type":"module"}\n');
+  await writeIsland(
+    root,
+    "content/blog/PublishedProbe.tsx",
+    "PublishedProbe",
+    "PUBLISHED_ISLAND_SENTINEL",
+  );
+  await writeIsland(root, "content/blog/DraftProbe.tsx", "DraftProbe", "DRAFT_ONLY_SENTINEL");
+  await writeIsland(root, "content/blog/HiddenProbe.tsx", "HiddenProbe", "HIDDEN_ONLY_SENTINEL");
+  await writeIsland(root, "content/blog/ExtraProbe.tsx", "ExtraProbe", "EXTRA_ISLAND_SENTINEL");
+  await writeIsland(
+    root,
+    "content/docs/guide/DirectoryProbe.tsx",
+    "DirectoryProbe",
+    "DIRECTORY_INDEX_SENTINEL",
+    true,
+  );
+  await writeMdx(
+    root,
+    "content/blog/published.mdx",
+    "PublishedProbe",
+    "./PublishedProbe.tsx",
+    true,
+  );
+  await writeMdx(root, "content/blog/draft.mdx", "DraftProbe", "./DraftProbe.tsx", false);
+  await writeMdx(root, "content/blog/hidden.mdx", "HiddenProbe", "./HiddenProbe.tsx", false);
+  await fs.writeFile(
+    path.join(root, "content", "docs", "guide", "index.mdx"),
+    "---\ntitle: Guide\npublished: true\n---\nimport { DirectoryProbe } from './DirectoryProbe.tsx'\n<DirectoryProbe />\n",
+  );
+  return root;
+}
+
+async function writePublishedVariant(root: string, name: string, marker: string) {
+  await writeIsland(root, `content/blog/${name}.tsx`, name, marker);
+  await writeMdx(root, "content/blog/published.mdx", name, `./${name}.tsx`, true);
+}
+
+async function writeMdx(
+  root: string,
+  file: string,
+  component: string,
+  specifier: string,
+  published: boolean,
+) {
+  await fs.writeFile(
+    path.join(root, file),
+    `---\ntitle: ${component}\npublished: ${published}\n---\nimport ${component} from '${specifier}'\n<${component} />\n`,
+  );
+}
+
+async function writeIsland(
+  root: string,
+  file: string,
+  name: string,
+  marker: string,
+  named = false,
+) {
+  const declaration = `${named ? "export " : "export default "}function ${name}() { console.log("${marker}"); return "${marker}"; }\n`;
+  await fs.writeFile(path.join(root, file), declaration);
+}
+
+function relativeDocumentPaths(
+  root: string,
+  documents: readonly { documentPath: string }[],
+): string[] {
+  return documents.map((document) => path.relative(root, document.documentPath)).sort();
+}
+
+async function runConfig(plugin: Plugin, command: "build" | "serve") {
+  await (plugin.config as (config: unknown, env: { command: typeof command }) => unknown)?.(
+    {},
+    { command },
+  );
+}
+
+async function invalidate(plugin: Plugin, root: string, relative: string) {
+  await (plugin.handleHotUpdate as (ctx: unknown) => Promise<unknown[]>)({
+    file: path.join(root, relative),
+    modules: [],
+    server: {
+      moduleGraph: {
+        getModuleById: () => ({}),
+        invalidateModule: () => {},
+      },
+      ws: { send: () => {} },
+    } as unknown as ViteDevServer,
+  } as never);
+}
+
+async function loadVirtual(plugin: Plugin, id: string): Promise<string> {
+  const loaded = await (plugin.load as (id: string) => Promise<string>)(id);
+  return String(loaded);
+}
+
+async function readDist(root: string): Promise<string> {
+  const chunks: string[] = [];
+  await collectFiles(path.join(root, "dist"), chunks);
+  return chunks.join("\n");
+}
+
+async function collectFiles(dir: string, chunks: string[]): Promise<void> {
+  for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
+    const file = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await collectFiles(file, chunks);
+    } else if (entry.isFile()) {
+      chunks.push(await fs.readFile(file, "utf8"));
+    }
+  }
+}

--- a/npm/vite-plugin-ox-content-solid/src/html-host-collection-documents.ts
+++ b/npm/vite-plugin-ox-content-solid/src/html-host-collection-documents.ts
@@ -1,0 +1,146 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  buildCollectionManifest,
+  customHostOxContentOptions,
+  normalizeMarkdownExtensions,
+  resolveCascadeOptions,
+  resolveCollectionsOptions,
+  resolvePermalinksOptions,
+  type CollectionEntry,
+  type OxContentOptions,
+  type ResolvedCollectionsOptions,
+  type ResolvedOptions,
+} from "@ox-content/vite-plugin";
+import type {
+  SolidHtmlHostIslandDocument,
+  SolidHtmlHostIslandRegistryContext,
+} from "./html-host-registry";
+
+type MaybePromise<T> = T | Promise<T>;
+
+export interface SolidHtmlHostCollectionDocument extends SolidHtmlHostIslandDocument {
+  collection: string;
+  entry: CollectionEntry;
+  frontmatter: Record<string, unknown>;
+  path: string;
+  source: string;
+}
+
+export interface SolidHtmlHostCollectionDocumentsOptions {
+  oxContent?: OxContentOptions;
+  collections?: string | readonly string[];
+  select?: (
+    document: SolidHtmlHostCollectionDocument,
+    context: SolidHtmlHostIslandRegistryContext,
+  ) => MaybePromise<boolean>;
+}
+
+export function createSolidHtmlHostCollectionDocuments(
+  input: SolidHtmlHostCollectionDocumentsOptions = {},
+): (
+  context: SolidHtmlHostIslandRegistryContext,
+) => Promise<readonly SolidHtmlHostCollectionDocument[]> {
+  return (context) => resolveSolidHtmlHostCollectionDocuments(input, context);
+}
+
+export async function resolveSolidHtmlHostCollectionDocuments(
+  input: SolidHtmlHostCollectionDocumentsOptions,
+  context: SolidHtmlHostIslandRegistryContext,
+): Promise<readonly SolidHtmlHostCollectionDocument[]> {
+  const oxContent = customHostOxContentOptions(input.oxContent ?? {});
+  const options = resolveCollectionManifestOptions(oxContent);
+  if (!options.collections.enabled) return [];
+
+  const manifest = await buildCollectionManifest(context.root, options);
+  const names = resolveCollectionNames(input.collections, options.collections);
+  const documents = new Map<string, SolidHtmlHostCollectionDocument>();
+
+  for (const name of names) {
+    for (const entry of manifest.collections[name] ?? []) {
+      const document = await resolveCollectionDocument(context.root, options.srcDir, name, entry);
+      if (!document) continue;
+      if (input.select && !(await input.select(document, context))) continue;
+      documents.set(document.documentPath, document);
+    }
+  }
+
+  return [...documents.values()];
+}
+
+function resolveCollectionManifestOptions(oxContent: OxContentOptions): ResolvedOptions {
+  const collections = withoutCollectionInclude(resolveCollectionsOptions(oxContent.collections));
+  return {
+    srcDir: oxContent.srcDir ?? "content",
+    outDir: oxContent.outDir ?? "dist",
+    base: oxContent.base ?? "/",
+    extensions: normalizeMarkdownExtensions(oxContent.extensions),
+    collections,
+    permalinks: resolvePermalinksOptions(oxContent.permalinks),
+    cascade: resolveCascadeOptions(oxContent.cascade),
+    gfm: oxContent.gfm ?? true,
+    mdx: oxContent.mdx,
+    footnotes: oxContent.footnotes ?? true,
+    semanticFootnotes: oxContent.semanticFootnotes ?? false,
+    taskLists: oxContent.taskLists ?? true,
+    tables: oxContent.tables ?? true,
+    strikethrough: oxContent.strikethrough ?? true,
+    autolinks: oxContent.autolinks ?? oxContent.gfm ?? true,
+    superscript: oxContent.superscript ?? false,
+    subscript: oxContent.subscript ?? false,
+    smartPunctuation: oxContent.smartPunctuation ?? false,
+    autolinkTargetBlank: oxContent.autolinkTargetBlank ?? true,
+    linkTargetBlank: oxContent.linkTargetBlank ?? true,
+    sourceSpans: oxContent.sourceSpans ?? false,
+    frontmatter: oxContent.frontmatter ?? true,
+    tocMaxDepth: oxContent.tocMaxDepth ?? 3,
+    cjkEmphasis: oxContent.cjkEmphasis ?? false,
+  } as ResolvedOptions;
+}
+
+function withoutCollectionInclude(
+  collections: ResolvedCollectionsOptions,
+): ResolvedCollectionsOptions {
+  return {
+    enabled: collections.enabled,
+    collections: Object.fromEntries(
+      Object.entries(collections.collections).map(([name, collection]) => [
+        name,
+        { ...collection, include: [] },
+      ]),
+    ),
+  };
+}
+
+function resolveCollectionNames(
+  input: string | readonly string[] | undefined,
+  collections: ResolvedCollectionsOptions,
+): string[] {
+  const available = Object.keys(collections.collections);
+  if (!input) return available;
+  const selected = new Set(Array.isArray(input) ? input : [input]);
+  return available.filter((name) => selected.has(name));
+}
+
+async function resolveCollectionDocument(
+  root: string,
+  srcDir: string,
+  collection: string,
+  entry: CollectionEntry,
+): Promise<SolidHtmlHostCollectionDocument | undefined> {
+  const candidate = path.resolve(root, srcDir, entry.source);
+  let source: string;
+  try {
+    source = await fs.readFile(candidate, "utf8");
+  } catch {
+    return undefined;
+  }
+  return {
+    collection,
+    documentPath: candidate,
+    entry,
+    frontmatter: entry.frontmatter,
+    path: entry.path,
+    source,
+  };
+}

--- a/npm/vite-plugin-ox-content-solid/src/html-host-registry.ts
+++ b/npm/vite-plugin-ox-content-solid/src/html-host-registry.ts
@@ -21,8 +21,11 @@ import {
   shouldInvalidate,
   toSolidHtmlHostClientModuleId,
 } from "./html-host-registry-paths";
+import {
+  resolveSolidHtmlHostCollectionDocuments,
+  type SolidHtmlHostCollectionDocumentsOptions,
+} from "./html-host-collection-documents";
 import type { ComponentsMap, ComponentsOption } from "./types";
-
 export { toSolidHtmlHostClientModuleId } from "./html-host-registry-paths";
 
 export const SOLID_HTML_HOST_MODULES_VIRTUAL_ID = "virtual:ox-content-solid/html-host/modules";
@@ -57,6 +60,7 @@ export interface CreateSolidHtmlHostIslandRegistryInput {
     | ((
         context: SolidHtmlHostIslandRegistryContext,
       ) => MaybePromise<readonly SolidHtmlHostIslandDocument[]>);
+  collectionDocuments?: false | SolidHtmlHostCollectionDocumentsOptions;
   entries?:
     | readonly SolidHtmlHostIslandEntry[]
     | ((
@@ -175,7 +179,10 @@ export async function resolveSolidHtmlHostIslandRegistry(
   const components =
     resolvedComponents ??
     (input.components ? await resolveComponentsGlob(input.components, context.root) : {});
-  const documents = await resolveMaybe(input.documents, context);
+  const documents = [
+    ...((await resolveMaybe(input.documents, context)) ?? []),
+    ...((await resolveInputCollectionDocuments(input, context)) ?? []),
+  ];
   const entries = await resolveMaybe(input.entries, context);
   const modules = new Map<string, SolidHtmlHostClientModule>();
   const watchFiles = new Set<string>();
@@ -197,7 +204,7 @@ export async function resolveSolidHtmlHostIslandRegistry(
   const oxContent = customHostOxContentOptions(input.oxContent ?? {});
   const srcDir = oxContent.srcDir ?? "content";
   const contentRoot = resolveContentRootPath({ root: context.root, srcDir });
-  for (const document of documents ?? []) {
+  for (const document of documents) {
     const documentPath = resolveDocumentPath(document.documentPath, context.root);
     watchFiles.add(documentPath);
     for (const dependency of document.dependencies ?? []) {
@@ -251,6 +258,18 @@ export async function resolveSolidHtmlHostIslandRegistry(
     ),
     watchFiles: [...watchFiles],
   };
+}
+
+function resolveInputCollectionDocuments(
+  input: CreateSolidHtmlHostIslandRegistryInput,
+  context: SolidHtmlHostIslandRegistryContext,
+): Promise<readonly SolidHtmlHostIslandDocument[]> | undefined {
+  if (!input.collectionDocuments) return undefined;
+  const collectionInput =
+    input.collectionDocuments.oxContent === undefined
+      ? { ...input.collectionDocuments, oxContent: input.oxContent }
+      : input.collectionDocuments;
+  return resolveSolidHtmlHostCollectionDocuments(collectionInput, context);
 }
 
 function renderModulesVirtualModule(registry: ResolvedSolidHtmlHostIslandRegistry): string {

--- a/npm/vite-plugin-ox-content-solid/src/index.test.ts
+++ b/npm/vite-plugin-ox-content-solid/src/index.test.ts
@@ -29,6 +29,7 @@ describe("oxContentSolid", () => {
     expect(solidApi).toHaveProperty("createSolidHtmlHostRenderer");
     expect(solidApi).toHaveProperty("createSolidHtmlHostDomRenderer");
     expect(solidApi).toHaveProperty("createSolidHtmlHostLazyHydrate");
+    expect(solidApi).toHaveProperty("createSolidHtmlHostCollectionDocuments");
     expect(solidApi).toHaveProperty("initSolidHtmlHost");
     expect(solidApi).toHaveProperty("loadSolidHtmlHostDomRuntime");
     expect(solidApi).toHaveProperty("renderSolidHtmlHost");

--- a/npm/vite-plugin-ox-content-solid/src/index.ts
+++ b/npm/vite-plugin-ox-content-solid/src/index.ts
@@ -101,6 +101,12 @@ export {
   type SolidHtmlHostIslandRegistryContext,
 } from "./html-host-registry";
 export {
+  createSolidHtmlHostCollectionDocuments,
+  resolveSolidHtmlHostCollectionDocuments,
+  type SolidHtmlHostCollectionDocument,
+  type SolidHtmlHostCollectionDocumentsOptions,
+} from "./html-host-collection-documents";
+export {
   resolveSolidIslandStylesheets,
   type ResolveSolidIslandStylesheetsInput,
   type ResolveSolidIslandStylesheetsResult,


### PR DESCRIPTION
## Triage

#1322 is valid. Custom hosts can already pass explicit selected documents, but hosts that source pages from Ox Content collections still have to duplicate collection globbing, file reads, and frontmatter parsing. This PR adds a supported collection-document path while keeping publication policy host-owned.

## Changes

- Add `collectionDocuments` support to `createSolidHtmlHostIslandRegistry()`.
- Export `createSolidHtmlHostCollectionDocuments()` and `resolveSolidHtmlHostCollectionDocuments()` for hosts that prefer the existing `documents` callback shape.
- Resolve configured collection source patterns without evaluating `virtual:ox-content/collections` during Vite config.
- Keep explicit `documents` supported beside collection-derived documents.
- Document the custom-host Solid registry flow in EN/JA package docs.

## Tests

- `rtk vp check --fix npm/vite-plugin-ox-content-solid/src/html-host-collection-documents.ts npm/vite-plugin-ox-content-solid/src/html-host-collection-documents.test.ts npm/vite-plugin-ox-content-solid/src/html-host-registry.ts npm/vite-plugin-ox-content-solid/src/index.ts npm/vite-plugin-ox-content-solid/src/index.test.ts docs/content/packages/vite-plugin-ox-content-solid.md docs/content/ja/packages/vite-plugin-ox-content-solid.md`
- `rtk vp test npm/vite-plugin-ox-content-solid/src/html-host-collection-documents.test.ts npm/vite-plugin-ox-content-solid/src/html-host-registry.test.ts npm/vite-plugin-ox-content-solid/src/index.test.ts`
- `rtk node tools/scripts/check-file-lines.ts`
- `rtk vp run check:ts` (0 errors, existing 24 warnings)
- `rtk vp run build:npm`
- `rtk node tools/scripts/package-dry-run.mjs`

Closes #1322

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791358485&installation_model_id=422833&pr_number=1343&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1343&signature=a17fcd9a4b1d4fd2bb47e8dfcb12f68831454adba2ff431b2ff0c215b252ecd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Custom Solid HTML hosts can now build browser module maps from selected Ox Content collection documents.
  - Collection documents can be filtered, deduplicated, and combined with explicitly supplied documents.
  - Development registries now reflect document additions, changes, and deletions automatically.
  - New public helpers and configuration options support collection-based document discovery.

- **Documentation**
  - Updated English and Japanese guidance with production and development configuration examples.
  - Documented source handling, document path preservation, and collection selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->