### PR TITLE
fix(parser): normalize CRLF line endings

### DIFF
--- a/crates/ox_content_mdast/src/mdast/tests.rs
+++ b/crates/ox_content_mdast/src/mdast/tests.rs
@@ -76,12 +76,13 @@ fn serializes_code_breaks_and_ordered_list_start() {
 #[test]
 fn escapes_json_string_bytes_across_chunk_boundaries() {
     // 8-byte-aligned safe prefix, then every escape class: structural,
-    // shorthand control, and \u-encoded control — all must round-trip.
+    // shorthand control, and \u-encoded control. Markdown line endings are
+    // normalized before mdast serialization, so the raw CR becomes LF.
     let source = "```\nabcdefgh\"quote\\back\ttab\rcr\x08bs\x0cff\x01ctl and 日本語テキスト\n```";
     let json = parse_json(source, ParserOptions::default());
     assert_eq!(
         json["children"][0]["value"],
-        "abcdefgh\"quote\\back\ttab\rcr\x08bs\x0cff\x01ctl and 日本語テキスト\n"
+        "abcdefgh\"quote\\back\ttab\ncr\x08bs\x0cff\x01ctl and 日本語テキスト\n"
     );
 }
 

--- a/crates/ox_content_parser/src/parser/fenced_code.rs
+++ b/crates/ox_content_parser/src/parser/fenced_code.rs
@@ -119,7 +119,12 @@ impl<'a> Parser<'a> {
                 self.find_fenced_close(fence_char, fence_len, body_start);
             self.position = fence_line_end;
             span = Span::new(start as u32, self.position as u32);
-            &self.source[body_start..body_end]
+            let body = &self.source[body_start..body_end];
+            if body.as_bytes().contains(&b'\r') {
+                self.normalize_code_block_line_endings(body)
+            } else {
+                body
+            }
         } else {
             // Indented opening fence: lines may need leading-space stripping,
             // so a borrowed source slice would be wrong. Materialize only this
@@ -193,5 +198,28 @@ impl<'a> Parser<'a> {
             value,
             span,
         }))))
+    }
+
+    fn normalize_code_block_line_endings(&self, source: &str) -> &'a str {
+        let mut value =
+            ox_content_allocator::String::with_capacity_in(source.len(), self.allocator.bump());
+        let bytes = source.as_bytes();
+        let mut chunk_start = 0;
+        let mut cursor = 0;
+
+        while cursor < bytes.len() {
+            if bytes[cursor] != b'\r' {
+                cursor += 1;
+                continue;
+            }
+
+            value.push_str(&source[chunk_start..cursor]);
+            value.push('\n');
+            cursor += if bytes.get(cursor + 1) == Some(&b'\n') { 2 } else { 1 };
+            chunk_start = cursor;
+        }
+
+        value.push_str(&source[chunk_start..]);
+        value.into_bump_str()
     }
 }

--- a/crates/ox_content_parser/src/parser/list.rs
+++ b/crates/ox_content_parser/src/parser/list.rs
@@ -3,6 +3,7 @@ use ox_content_ast::{List, ListItem, Node, Span};
 
 use self::item_source::ListItemSource;
 use super::Parser;
+use super::line_scan::{is_line_ending_byte, line_terminator_end};
 use super::list_item::ParsedListItem;
 use crate::error::ParseResult;
 #[allow(unused_imports)]
