### PR TITLE
fix(release): annotate changelog impact scopes

### DIFF
--- a/tools/scripts/release-changelog.test.ts
+++ b/tools/scripts/release-changelog.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  categorizeCommits,
+  collectCommitImpact,
+  formatImpact,
+  generateChangelog,
+} from "./release-changelog";
+
+const options = {
+  root: process.cwd(),
+  npmPackages: [
+    "crates/ox_content_napi",
+    "npm/vite-plugin-ox-content",
+    "npm/theme/swiss",
+    "npm/theme-color/oceanic",
+  ],
+};
+
+describe("release changelog impacts", () => {
+  it("names changed crates on each changelog entry", () => {
+    const categories = categorizeCommits([
+      {
+        subject: "fix(parser): parse digit-prefixed inline math (#1326)",
+        files: ["crates/ox_content_parser/src/inlines.rs"],
+        impact: collectCommitImpact(["crates/ox_content_parser/src/inlines.rs"], options),
+      },
+    ]);
+
+    expect(generateChangelog("3.0.1", categories)).toContain(
+      "- parse digit-prefixed inline math (#1326) _(affects: crates: ox_content_parser)_",
+    );
+  });
+
+  it("also reports npm packages and release areas", () => {
+    const impact = collectCommitImpact(
+      [
+        "npm/vite-plugin-ox-content/src/custom-host.ts",
+        "docs/content/built-in/custom-host.md",
+        ".github/workflows/publish.yml",
+      ],
+      options,
+    );
+
+    expect(formatImpact(impact)).toBe("npm: @ox-content/vite-plugin; ci, docs");
+  });
+
+  it("summarizes large package sets instead of flooding the changelog", () => {
+    const impact = collectCommitImpact(
+      [
+        "crates/ox_content_allocator/src/lib.rs",
+        "crates/ox_content_ast/src/lib.rs",
+        "crates/ox_content_docs/src/lib.rs",
+        "crates/ox_content_incremental/src/lib.rs",
+        "crates/ox_content_mdast/src/lib.rs",
+        "crates/ox_content_og_image/src/lib.rs",
+        "npm/theme/swiss/package.json",
+        "npm/theme-color/oceanic/package.json",
+        "crates/ox_content_parser/src/lib.rs",
+        "crates/ox_content_renderer/src/lib.rs",
+        "crates/ox_content_transform/src/lib.rs",
+      ],
+      options,
+    );
+
+    expect(formatImpact(impact)).toBe(
+      "crates: ox_content_allocator, ox_content_ast, ox_content_docs, ox_content_incremental, ox_content_mdast, ox_content_og_image, ox_content_parser, ox_content_renderer (+1 more); npm: @ox-content/theme-color-oceanic, @ox-content/theme-swiss",
+    );
+  });
+});

