### PR TITLE
chore(release): v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [3.0.0] - 2026-09-07
+
+### Features
+
+- discover SSR stylesheet roots (#1344)
+- discover html host islands from collections (#1343)
+- add configured markdown renderer (#1342)
+- serve feed outputs in dev (#1341)
+- plan collection assets from documents (#1340)
+- share collection asset manifest context (#1339)
+- expose stylesheet artifact content (#1338)
+- add custom host renderer factory (#1337)
+
+### Bug Fixes
+
+- publish virtual collections declarations (#1336)
+- recognize CR line endings (#1334)
+- publish custom host output context types (#1335)
+- remap footnote definition child spans (#1333)
+- parse digit-prefixed inline math (#1332)
+- curl elision apostrophes as closing quotes (#1331)
+
 ## [3.0.0-beta.17] - 2026-09-06
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,21 +1355,21 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "ox_content_allocator"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "bumpalo",
 ]
 
 [[package]]
 name = "ox_content_ast"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "ox_content_allocator",
 ]
 
 [[package]]
 name = "ox_content_component_resolver"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "corsa_client",
  "insta",
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_docs"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_highlight"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "tree-sitter",
  "tree-sitter-bash",
@@ -1458,7 +1458,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_i18n"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "insta",
  "miette",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_i18n_checker"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "insta",
  "miette",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_i18n_cli"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "clap",
  "miette",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_i18n_lsp"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "ox_content_i18n",
  "ox_content_i18n_checker",
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_incremental"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "compact_str 0.10.0",
  "criterion",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_link_checker"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "clap",
  "insta",
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_lsp"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "compact_str 0.10.0",
  "insta",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_markdown_lint"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "compact_str 0.10.0",
  "ox_content_allocator",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_mdast"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "ox_content_allocator",
  "ox_content_ast",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_mdc_checker"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "clap",
  "insta",
@@ -1599,11 +1599,11 @@ dependencies = [
 
 [[package]]
 name = "ox_content_mermaid"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 
 [[package]]
 name = "ox_content_napi"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_og_image"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "insta",
  "serde",
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_parser"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "compact_str 0.10.0",
  "criterion",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_profile_cli"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "clap",
  "ox_content_allocator",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_profiler"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "insta",
  "serde",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_renderer"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "compact_str 0.10.0",
  "criterion",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_search"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "compact_str 0.10.0",
  "insta",
@@ -1719,7 +1719,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_ssg"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "askama",
  "insta",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_theme_generator"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "regex",
  "serde",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_transform"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "compact_str 0.10.0",
  "insta",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_vite"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "insta",
  "ox_content_allocator",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_wasm"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 dependencies = [
  "js-sys",
  "ox_content_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*", "tools/theme-generator"]
 
 [workspace.package]
-version = "3.0.0-beta.17"
+version = "3.0.0"
 authors = ["ubugeeei"]
 categories = ["development-tools"]
 edition = "2024"
@@ -73,29 +73,29 @@ use_self = "allow"
 
 [workspace.dependencies]
 # Internal crates (version is used for crates.io publish, path for local dev)
-ox_content_allocator = { version = "3.0.0-beta.17", path = "crates/ox_content_allocator" }
-ox_content_ast = { version = "3.0.0-beta.17", path = "crates/ox_content_ast" }
-ox_content_parser = { version = "3.0.0-beta.17", path = "crates/ox_content_parser" }
-ox_content_renderer = { version = "3.0.0-beta.17", path = "crates/ox_content_renderer" }
-ox_content_incremental = { version = "3.0.0-beta.17", path = "crates/ox_content_incremental" }
-ox_content_mdast = { version = "3.0.0-beta.17", path = "crates/ox_content_mdast" }
-ox_content_napi = { version = "3.0.0-beta.17", path = "crates/ox_content_napi" }
-ox_content_vite = { version = "3.0.0-beta.17", path = "crates/ox_content_vite" }
-ox_content_og_image = { version = "3.0.0-beta.17", path = "crates/ox_content_og_image" }
-ox_content_docs = { version = "3.0.0-beta.17", path = "crates/ox_content_docs" }
-ox_content_highlight = { version = "3.0.0-beta.17", path = "crates/ox_content_highlight" }
-ox_content_search = { version = "3.0.0-beta.17", path = "crates/ox_content_search" }
-ox_content_ssg = { version = "3.0.0-beta.17", path = "crates/ox_content_ssg" }
-ox_content_transform = { version = "3.0.0-beta.17", path = "crates/ox_content_transform" }
-ox_content_i18n = { version = "3.0.0-beta.17", path = "crates/ox_content_i18n" }
-ox_content_i18n_checker = { version = "3.0.0-beta.17", path = "crates/ox_content_i18n_checker" }
-ox_content_lsp = { version = "3.0.0-beta.17", path = "crates/ox_content_lsp" }
-ox_content_markdown_lint = { version = "3.0.0-beta.17", path = "crates/ox_content_markdown_lint" }
-ox_content_mdc_checker = { version = "3.0.0-beta.17", path = "crates/ox_content_mdc_checker" }
-ox_content_mermaid = { version = "3.0.0-beta.17", path = "crates/ox_content_mermaid" }
-ox_content_link_checker = { version = "3.0.0-beta.17", path = "crates/ox_content_link_checker" }
-ox_content_component_resolver = { version = "3.0.0-beta.17", path = "crates/ox_content_component_resolver" }
-ox_content_profiler = { version = "3.0.0-beta.17", path = "crates/ox_content_profiler" }
+ox_content_allocator = { version = "3.0.0", path = "crates/ox_content_allocator" }
+ox_content_ast = { version = "3.0.0", path = "crates/ox_content_ast" }
+ox_content_parser = { version = "3.0.0", path = "crates/ox_content_parser" }
+ox_content_renderer = { version = "3.0.0", path = "crates/ox_content_renderer" }
+ox_content_incremental = { version = "3.0.0", path = "crates/ox_content_incremental" }
+ox_content_mdast = { version = "3.0.0", path = "crates/ox_content_mdast" }
+ox_content_napi = { version = "3.0.0", path = "crates/ox_content_napi" }
+ox_content_vite = { version = "3.0.0", path = "crates/ox_content_vite" }
+ox_content_og_image = { version = "3.0.0", path = "crates/ox_content_og_image" }
+ox_content_docs = { version = "3.0.0", path = "crates/ox_content_docs" }
+ox_content_highlight = { version = "3.0.0", path = "crates/ox_content_highlight" }
+ox_content_search = { version = "3.0.0", path = "crates/ox_content_search" }
+ox_content_ssg = { version = "3.0.0", path = "crates/ox_content_ssg" }
+ox_content_transform = { version = "3.0.0", path = "crates/ox_content_transform" }
+ox_content_i18n = { version = "3.0.0", path = "crates/ox_content_i18n" }
+ox_content_i18n_checker = { version = "3.0.0", path = "crates/ox_content_i18n_checker" }
+ox_content_lsp = { version = "3.0.0", path = "crates/ox_content_lsp" }
+ox_content_markdown_lint = { version = "3.0.0", path = "crates/ox_content_markdown_lint" }
+ox_content_mdc_checker = { version = "3.0.0", path = "crates/ox_content_mdc_checker" }
+ox_content_mermaid = { version = "3.0.0", path = "crates/ox_content_mermaid" }
+ox_content_link_checker = { version = "3.0.0", path = "crates/ox_content_link_checker" }
+ox_content_component_resolver = { version = "3.0.0", path = "crates/ox_content_component_resolver" }
+ox_content_profiler = { version = "3.0.0", path = "crates/ox_content_profiler" }
 ox_jsdoc = "0.0.19"
 
 # Memory allocation

--- a/crates/ox_content_napi/package.json
+++ b/crates/ox_content_napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/napi",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Node.js bindings for Ox Content - High-performance Markdown parser",
   "keywords": [
     "markdown",

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -226,10 +226,10 @@ If you want the lowest-level building blocks directly, use the Rust crates.
 
 ```toml
 [dependencies]
-ox_content_allocator = "3.0.0-beta.17"
-ox_content_ast = "3.0.0-beta.17"
-ox_content_parser = "3.0.0-beta.17"
-ox_content_renderer = "3.0.0-beta.17"
+ox_content_allocator = "3.0.0"
+ox_content_ast = "3.0.0"
+ox_content_parser = "3.0.0"
+ox_content_renderer = "3.0.0"
 ```
 
 ### Parse and Render in Rust

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ox-content-zed"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 edition = "2021"
 publish = false
 

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "ox-content"
 name = "Ox Content"
-version = "3.0.0-beta.17"
+version = "3.0.0"
 schema_version = 1
 authors = ["ubugeeei"]
 description = "Ox Content authoring support for Zed"

--- a/npm/ox-content-code-play/package.json
+++ b/npm/ox-content-code-play/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/code-play",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Opt-in Code Play plugin for on-demand documentation sample execution",
   "keywords": [
     "code-play",

--- a/npm/ox-content-islands/package.json
+++ b/npm/ox-content-islands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/islands",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Framework-agnostic Island Architecture for ox-content",
   "keywords": [
     "framework-agnostic",

--- a/npm/theme-color/arctic/package.json
+++ b/npm/theme-color/arctic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-arctic",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Cold white with glacier cyan — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "arctic",

--- a/npm/theme-color/ayu/package.json
+++ b/npm/theme-color/ayu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-ayu",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Ayu Light and Ayu Mirage — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "ayu",

--- a/npm/theme-color/cacao/package.json
+++ b/npm/theme-color/cacao/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-cacao",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Warm dark chocolate with caramel — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "cacao",

--- a/npm/theme-color/catppuccin/package.json
+++ b/npm/theme-color/catppuccin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-catppuccin",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Catppuccin Latte and Mocha — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "catppuccin",

--- a/npm/theme-color/commander/package.json
+++ b/npm/theme-color/commander/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-commander",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "CGA cyan panels by day, the bare console prompt by night — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/coral/package.json
+++ b/npm/theme-color/coral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-coral",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Warm off-white with coral and teal — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/dracula/package.json
+++ b/npm/theme-color/dracula/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-dracula",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Dracula with the Alucard light counterpart — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/emerald/package.json
+++ b/npm/theme-color/emerald/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-emerald",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Vivid green over deep slate — the conference-badge palette — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/everforest/package.json
+++ b/npm/theme-color/everforest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-everforest",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Everforest light and dark, medium contrast — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/flexoki/package.json
+++ b/npm/theme-color/flexoki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-flexoki",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Ink and paper, tuned for e-ink-like calm — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/fuji/package.json
+++ b/npm/theme-color/fuji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-fuji",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Mountain festival poster — forest, dawn orange and open sky — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/github/package.json
+++ b/npm/theme-color/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-github",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "GitHub Light and GitHub Dark — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/graphite/package.json
+++ b/npm/theme-color/graphite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-graphite",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Off-black and off-white with one electric accent — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/gruvbox/package.json
+++ b/npm/theme-color/gruvbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-gruvbox",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Gruvbox light and dark, medium contrast — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/high-contrast/package.json
+++ b/npm/theme-color/high-contrast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-high-contrast",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Maximum-contrast scheme aimed at WCAG AAA body text — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/horizon/package.json
+++ b/npm/theme-color/horizon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-horizon",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Warm coral and plum at dusk — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/iceberg/package.json
+++ b/npm/theme-color/iceberg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-iceberg",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Cold, quiet blues borrowed from the vim scheme — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/ink/package.json
+++ b/npm/theme-color/ink/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-ink",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Deep navy with warm sand — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/kanagawa/package.json
+++ b/npm/theme-color/kanagawa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-kanagawa",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Kanagawa Lotus and Wave — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/material/package.json
+++ b/npm/theme-color/material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-material",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Material Theme Lighter and Material Theme — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/melange/package.json
+++ b/npm/theme-color/melange/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-melange",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Muted earth tones, warm and unhurried — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/modus/package.json
+++ b/npm/theme-color/modus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-modus",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Protesilaos' accessibility-first scheme, WCAG AAA throughout — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/mono/package.json
+++ b/npm/theme-color/mono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-mono",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Pure monochrome, zero hue — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/monokai/package.json
+++ b/npm/theme-color/monokai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-monokai",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Monokai Pro with a light companion — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/moss/package.json
+++ b/npm/theme-color/moss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-moss",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Deep forest and paper cream — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/night-owl/package.json
+++ b/npm/theme-color/night-owl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-night-owl",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Sarah Drasner's Light Owl and Night Owl — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/nord/package.json
+++ b/npm/theme-color/nord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-nord",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Nord Snow Storm and Polar Night — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/oceanic/package.json
+++ b/npm/theme-color/oceanic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-oceanic",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Oceanic Next — deep slate teal — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/one-dark/package.json
+++ b/npm/theme-color/one-dark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-one-dark",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Atom One Light and One Dark — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/palenight/package.json
+++ b/npm/theme-color/palenight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-palenight",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Material Palenight — soft indigo — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/plum/package.json
+++ b/npm/theme-color/plum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-plum",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Aubergine and blush — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/poimandres/package.json
+++ b/npm/theme-color/poimandres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-poimandres",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Poimandres, cool teal on deep navy — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/porcelain/package.json
+++ b/npm/theme-color/porcelain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-porcelain",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Soft warm white with muted blue-grey — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/retro/package.json
+++ b/npm/theme-color/retro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-retro",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Warm amber phosphor terminal — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/rose-pine/package.json
+++ b/npm/theme-color/rose-pine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-rose-pine",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Rosé Pine Dawn and Rosé Pine — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/sand/package.json
+++ b/npm/theme-color/sand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-sand",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Warm neutral stone with terracotta — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/sepia/package.json
+++ b/npm/theme-color/sepia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-sepia",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Low-glare sepia tuned for long reading sessions — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/slate/package.json
+++ b/npm/theme-color/slate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-slate",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Cool grey with an electric lime edge — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/snow/package.json
+++ b/npm/theme-color/snow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-snow",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Crisp snow white over deep slate — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/solarized/package.json
+++ b/npm/theme-color/solarized/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-solarized",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Ethan Schoonover's Solarized Light and Dark — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/stage/package.json
+++ b/npm/theme-color/stage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-stage",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Event poster — deep indigo with coral and acid yellow — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/synthwave/package.json
+++ b/npm/theme-color/synthwave/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-synthwave",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Sunset-grid synthwave with hot magenta accents — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/tokyo-night/package.json
+++ b/npm/theme-color/tokyo-night/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-tokyo-night",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Tokyo Night Day and Tokyo Night Storm — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/vitesse/package.json
+++ b/npm/theme-color/vitesse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-vitesse",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Anthony Fu's Vitesse light and dark — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/voltage/package.json
+++ b/npm/theme-color/voltage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-voltage",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "High-voltage accents over a near-black canvas — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme-color/zenburn/package.json
+++ b/npm/theme-color/zenburn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-color-zenburn",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "The classic low-contrast scheme for long sessions — an Ox Content color scheme that composes with any @ox-content/theme-* skin",
   "keywords": [
     "color-scheme",

--- a/npm/theme/analog-film/package.json
+++ b/npm/theme/analog-film/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-analog-film",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Grain, halation and sprocket rails with a gentle gate weave — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "analog",

--- a/npm/theme/atlas/package.json
+++ b/npm/theme/atlas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-atlas",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "A survey sheet — contour bands, a keyed legend sidebar and registration marks — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "cartography",

--- a/npm/theme/aurora/package.json
+++ b/npm/theme/aurora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-aurora",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Slow conic light curtains drifting behind translucent panels — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "ambient",

--- a/npm/theme/bauhaus/package.json
+++ b/npm/theme/bauhaus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-bauhaus",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Circle, square, triangle and a diagonal that refuses the grid — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "bauhaus",

--- a/npm/theme/blueprint/package.json
+++ b/npm/theme/blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-blueprint",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Technical drawing grid with dashed callouts and strokes that draw themselves — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "blueprint",

--- a/npm/theme/blur-glass/package.json
+++ b/npm/theme/blur-glass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-blur-glass",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Frosted backdrop-blur layers that resolve out of a soft haze — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "blur",

--- a/npm/theme/brutalist/package.json
+++ b/npm/theme/brutalist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-brutalist",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Raw structure, oversized type and shadows that slam into place — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "bold",

--- a/npm/theme/clay/package.json
+++ b/npm/theme/clay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-clay",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Soft extruded clay that squishes under the pointer — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "3d",

--- a/npm/theme/editorial/package.json
+++ b/npm/theme/editorial/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-editorial",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Magazine typography with drop caps, hairline rules and column reveals — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "documentation",

--- a/npm/theme/fabric/package.json
+++ b/npm/theme/fabric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-fabric",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Woven texture, stitched seams and soft cloth-fold reveals — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "craft",

--- a/npm/theme/fluid/package.json
+++ b/npm/theme/fluid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-fluid",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Organic blob gradients that drift and morph behind the content — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "blob",

--- a/npm/theme/holo/package.json
+++ b/npm/theme/holo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-holo",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Iridescent foil that shifts hue as panels tilt and slide — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "chrome",

--- a/npm/theme/kiosk/package.json
+++ b/npm/theme/kiosk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-kiosk",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Platform signage — a departure-board sidebar, banded heads and arrows — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "board",

--- a/npm/theme/leather/package.json
+++ b/npm/theme/leather/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-leather",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Embossed grain and saddle stitching that presses in when touched — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "craft",

--- a/npm/theme/ledger/package.json
+++ b/npm/theme/ledger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-ledger",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "A bound accounting book — text set on real ruled lines, tabular figures throughout — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "accounting",

--- a/npm/theme/liquid-glass/package.json
+++ b/npm/theme/liquid-glass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-liquid-glass",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Refractive glass panels with specular edges and a light sweep on hover — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "documentation",

--- a/npm/theme/manuscript/package.json
+++ b/npm/theme/manuscript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-manuscript",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "A codex page — narrow measure, rubricated heads, and a table of contents that becomes marginalia — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "book",

--- a/npm/theme/neon/package.json
+++ b/npm/theme/neon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-neon",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Sunset-grid glow with humming tube outlines and a scanline sweep — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "cyberpunk",

--- a/npm/theme/noir/package.json
+++ b/npm/theme/noir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-noir",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "One hard key light and a steep falloff — shapes picked out of the dark — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "chiaroscuro",

--- a/npm/theme/paper/package.json
+++ b/npm/theme/paper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-paper",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Letterpress impressions on soft stock with a deckled page edge — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "documentation",

--- a/npm/theme/pixel/package.json
+++ b/npm/theme/pixel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-pixel",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Chunky 8-bit surfaces, hard offset shadows and stepped motion — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "8bit",

--- a/npm/theme/receipt/package.json
+++ b/npm/theme/receipt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-receipt",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "A thermal roll — one narrow centred column, dotted leaders and a torn edge — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "documentation",

--- a/npm/theme/risograph/package.json
+++ b/npm/theme/risograph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-risograph",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Misregistered duotone print where the ink channels separate on hover — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "documentation",

--- a/npm/theme/swiss/package.json
+++ b/npm/theme/swiss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-swiss",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "International Typographic Style — a hard grid, rules, and precise slides — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "documentation",

--- a/npm/theme/terminal/package.json
+++ b/npm/theme/terminal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-terminal",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "CRT phosphor with scanlines, a blinking block caret and prompt gutters — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "console",

--- a/npm/theme/voltage/package.json
+++ b/npm/theme/voltage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-voltage",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Oversized display type with charged gradient edges and a live electric field — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "bold",

--- a/npm/theme/zine/package.json
+++ b/npm/theme/zine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/theme-zine",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Photocopied and taped together — nothing square to the page — an Ox Content skin that composes with any @ox-content/theme-color-* scheme",
   "keywords": [
     "collage",

--- a/npm/unplugin-ox-content/package.json
+++ b/npm/unplugin-ox-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/unplugin",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Universal plugin for Ox Content - Markdown processing for webpack, rollup, esbuild, vite, and more",
   "keywords": [
     "esbuild",

--- a/npm/vite-plugin-ox-content-react/package.json
+++ b/npm/vite-plugin-ox-content-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/vite-plugin-react",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "React integration for Ox Content - Embed React components in Markdown",
   "keywords": [
     "markdown",

--- a/npm/vite-plugin-ox-content-solid/package.json
+++ b/npm/vite-plugin-ox-content-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/vite-plugin-solid",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Solid integration for Ox Content - Embed Solid components in Markdown",
   "keywords": [
     "markdown",

--- a/npm/vite-plugin-ox-content-svelte/package.json
+++ b/npm/vite-plugin-ox-content-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/vite-plugin-svelte",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Svelte integration for Ox Content - Embed Svelte components in Markdown",
   "keywords": [
     "markdown",

--- a/npm/vite-plugin-ox-content-vue/package.json
+++ b/npm/vite-plugin-ox-content-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/vite-plugin-vue",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Vue integration for Ox Content - Embed Vue components in Markdown",
   "keywords": [
     "markdown",

--- a/npm/vite-plugin-ox-content/package.json
+++ b/npm/vite-plugin-ox-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/vite-plugin",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "description": "Vite plugin for Ox Content - High-performance Markdown processing with Environment API",
   "keywords": [
     "environment-api",

--- a/npm/vscode-ox-content/package.json
+++ b/npm/vscode-ox-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-ox-content",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0",
   "private": true,
   "description": "VS Code extension for Ox Content authoring and i18n workflows",
   "categories": [


### PR DESCRIPTION
## Triage

#699 is valid and is now the only open issue. Its roadmap boxes are complete; the remaining work is the stable 3.0.0 release itself.

Decision: prepare the stable release as a dedicated release PR, keep #699 open during PR/CI, then tag and verify the actual publish before closing the tracker.

## Summary

- bump Rust workspace, npm packages, VS Code package, and Zed extension versions from 3.0.0-beta.17 to 3.0.0
- update Rust getting-started dependency snippets to 3.0.0
- add the stable 3.0.0 changelog section for the final issue sweep

## Local validation

- rtk node tools/scripts/release.ts 3.0.0 --prepare-only
- rtk vp check --fix
- rtk vp run build:npm
- rtk node tools/scripts/package-dry-run.mjs
- rtk git diff --check
- rtk gh release view v3.0.0 --json tagName,isPrerelease,isDraft,publishedAt,url (release not found)
- rtk npm view @ox-content/vite-plugin@3.0.0 version (E404)
- rtk curl -fsSL -A ox-content-release https://crates.io/api/v1/crates/ox_content_parser/3.0.0 (404)

Refs #699

Co-authored-by: ubugeeei <71201308+ubugeeei@users.noreply.github.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791362262&installation_model_id=422833&pr_number=1345&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1345&signature=c964e147f55d3ea8d89a57c2c25f7c821eb1edb252bc46d4a67a76a082494682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released version 3.0.0 as a stable release across the ecosystem.
  * Improved server-rendered stylesheet discovery and collection asset planning.
  * Added configuration options for Markdown rendering.
  * Enabled feed serving and custom host renderers.

* **Bug Fixes**
  * Fixed parsing issues and other issues affecting rendering, feeds, and asset handling.

* **Documentation**
  * Updated getting-started instructions to reference the stable 3.0.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->