@@ -37,9 +38,11 @@ impl<'a> Parser<'a> {
 
             // Consume the marker line.
             self.position += line_len;
-            let consumed_newline = self.peek() == Some('\n');
+            let bytes = self.source.as_bytes();
+            let consumed_newline =
+                self.position < bytes.len() && is_line_ending_byte(bytes[self.position]);
             if consumed_newline {
-                self.advance();
+                self.position = line_terminator_end(bytes, self.position);
             }
 
             let mut lazy_lines = rustc_hash::FxHashSet::default();

--- a/crates/ox_content_parser/tests/edge_cases/blocks.rs
+++ b/crates/ox_content_parser/tests/edge_cases/blocks.rs
@@ -98,6 +98,22 @@ fn unclosed_fence_consumes_until_eof() {
 }
 
 #[test]
+fn fenced_code_normalizes_crlf_and_lone_cr_line_endings() {
+    for source in ["```rust\r\nfn main() {}\r\n```\r\n", "```rust\rfn main() {}\r```\r"] {
+        let allocator = Allocator::new();
+        let doc = parse_with_options(&allocator, source, ParserOptions::default());
+
+        match &doc.children[0] {
+            Node::CodeBlock(block) => {
+                assert_eq!(block.lang, Some("rust"));
+                assert_eq!(block.value, "fn main() {}\n");
+            }
+            other => panic!("expected code block, got {other:?}"),
+        }
+    }
+}
+
+#[test]
 fn indented_fence_inside_list_item_stays_nested_block() {
     let allocator = Allocator::new();
     let doc = parse_with_options(

--- a/crates/ox_content_parser/tests/edge_cases/lists.rs
+++ b/crates/ox_content_parser/tests/edge_cases/lists.rs
@@ -48,6 +48,26 @@ fn task_list_marker_sets_checked_when_enabled() {
 }
 
 #[test]
+fn crlf_and_lone_cr_tight_lists_stay_tight() {
+    for source in ["- item one\r\n- item two\r\n", "- item one\r- item two\r"] {
+        let allocator = Allocator::new();
+        let doc = parse_with_options(&allocator, source, ParserOptions::gfm());
+
+        match &doc.children[0] {
+            Node::List(list) => {
+                assert!(!list.spread, "{source:?}");
+                assert_eq!(list.children.len(), 2);
+                assert!(!list.children[0].spread, "{source:?}");
+                assert!(!list.children[1].spread, "{source:?}");
+                assert_eq!(flatten_text(&list.children[0].children[0]), "item one");
+                assert_eq!(flatten_text(&list.children[1].children[0]), "item two");
+            }
+            other => panic!("expected list, got {other:?}"),
+        }
+    }
+}
+
+#[test]
 fn nested_list_is_attached_to_previous_item() {
     let allocator = Allocator::new();
     let doc =

--- a/crates/ox_content_renderer/src/html/tests/blocks.rs
+++ b/crates/ox_content_renderer/src/html/tests/blocks.rs
@@ -21,12 +21,28 @@ fn test_render_heading() {
 }
 
 #[test]
+fn test_render_crlf_fenced_code_like_lf() {
+    let lf = render_html("```rust\nfn main() {}\n```\n");
+    let crlf = render_html("```rust\r\nfn main() {}\r\n```\r\n");
+
+    assert_eq!(crlf, lf);
+    assert_eq!(crlf, "<pre><code class=\"language-rust\">fn main() {}\n</code></pre>\n");
+}
+
+#[test]
 fn test_render_heading_ids_are_unique_and_unicode() {
     let allocator = Allocator::new();
     let doc = Parser::new(&allocator, "## はじめに\n## はじめに").parse().unwrap();
     let mut renderer = HtmlRenderer::new();
     let html = renderer.render(&doc);
     insta::assert_snapshot!(html);
+}
+
+fn render_html(source: &str) -> String {
+    let allocator = Allocator::new();
+    let doc = Parser::new(&allocator, source).parse().unwrap();
+    let mut renderer = HtmlRenderer::new();
+    renderer.render(&doc)
 }
 
 #[test]

--- a/crates/ox_content_renderer/src/html/tests/lists_tables.rs
+++ b/crates/ox_content_renderer/src/html/tests/lists_tables.rs
@@ -45,6 +45,15 @@ fn test_render_list_with_bold() {
 }
 
 #[test]
+fn test_render_crlf_tight_list_like_lf() {
+    let lf = render_html("- item one\n- item two\n");
+    let crlf = render_html("- item one\r\n- item two\r\n");
+
+    assert_eq!(crlf, lf);
+    assert_eq!(crlf, "<ul>\n<li>item one</li>\n<li>item two</li>\n</ul>\n");
+}
+
+#[test]
 fn test_render_task_list() {
     let allocator = Allocator::new();
     let parser_options = ox_content_parser::ParserOptions::gfm();
@@ -54,4 +63,11 @@ fn test_render_task_list() {
     let mut renderer = HtmlRenderer::new();
     let html = renderer.render(&doc);
     insta::assert_snapshot!(html);
+}
+
+fn render_html(source: &str) -> String {
+    let allocator = Allocator::new();
+    let doc = Parser::new(&allocator, source).parse().unwrap();
+    let mut renderer = HtmlRenderer::new();
+    renderer.render(&doc)
 }


### PR DESCRIPTION
## Triage

Issue #1352 is valid. CommonMark treats LF, CRLF, and CR as line endings, but the parser only consumed LF in one list path and preserved carriage returns in zero-copy fenced code bodies.

## Changes

- consume CRLF and lone CR after list marker lines so tight lists stay tight
- normalize CRLF and lone CR inside fenced code block values before rendering
- add parser and renderer regressions for tight lists and fenced code

## Verification

- cargo test -p ox_content_parser --test edge_cases crlf_and_lone_cr_tight_lists_stay_tight
- cargo test -p ox_content_parser --test edge_cases fenced_code_normalizes_crlf_and_lone_cr_line_endings
- cargo test -p ox_content_renderer test_render_crlf_tight_list_like_lf
- cargo test -p ox_content_renderer test_render_crlf_fenced_code_like_lf
- cargo test -p ox_content_parser --test edge_cases
- cargo test -p ox_content_renderer
- cargo fmt --check
- git diff --check
- node tools/scripts/check-file-lines.ts

Closes #1352

Co-authored-by: lambdalisue <546312+lambdalisue@users.noreply.github.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791368736&installation_model_id=422833&pr_number=1354&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1354&signature=a2c8ab670bdf1b3242ff5cf0d094c6295c668d6d948237e6d19146fb321e8efd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fenced code blocks now consistently normalize CRLF and carriage-return line endings to standard line breaks.
  * Lists correctly recognize and consume CRLF and carriage-return line endings, preserving tight-list formatting.
  * HTML rendering now produces consistent output for fenced code blocks and tight lists regardless of line-ending style.

* **Tests**
  * Added coverage for mixed line endings in parsing and HTML rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->