--- a/tools/scripts/release-changelog.ts
+++ b/tools/scripts/release-changelog.ts
@@ -1,0 +1,194 @@
+import * as fs from "fs";
+import * as path from "path";
+
+export type Exec = (cmd: string) => string;
+
+export type ChangelogImpact = {
+  crates: string[];
+  npmPackages: string[];
+  areas: string[];
+};
+
+export type CommitEntry = {
+  hash?: string;
+  subject: string;
+  files: string[];
+  impact: ChangelogImpact;
+};
+
+type ImpactOptions = {
+  root: string;
+  npmPackages: string[];
+};
+
+const CHANGELOG_CATEGORIES = {
+  feat: "Features",
+  fix: "Bug Fixes",
+  perf: "Performance",
+  refactor: "Refactoring",
+  docs: "Documentation",
+} as const;
+
+const CATEGORY_KEYS = [...Object.keys(CHANGELOG_CATEGORIES), "chore", "other"] as const;
+
+type CategoryKey = (typeof CATEGORY_KEYS)[number];
+
+export function getCommitsSinceTag(
+  exec: Exec,
+  tag: string | undefined,
+  options: ImpactOptions,
+): CommitEntry[] {
+  try {
+    const range = tag ? `${tag}..HEAD` : "HEAD";
+    const log = exec(`git log ${range} --pretty=format:%H%x00%s --no-merges`);
+    return log
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        const [hash, subject] = line.split("\0", 2);
+        const files = getCommitFiles(exec, hash);
+        return {
+          hash,
+          subject,
+          files,
+          impact: collectCommitImpact(files, options),
+        };
+      });
+  } catch {
+    return [];
+  }
+}
+
+export function categorizeCommits(commits: CommitEntry[]): Record<CategoryKey, CommitEntry[]> {
+  const categories = Object.fromEntries(CATEGORY_KEYS.map((key) => [key, []])) as Record<
+    CategoryKey,
+    CommitEntry[]
+  >;
+
+  for (const commit of commits) {
+    if (commit.subject.includes("Generated with [Claude Code]")) continue;
+
+    const match = commit.subject.match(/^(\w+)(?:\([^)]+\))?(?:!)?:\s*(.+)/);
+    if (match) {
+      const [, type, message] = match;
+      const category = isCategoryKey(type) && categories[type] ? type : "other";
+      categories[category].push({ ...commit, subject: message });
+    } else {
+      categories.other.push(commit);
+    }
+  }
+
+  return categories;
+}
+
+export function generateChangelog(
+  version: string,
+  commits: Record<CategoryKey, CommitEntry[]>,
+): string {
+  const date = new Date().toISOString().split("T")[0];
+  let changelog = `## [${version}] - ${date}\n\n`;
+
+  for (const [key, title] of Object.entries(CHANGELOG_CATEGORIES) as [CategoryKey, string][]) {
+    if (commits[key]?.length) {
+      changelog += `### ${title}\n\n`;
+      for (const entry of commits[key]) {
+        changelog += `- ${entry.subject}${formatImpactAnnotation(entry.impact)}\n`;
+      }
+      changelog += "\n";
+    }
+  }
+
+  return changelog;
+}
+
+export function collectCommitImpact(files: string[], options: ImpactOptions): ChangelogImpact {
+  const npmPackages = buildNpmPackageLookup(options);
+  const impact = {
+    crates: new Set<string>(),
+    npmPackages: new Set<string>(),
+    areas: new Set<string>(),
+  };
+
+  for (const file of files) {
+    const normalized = file.replace(/\\/g, "/");
+    const crate = normalized.match(/^crates\/(ox_content_[^/]+)/)?.[1];
+    if (crate) impact.crates.add(crate);
+
+    const npmPackage = npmPackages.find((pkg) => pathBelongsTo(normalized, pkg.path));
+    if (npmPackage) impact.npmPackages.add(npmPackage.name);
+
+    for (const area of collectAreas(normalized)) {
+      impact.areas.add(area);
+    }
+  }
+
+  return {
+    crates: [...impact.crates].sort(),
+    npmPackages: [...impact.npmPackages].sort(),
+    areas: [...impact.areas].sort(),
+  };
+}
+
+export function formatImpact(impact: ChangelogImpact): string {
+  const parts = [];
+  if (impact.crates.length) parts.push(`crates: ${summarize(impact.crates)}`);
+  if (impact.npmPackages.length) parts.push(`npm: ${summarize(impact.npmPackages)}`);
+  if (impact.areas.length) parts.push(summarize(impact.areas));
+  return parts.join("; ");
+}
+
+function getCommitFiles(exec: Exec, hash: string): string[] {
+  if (!hash) return [];
+  return exec(`git show --format= --name-only ${hash}`).trim().split("\n").filter(Boolean);
+}
+
+function formatImpactAnnotation(impact: ChangelogImpact): string {
+  const formatted = formatImpact(impact);
+  return formatted ? ` _(affects: ${formatted})_` : "";
+}
+
+function buildNpmPackageLookup(options: ImpactOptions): { path: string; name: string }[] {
+  return options.npmPackages
+    .map((pkgPath) => {
+      const packageJsonPath = path.join(options.root, pkgPath, "package.json");
+      if (!fs.existsSync(packageJsonPath)) return undefined;
+      const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as { name?: string };
+      return pkg.name ? { path: pkgPath.replace(/\\/g, "/"), name: pkg.name } : undefined;
+    })
+    .filter((pkg): pkg is { path: string; name: string } => Boolean(pkg))
+    .sort((a, b) => b.path.length - a.path.length);
+}
+
+function collectAreas(file: string): string[] {
+  const areas = [];
+  if (file === "README.md" || file.startsWith("docs/")) areas.push("docs");
+  if (file.startsWith(".github/")) areas.push("ci");
+  if (file.startsWith("tools/")) areas.push("tooling");
+  if (file.startsWith("editors/")) areas.push("editor extensions");
+  if (file.startsWith("nix/") || file === "flake.nix" || file === "flake.lock") areas.push("nix");
+  if (
+    file === "Cargo.toml" ||
+    file === "Cargo.lock" ||
+    file === "package.json" ||
+    file === "pnpm-lock.yaml" ||
+    file === "pnpm-workspace.yaml" ||
+    file === "rust-toolchain.toml"
+  ) {
+    areas.push("workspace metadata");
+  }
+  return areas;
+}
+
+function summarize(items: string[], max = 8): string {
+  if (items.length <= max) return items.join(", ");
+  return `${items.slice(0, max).join(", ")} (+${items.length - max} more)`;
+}
+
+function pathBelongsTo(file: string, dir: string): boolean {
+  return file === dir || file.startsWith(`${dir}/`);
+}
+
+function isCategoryKey(key: string): key is CategoryKey {
+  return CATEGORY_KEYS.includes(key as CategoryKey);
+}

--- a/tools/scripts/release.ts
+++ b/tools/scripts/release.ts
@@ -5,6 +5,7 @@ import { execSync } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
+import { categorizeCommits, generateChangelog, getCommitsSinceTag } from "./release-changelog.ts";
 import { verifyPublishWorkflow } from "./verify-publish-targets.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -169,75 +170,12 @@ function isValidVersion(v: string): boolean {
   return /^\d+\.\d+\.\d+(-[\w.]+)?$/.test(v);
 }
 
-function getCommitsSinceTag(tag?: string): string[] {
-  try {
-    const range = tag ? `${tag}..HEAD` : "HEAD";
-    const log = exec(`git log ${range} --pretty=format:"%s" --no-merges`);
-    return log.trim().split("\n").filter(Boolean);
-  } catch {
-    return [];
-  }
-}
-
 function getLatestTag(): string | undefined {
   try {
     return exec("git describe --tags --abbrev=0").trim();
   } catch {
     return undefined;
   }
-}
-
-function categorizeCommits(commits: string[]): Record<string, string[]> {
-  const categories: Record<string, string[]> = {
-    feat: [],
-    fix: [],
-    perf: [],
-    refactor: [],
-    docs: [],
-    chore: [],
-    other: [],
-  };
-
-  for (const commit of commits) {
-    // Skip generated commits
-    if (commit.includes("Generated with [Claude Code]")) continue;
-
-    const match = commit.match(/^(\w+)(?:\([^)]+\))?:\s*(.+)/);
-    if (match) {
-      const [, type, message] = match;
-      const category = categories[type] ? type : "other";
-      categories[category].push(message);
-    } else {
-      categories.other.push(commit);
-    }
-  }
-
-  return categories;
-}
-
-function generateChangelog(version: string, commits: Record<string, string[]>): string {
-  const date = new Date().toISOString().split("T")[0];
-  let changelog = `## [${version}] - ${date}\n\n`;
-
-  const sections: [string, string][] = [
-    ["feat", "Features"],
-    ["fix", "Bug Fixes"],
-    ["perf", "Performance"],
-    ["refactor", "Refactoring"],
-    ["docs", "Documentation"],
-  ];
-
-  for (const [key, title] of sections) {
-    if (commits[key]?.length) {
-      changelog += `### ${title}\n\n`;
-      for (const msg of commits[key]) {
-        changelog += `- ${msg}\n`;
-      }
-      changelog += "\n";
-    }
-  }
-
-  return changelog;
 }
 
 function updateChangelogFile(content: string): void {
@@ -312,7 +250,10 @@ async function main(): Promise<void> {
 
   console.log("\nGenerating changelog...");
   const latestTag = getLatestTag();
-  const commits = getCommitsSinceTag(latestTag);
+  const commits = getCommitsSinceTag(exec, latestTag, {
+    root: ROOT,
+    npmPackages: NPM_PACKAGES,
+  });
   const categorized = categorizeCommits(commits);
   const changelogContent = generateChangelog(newVersion, categorized);
   updateChangelogFile(changelogContent);


### PR DESCRIPTION
## Summary
- Triage: #1346 is valid. Lockstep releases can still be deliberate, but the generated changelog did not say which crates/packages/areas each entry affects, so consumers had to diff published tarballs to know whether a Rust crate changed.
- Move changelog generation into a small helper and add per-entry impact annotations such as affected crates, npm packages, docs, CI, tooling, editor extensions, nix, and workspace metadata.
- Keep large impact sets readable with a bounded summary instead of flooding each entry.

## Validation
- `vp check --fix tools/scripts/release.ts tools/scripts/release-changelog.ts tools/scripts/release-changelog.test.ts`
- `vp test tools/scripts/release-changelog.test.ts tools/scripts/verify-publish-targets.test.ts`
- `node tools/scripts/check-file-lines.ts`
- `vp run check:ts` (0 errors; existing unrelated warnings remain)
- `git diff --check`

Closes #1346

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791366186&installation_model_id=422833&pr_number=1348&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1348&signature=449f6a005ecba6b719f88342d650850906a4876c35753ba7b1e29501bc59075d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release changelogs now organize changes by category and include the affected packages, crates, and repository areas.
  - Large sets of affected packages are summarized clearly while still indicating additional items.
  - Changelog generation now handles unavailable repository history gracefully.

- **Tests**
  - Added coverage for change categorization, impact summaries, package reporting, and large package lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->