### PR TITLE
fix(custom-host): pipeline SSR styles through Vite

### DIFF
--- a/npm/vite-plugin-ox-content/src/custom-host-ssr-build-stylesheets.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-ssr-build-stylesheets.ts
@@ -1,17 +1,36 @@
-import { createHash } from "node:crypto";
-import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { normalizeFilePath } from "./custom-host-ssr-imports";
+import { normalizeFilePath, publicModuleId } from "./custom-host-ssr-imports";
 import type {
   OxContentCustomHostStylesheet,
   OxContentCustomHostStylesheetsResult,
 } from "./custom-host-types";
 import { withBase } from "./custom-host-utils";
 
+const VIRTUAL_SSR_STYLESHEET_PREFIX = "\0ox-content:custom-host-ssr-stylesheet:";
+
 export type SsrStylesheetBuildRecord = {
   moduleId: string;
   stylesheet?: OxContentCustomHostStylesheet;
 };
+
+export type WritableSsrStylesheetBuildRecord = SsrStylesheetBuildRecord & {
+  entryName: string;
+  css: readonly { file: string }[];
+  referenceId?: string;
+};
+
+export type SsrStylesheetOutputBundle = Record<string, SsrStylesheetBundleEntry>;
+
+type SsrStylesheetBundleEntry =
+  | {
+      type: "asset";
+      fileName?: string;
+    }
+  | {
+      type: "chunk";
+      fileName?: string;
+      viteMetadata?: { importedCss?: Set<string> | string[] };
+    };
 
 export function resolveBuildSsrStylesheetRecords(input: {
   records: readonly SsrStylesheetBuildRecord[];
@@ -45,28 +64,78 @@ export function ssrStylesheetEntryName(file: string, root: string): string {
     .replace(/\//gu, "-");
 }
 
-export async function writeSsrStylesheetArtifact(
-  record: {
-    moduleId: string;
-    entryName: string;
-    css: readonly { file: string }[];
-  },
-  outDir: string,
-): Promise<OxContentCustomHostStylesheet | undefined> {
+export function ssrStylesheetVirtualId(entryName: string): string {
+  return `${VIRTUAL_SSR_STYLESHEET_PREFIX}${entryName}.css`;
+}
+
+export function isSsrStylesheetVirtualId(id: string): boolean {
+  return id.startsWith(VIRTUAL_SSR_STYLESHEET_PREFIX);
+}
+
+export function ssrStylesheetVirtualCss(
+  record: { css: readonly { file: string }[] },
+  root: string,
+): string {
+  return `${record.css
+    .map((stylesheet) => `@import ${JSON.stringify(publicModuleId(stylesheet.file, root))};`)
+    .join("\n")}\n`;
+}
+
+export function resolveSsrStylesheetBundleOutput(
+  record: WritableSsrStylesheetBuildRecord,
+  bundle: SsrStylesheetOutputBundle,
+  getFileName: (referenceId: string) => string,
+): OxContentCustomHostStylesheet | undefined {
   if (record.css.length === 0) {
     return undefined;
   }
-  const content = (
-    await Promise.all(record.css.map((stylesheet) => fs.readFile(stylesheet.file, "utf8")))
-  ).join("\n");
-  const hash = createHash("sha256").update(content).digest("base64url").slice(0, 8);
-  const outputPath = `assets/${record.entryName}-${hash}.css`;
-  await fs.mkdir(path.join(outDir, "assets"), { recursive: true });
-  await fs.writeFile(path.join(outDir, outputPath), content, "utf8");
+  if (!record.referenceId) {
+    return undefined;
+  }
+  const outputPath = cssOutputPath(bundle, getFileName(record.referenceId), record.entryName);
+  if (!outputPath) {
+    return undefined;
+  }
   return {
     kind: "style",
     href: `/${outputPath}`,
     moduleId: record.moduleId,
     outputPath,
   };
+}
+
+function cssOutputPath(
+  bundle: SsrStylesheetOutputBundle,
+  fileName: string,
+  entryName: string,
+): string | undefined {
+  const entry = bundle[fileName];
+  if (entry?.type === "asset" && fileName.endsWith(".css")) {
+    return fileName;
+  }
+  if (entry?.type === "chunk") {
+    const importedCss = viteImportedCss(entry);
+    if (importedCss[0]) {
+      return importedCss[0];
+    }
+  }
+  return findNamedCssAsset(bundle, entryName);
+}
+
+function findNamedCssAsset(
+  bundle: SsrStylesheetOutputBundle,
+  entryName: string,
+): string | undefined {
+  const prefix = `assets/${entryName}-`;
+  for (const [fileName, entry] of Object.entries(bundle)) {
+    if (entry.type === "asset" && fileName.startsWith(prefix) && fileName.endsWith(".css")) {
+      return fileName;
+    }
+  }
+  return undefined;
+}
+
+function viteImportedCss(chunk: Extract<SsrStylesheetBundleEntry, { type: "chunk" }>): string[] {
+  const importedCss = chunk.viteMetadata?.importedCss;
+  return importedCss ? Array.from(importedCss) : [];
 }

--- a/npm/vite-plugin-ox-content/src/custom-host-ssr-discovery.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-ssr-discovery.ts
@@ -1,0 +1,174 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { glob } from "glob";
+import type { CustomHostSsrRollupContext } from "./custom-host-ssr-stylesheets";
+import {
+  cleanModulePath,
+  dynamicDiagnostic,
+  fileFromModuleId,
+  hasGlobSyntax,
+  isLocalSpecifier,
+  isSourceFile,
+  isStyleFile,
+  isWithinRoot,
+  moduleIdCandidates,
+  normalizeFilePath,
+  outsideRootDiagnostic,
+  parseImports,
+  publicModuleId,
+  unresolvedDiagnostic,
+  unique,
+} from "./custom-host-ssr-imports";
+import { ssrStylesheetEntryName } from "./custom-host-ssr-build-stylesheets";
+import type {
+  OxContentCustomHostStylesheet,
+  OxContentCustomHostStylesheetDiagnostic,
+} from "./custom-host-types";
+
+type CssRecord = {
+  moduleId: string;
+  file: string;
+};
+
+export type RootRecord = {
+  moduleId: string;
+  file: string;
+  entryName: string;
+  css: CssRecord[];
+  dependencies: string[];
+  diagnostics: OxContentCustomHostStylesheetDiagnostic[];
+  referenceId?: string;
+  stylesheet?: OxContentCustomHostStylesheet;
+};
+
+export async function expandConfiguredModules(
+  modules: readonly string[],
+  root: string,
+): Promise<string[]> {
+  const expanded: string[] = [];
+  for (const moduleId of modules) {
+    if (!hasGlobSyntax(moduleId)) {
+      expanded.push(moduleId);
+      continue;
+    }
+    expanded.push(...(await glob(moduleId, { absolute: true, cwd: root, nodir: true })));
+  }
+  return unique(expanded);
+}
+
+export async function discoverRoot(
+  context: CustomHostSsrRollupContext,
+  moduleId: string,
+  root: string,
+): Promise<RootRecord> {
+  const resolved = await resolveModule(context, moduleId, undefined, root);
+  const fallback = fileFromModuleId(moduleId, root) ?? path.resolve(root, moduleId);
+  const file = resolved?.file ?? normalizeFilePath(fallback);
+  const record: RootRecord = {
+    moduleId: publicModuleId(file, root),
+    file,
+    entryName: ssrStylesheetEntryName(file, root),
+    css: [],
+    dependencies: [],
+    diagnostics: resolved
+      ? []
+      : [
+          {
+            code: "missing-module",
+            moduleId,
+            message: `SSR stylesheet root "${moduleId}" could not be resolved.`,
+          },
+        ],
+  };
+  if (resolved) {
+    await visitSource(context, resolved.file, root, record, new Set());
+  }
+  return record;
+}
+
+export function findRecord(
+  records: Map<string, RootRecord>,
+  moduleId: string,
+  root: string | undefined,
+): RootRecord | undefined {
+  for (const candidate of moduleIdCandidates(moduleId, root)) {
+    const record = records.get(candidate);
+    if (record) {
+      return record;
+    }
+  }
+  return undefined;
+}
+
+async function visitSource(
+  context: CustomHostSsrRollupContext,
+  file: string,
+  root: string,
+  record: RootRecord,
+  seen: Set<string>,
+): Promise<void> {
+  const clean = normalizeFilePath(file);
+  if (seen.has(clean)) {
+    return;
+  }
+  seen.add(clean);
+  record.dependencies.push(clean);
+  context.addWatchFile(clean);
+
+  const source = await fs.readFile(clean, "utf8");
+  for (const item of parseImports(source)) {
+    if (!isLocalSpecifier(item.specifier)) {
+      continue;
+    }
+    if (item.dynamic) {
+      record.diagnostics.push(dynamicDiagnostic(record.moduleId, item.specifier, clean));
+      continue;
+    }
+    const resolved = await resolveModule(context, item.specifier, clean, root);
+    if (resolved?.kind === "outside-root") {
+      record.diagnostics.push(outsideRootDiagnostic(record.moduleId, item.specifier, clean));
+      continue;
+    }
+    if (!resolved) {
+      record.diagnostics.push(unresolvedDiagnostic(record.moduleId, item.specifier, clean));
+      continue;
+    }
+    if (resolved.kind === "style") {
+      record.dependencies.push(resolved.file);
+      context.addWatchFile(resolved.file);
+      record.css.push({ moduleId: resolved.file, file: resolved.file });
+    } else {
+      await visitSource(context, resolved.file, root, record, seen);
+    }
+  }
+}
+
+async function resolveModule(
+  context: CustomHostSsrRollupContext,
+  specifier: string,
+  importer: string | undefined,
+  root: string,
+): Promise<{ file: string; kind: "outside-root" | "source" | "style" } | undefined> {
+  const resolved = await context.resolve(specifier, importer, { skipSelf: true });
+  const resolvedId = resolved?.id ?? specifier;
+  const file = fileFromModuleId(resolvedId, root);
+  const clean = cleanModulePath(resolvedId);
+  if (!file && path.isAbsolute(clean) && isStyleFile(clean)) {
+    return { file: normalizeFilePath(clean), kind: "outside-root" };
+  }
+  if (!file || !isWithinRoot(file, root) || !(await fileExists(file))) {
+    return undefined;
+  }
+  if (isStyleFile(file)) {
+    return { file, kind: "style" };
+  }
+  return isSourceFile(file) ? { file, kind: "source" } : undefined;
+}
+
+async function fileExists(file: string): Promise<boolean> {
+  try {
+    return (await fs.stat(file)).isFile();
+  } catch {
+    return false;
+  }
+}

--- a/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.fixture.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.fixture.ts
@@ -1,0 +1,282 @@
+import * as fs from "node:fs/promises";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { InlineConfig, ViteDevServer } from "vite";
+import { oxContentCustomHost } from ".";
+
+const tempDirs: string[] = [];
+const activeServers: ViteDevServer[] = [];
+const activeListeners: http.Server[] = [];
+
+export async function cleanupCustomHostSsrFixtures(): Promise<void> {
+  await Promise.all(activeListeners.splice(0).map((server) => closeHttpServer(server)));
+  await Promise.all(activeServers.splice(0).map((server) => server.close().catch(() => {})));
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+}
+
+export function viteConfig(root: string, dev: { reloadDebounceMs?: number } = {}): InlineConfig {
+  return {
+    root,
+    base: "/docs/",
+    configFile: false,
+    appType: "custom",
+    logLevel: "silent",
+    plugins: [
+      ...oxContentCustomHost({
+        host: "./src/host.ts",
+        oxContent: {
+          base: "/docs/",
+          srcDir: "content",
+          outDir: "dist",
+          resources: false,
+          docs: false,
+          search: false,
+          ogViewer: false,
+          feeds: false,
+          siteMaps: false,
+        },
+        ssrStylesheets: {
+          modules: ["src/layout.ts", "src/pages/**/page.ts"],
+        },
+        build: { transformHtml: false },
+        dev: { transformHtml: false, ...dev },
+      }),
+    ],
+    build: {
+      outDir: "dist",
+      emptyOutDir: true,
+      cssMinify: true,
+      cssCodeSplit: true,
+      manifest: true,
+      rollupOptions: {
+        input: {
+          main: path.join(root, "src", "main.ts"),
+          island: path.join(root, "src", "islands", "client.ts"),
+        },
+      },
+    },
+  };
+}
+
+export async function createProject(prefix: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(root);
+  await fs.mkdir(path.join(root, "src", "components"), { recursive: true });
+  await fs.mkdir(path.join(root, "src", "styles"), { recursive: true });
+  await fs.mkdir(path.join(root, "src", "pages", "home"), { recursive: true });
+  await fs.mkdir(path.join(root, "src", "pages", "work"), { recursive: true });
+  await fs.mkdir(path.join(root, "src", "islands"), { recursive: true });
+  await fs.mkdir(path.join(root, "content"), { recursive: true });
+  await fs.mkdir(path.join(root, "node_modules", "@fixture", "styles"), { recursive: true });
+  await writeProjectFile(root, "package.json", '{"type":"module"}\n');
+  await writeProjectFile(
+    root,
+    "node_modules/@fixture/styles/package.json",
+    '{"name":"@fixture/styles","exports":{"./package.css":"./package.css"}}\n',
+  );
+  await writeProjectFile(
+    root,
+    "node_modules/@fixture/styles/package.css",
+    '.fixture-package{font-family:"fixture";src:url("./package.woff2")}\n',
+  );
+  await writeProjectFile(root, "node_modules/@fixture/styles/package.woff2", "fixture-font");
+  await writeSourceFiles(root);
+  await writeProjectFile(root, "src/host.ts", hostModuleSource());
+  return root;
+}
+
+export function writeProjectFile(root: string, file: string, content: string): Promise<void> {
+  return fs.writeFile(path.join(root, ...file.split("/")), content);
+}
+
+export async function readOutput(root: string, file: string): Promise<string> {
+  return fs.readFile(path.join(root, "dist", ...file.split("/")), "utf8");
+}
+
+export function hasMarker(html: string, marker: string): boolean {
+  return linkedCssPaths(html).some((href) =>
+    href.replace(/^\/docs\/assets\//u, "").startsWith(marker),
+  );
+}
+
+export async function readLinkedCss(root: string, html: string): Promise<string> {
+  const files = linkedCssPaths(html).map((href) =>
+    path.join(root, "dist", href.replace(/^\/docs\//u, "")),
+  );
+  return (await Promise.all(files.map((file) => fs.readFile(file, "utf8")))).join("\n");
+}
+
+export function resourcePaths(html: string, css: string): string[] {
+  const resources = new Set<string>();
+  for (const match of html.matchAll(/(?:href|src)="(\/docs\/[^"]+)"/gu)) {
+    resources.add(match[1]);
+  }
+  for (const match of css.matchAll(/url\((?:'|")?(\/docs\/[^)'"]+)(?:'|")?\)/gu)) {
+    resources.add(match[1]);
+  }
+  return [...resources];
+}
+
+export async function serveDist(root: string): Promise<{ port: number }> {
+  const dist = path.join(root, "dist");
+  const listener = http.createServer(async (req, res) => {
+    const requestPath = new URL(req.url ?? "/", "http://localhost").pathname;
+    const relative = requestPath.startsWith("/docs/")
+      ? requestPath.slice("/docs/".length)
+      : requestPath.replace(/^\/+/u, "");
+    const file = path.resolve(dist, decodeURIComponent(relative));
+    if (!file.startsWith(`${dist}${path.sep}`)) {
+      res.statusCode = 403;
+      res.end("Forbidden");
+      return;
+    }
+    try {
+      res.statusCode = 200;
+      res.end(await fs.readFile(file));
+    } catch {
+      res.statusCode = 404;
+      res.end("Not found");
+    }
+  });
+  activeListeners.push(listener);
+  await new Promise<void>((resolve) => listener.listen(0, "127.0.0.1", resolve));
+  return { port: (listener.address() as AddressInfo).port };
+}
+
+export async function readDistJs(root: string): Promise<string> {
+  return readDist(root, ".js");
+}
+
+export async function trackDevServer(
+  serverPromise: Promise<ViteDevServer>,
+): Promise<ViteDevServer> {
+  const server = await serverPromise;
+  activeServers.push(server);
+  return server;
+}
+
+export async function listen(server: ViteDevServer): Promise<{ port: number }> {
+  const listener = http.createServer(server.middlewares);
+  activeListeners.push(listener);
+  await new Promise<void>((resolve) => listener.listen(0, "127.0.0.1", resolve));
+  return { port: (listener.address() as AddressInfo).port };
+}
+
+export async function read(port: number, requestPath: string) {
+  const response = await fetch(`http://127.0.0.1:${port}${requestPath}`);
+  return { status: response.status, headers: response.headers, text: await response.text() };
+}
+
+export function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function writeSourceFiles(root: string): Promise<void> {
+  await writeProjectFile(root, "src/main.ts", "document.body.dataset.client='ready';\n");
+  await writeProjectFile(
+    root,
+    "src/layout.ts",
+    'import "./layout.css";\nimport { nested } from "./components/Nested.ts";\nexport function layout(body) { return `<div class="layout ${nested}">${body}</div>`; }\n',
+  );
+  await writeProjectFile(
+    root,
+    "src/components/Nested.ts",
+    'import "./nested.css";\nexport const nested = "nested";\n',
+  );
+  await writeProjectFile(
+    root,
+    "src/pages/home/page.ts",
+    'import "./home.css";\nexport const marker = "home server-only";\n',
+  );
+  await writeProjectFile(
+    root,
+    "src/pages/work/page.ts",
+    'import "./work.css";\nexport const marker = "work server-only";\n',
+  );
+  await writeProjectFile(
+    root,
+    "src/islands/client.ts",
+    'import "./island.css";\nexport const hydrate = true;\n',
+  );
+  await writeProjectFile(
+    root,
+    "src/layout.css",
+    '@import "./styles/prose.css";\n@import "@fixture/styles/package.css";\n.layout{display:block}\n',
+  );
+  await writeProjectFile(
+    root,
+    "src/styles/prose.css",
+    '@font-face{font-family:"prose";src:url("./prose.woff2") format("woff2")}.prose{line-height:1.6}\n',
+  );
+  await writeProjectFile(root, "src/styles/prose.woff2", "prose-font");
+  await writeProjectFile(root, "src/components/nested.css", ".nested{padding:1px}\n");
+  await writeProjectFile(
+    root,
+    "src/pages/home/home.css",
+    '.home{color:green;background:url("./home.png")}\n',
+  );
+  await writeProjectFile(root, "src/pages/home/home.png", "home-image");
+  await writeProjectFile(root, "src/pages/work/work.css", ".work{color:blue}\n");
+  await writeProjectFile(root, "src/islands/island.css", ".island{color:purple}\n");
+}
+
+function hostModuleSource(): string {
+  return `
+let renders = 0;
+
+const routes = [
+  { path: "/home", moduleId: "/src/pages/home/page.ts", marker: "home" },
+  { path: "/work", moduleId: "/src/pages/work/page.ts", marker: "work" },
+];
+
+export default {
+  routes: routes.map((route) => ({
+    path: route.path,
+    async render(ctx) {
+      renders += 1;
+      const ssr = ctx.assets.ssrStylesheets({
+        modules: ["/src/layout.ts", route.moduleId],
+      });
+      const island = ctx.assets.stylesheets({ modules: ["/src/islands/client.ts"] });
+      const diagnostics = [...ssr.diagnostics, ...island.diagnostics]
+        .map((diagnostic) => diagnostic.code)
+        .join(",");
+      const content = await ctx.assets.stylesheetContent({ stylesheets: ssr.stylesheets });
+      const assets = ctx.assets.document({
+        islandStyles: [...ssr.stylesheets, ...island.stylesheets],
+        inlineStyles: content.stylesheets.map((stylesheet) => ({
+          key: "critical:" + stylesheet.href,
+          content: stylesheet.content,
+          attrs: { "data-critical": stylesheet.href },
+        })),
+        clientEntries: ["src/main.ts"],
+      });
+      return {
+        html: "<!doctype html><html><head>" + assets.headHtml + "</head><body data-render=\\"" + renders + "\\" data-diagnostics=\\"" + diagnostics + "\\" data-style-content-diagnostics=\\"" + content.diagnostics.map((diagnostic) => diagnostic.code).join(",") + "\\"><div class=\\"layout nested\\"><main>" + route.marker + "</main></div></body></html>",
+        dependencies: [...ssr.dependencies, ...island.dependencies],
+      };
+    },
+  })),
+};
+`;
+}
+
+function linkedCssPaths(html: string): string[] {
+  return [...html.matchAll(/href="(\/docs\/[^"]+\.css)"/gu)].map((match) => match[1]);
+}
+
+async function readDist(root: string, extension: string): Promise<string> {
+  const assetDir = path.join(root, "dist", "assets");
+  const files = (await fs.readdir(assetDir)).filter((file) => file.endsWith(extension));
+  return (
+    await Promise.all(files.map((file) => fs.readFile(path.join(assetDir, file), "utf8")))
+  ).join("\n");
+}
+
+function closeHttpServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}

--- a/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.test.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.test.ts
@@ -1,21 +1,23 @@
-import * as fs from "node:fs/promises";
-import * as http from "node:http";
-import type { AddressInfo } from "node:net";
-import * as os from "node:os";
-import * as path from "node:path";
 import { afterEach, describe, expect, it } from "vite-plus/test";
-import { build as viteBuild, createServer, type InlineConfig, type ViteDevServer } from "vite";
-import { oxContentCustomHost } from ".";
+import { build as viteBuild, createServer } from "vite";
+import {
+  cleanupCustomHostSsrFixtures,
+  createProject,
+  hasMarker,
+  listen,
+  read,
+  readDistJs,
+  readLinkedCss,
+  readOutput,
+  resourcePaths,
+  serveDist,
+  trackDevServer,
+  viteConfig,
+  wait,
+  writeProjectFile,
+} from "./custom-host-ssr-stylesheets.fixture";
 
-const tempDirs: string[] = [];
-const activeServers: ViteDevServer[] = [];
-const activeListeners: http.Server[] = [];
-
-afterEach(async () => {
-  await Promise.all(activeListeners.splice(0).map((server) => closeHttpServer(server)));
-  await Promise.all(activeServers.splice(0).map((server) => server.close().catch(() => {})));
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
-});
+afterEach(cleanupCustomHostSsrFixtures);
 
 describe("custom host SSR stylesheets", () => {
   it("emits route-specific SSR styles without browser-bundling server modules", async () => {
@@ -23,16 +25,16 @@ describe("custom host SSR stylesheets", () => {
 
     await viteBuild(viteConfig(root));
 
-    const home = await fs.readFile(path.join(root, "dist", "home", "index.html"), "utf8");
-    const work = await fs.readFile(path.join(root, "dist", "work", "index.html"), "utf8");
-    expect(markers(home)).toEqual(
-      expect.arrayContaining(["src-layout", "src-pages-home-page", "island"]),
-    );
-    expect(markers(home)).not.toContain("src-pages-work-page");
-    expect(markers(work)).toEqual(
-      expect.arrayContaining(["src-layout", "src-pages-work-page", "island"]),
-    );
-    expect(markers(work)).not.toContain("src-pages-home-page");
+    const home = await readOutput(root, "home/index.html");
+    const work = await readOutput(root, "work/index.html");
+    expect(hasMarker(home, "src-layout")).toBe(true);
+    expect(hasMarker(home, "src-pages-home-page")).toBe(true);
+    expect(hasMarker(home, "island")).toBe(true);
+    expect(hasMarker(home, "src-pages-work-page")).toBe(false);
+    expect(hasMarker(work, "src-layout")).toBe(true);
+    expect(hasMarker(work, "src-pages-work-page")).toBe(true);
+    expect(hasMarker(work, "island")).toBe(true);
+    expect(hasMarker(work, "src-pages-home-page")).toBe(false);
     expect(home).toMatch(/href="\/docs\/assets\/src-layout-[^"]+\.css"/u);
     expect(home).toMatch(/href="\/docs\/assets\/src-pages-home-page-[^"]+\.css"/u);
     expect(home.indexOf('rel="stylesheet"')).toBeLessThan(home.indexOf('<script type="module"'));
@@ -42,7 +44,20 @@ describe("custom host SSR stylesheets", () => {
     expect(homeCss).toContain(".layout");
     expect(homeCss).toContain(".nested");
     expect(homeCss).toContain(".home");
+    expect(homeCss).toContain(".prose");
+    expect(homeCss).toContain(".fixture-package");
+    expect(homeCss).not.toContain("@import");
     expect(homeCss).not.toContain(".work");
+    expect(home).toContain('data-style-content-diagnostics=""');
+    expect(home).toContain("data-critical");
+    expect(home).toContain(".fixture-package");
+    expect(home).not.toContain("@import");
+
+    const staticServer = await serveDist(root);
+    for (const resource of resourcePaths(home, homeCss)) {
+      expect((await read(staticServer.port, resource)).status, resource).toBe(200);
+    }
+
     const workCss = await readLinkedCss(root, work);
     expect(workCss).toContain(".work");
     expect(workCss).not.toContain(".home");
@@ -66,13 +81,13 @@ describe("custom host SSR stylesheets", () => {
       home.text.indexOf('src="/docs/src/main.ts"'),
     );
 
-    const nested = path.join(root, "src", "components", "Nested.ts");
-    await fs.writeFile(
-      nested,
+    await writeProjectFile(
+      root,
+      "src/components/Nested.ts",
       'import "./nested.css";\nimport "./nested-extra.css";\nexport const nested = "nested";\n',
     );
-    await fs.writeFile(path.join(root, "src", "components", "nested-extra.css"), ".extra{}\n");
-    server.watcher.emit("change", nested);
+    await writeProjectFile(root, "src/components/nested-extra.css", ".extra{}\n");
+    server.watcher.emit("change", `${root}/src/components/Nested.ts`);
     await wait(30);
 
     const updated = await read(listener.port, "/docs/home");
@@ -82,188 +97,17 @@ describe("custom host SSR stylesheets", () => {
 
   it("reports unsupported local dynamic SSR imports", async () => {
     const root = await createProject("ox-custom-host-ssr-style-diagnostic-");
-    await fs.writeFile(
-      path.join(root, "src", "pages", "home", "page.ts"),
+    await writeProjectFile(
+      root,
+      "src/pages/home/page.ts",
       'import("./late.css");\nimport "./home.css";\nexport const marker = "home server-only";\n',
     );
-    await fs.writeFile(path.join(root, "src", "pages", "home", "late.css"), ".late{}\n");
+    await writeProjectFile(root, "src/pages/home/late.css", ".late{}\n");
 
     await viteBuild(viteConfig(root));
 
-    const home = await fs.readFile(path.join(root, "dist", "home", "index.html"), "utf8");
+    const home = await readOutput(root, "home/index.html");
     expect(home).toContain('data-diagnostics="unsupported-import"');
     expect(await readLinkedCss(root, home)).not.toContain(".late");
   });
 });
-
-function viteConfig(root: string, dev: { reloadDebounceMs?: number } = {}): InlineConfig {
-  return {
-    root,
-    base: "/docs/",
-    configFile: false,
-    appType: "custom",
-    logLevel: "silent",
-    plugins: [
-      ...oxContentCustomHost({
-        host: "./src/host.ts",
-        oxContent: {
-          base: "/docs/",
-          srcDir: "content",
-          outDir: "dist",
-          resources: false,
-          docs: false,
-          search: false,
-          ogViewer: false,
-          feeds: false,
-          siteMaps: false,
-        },
-        ssrStylesheets: {
-          modules: ["src/layout.ts", "src/pages/**/page.ts"],
-        },
-        build: { transformHtml: false },
-        dev: { transformHtml: false, ...dev },
-      }),
-    ],
-    build: {
-      outDir: "dist",
-      emptyOutDir: true,
-      cssCodeSplit: true,
-      manifest: true,
-      rollupOptions: {
-        input: {
-          main: path.join(root, "src", "main.ts"),
-          island: path.join(root, "src", "islands", "client.ts"),
-        },
-      },
-    },
-  };
-}
-
-async function createProject(prefix: string): Promise<string> {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(root);
-  await fs.mkdir(path.join(root, "src", "components"), { recursive: true });
-  await fs.mkdir(path.join(root, "src", "pages", "home"), { recursive: true });
-  await fs.mkdir(path.join(root, "src", "pages", "work"), { recursive: true });
-  await fs.mkdir(path.join(root, "src", "islands"), { recursive: true });
-  await fs.mkdir(path.join(root, "content"), { recursive: true });
-  await fs.writeFile(path.join(root, "package.json"), '{"type":"module"}\n');
-  await writeSourceFiles(root);
-  await fs.writeFile(path.join(root, "src", "host.ts"), hostModuleSource());
-  return root;
-}
-
-async function writeSourceFiles(root: string): Promise<void> {
-  await fs.writeFile(path.join(root, "src", "main.ts"), "document.body.dataset.client='ready';\n");
-  await fs.writeFile(
-    path.join(root, "src", "layout.ts"),
-    'import "./layout.css";\nimport { nested } from "./components/Nested.ts";\nexport function layout(body) { return `<div class="layout ${nested}">${body}</div>`; }\n',
-  );
-  await fs.writeFile(
-    path.join(root, "src", "components", "Nested.ts"),
-    'import "./nested.css";\nexport const nested = "nested";\n',
-  );
-  await fs.writeFile(
-    path.join(root, "src", "pages", "home", "page.ts"),
-    'import "./home.css";\nexport const marker = "home server-only";\n',
-  );
-  await fs.writeFile(
-    path.join(root, "src", "pages", "work", "page.ts"),
-    'import "./work.css";\nexport const marker = "work server-only";\n',
-  );
-  await fs.writeFile(
-    path.join(root, "src", "islands", "client.ts"),
-    'import "./island.css";\nexport const hydrate = true;\n',
-  );
-  await fs.writeFile(path.join(root, "src", "layout.css"), ".layout{}\n");
-  await fs.writeFile(path.join(root, "src", "components", "nested.css"), ".nested{}\n");
-  await fs.writeFile(path.join(root, "src", "pages", "home", "home.css"), ".home{}\n");
-  await fs.writeFile(path.join(root, "src", "pages", "work", "work.css"), ".work{}\n");
-  await fs.writeFile(path.join(root, "src", "islands", "island.css"), ".island{}\n");
-}
-
-function hostModuleSource(): string {
-  return `
-let renders = 0;
-
-const routes = [
-  { path: "/home", moduleId: "/src/pages/home/page.ts", marker: "home" },
-  { path: "/work", moduleId: "/src/pages/work/page.ts", marker: "work" },
-];
-
-export default {
-  routes: routes.map((route) => ({
-    path: route.path,
-    async render(ctx) {
-      renders += 1;
-      const ssr = ctx.assets.ssrStylesheets({
-        modules: ["/src/layout.ts", route.moduleId],
-      });
-      const island = ctx.assets.stylesheets({ modules: ["/src/islands/client.ts"] });
-      const diagnostics = [...ssr.diagnostics, ...island.diagnostics]
-        .map((diagnostic) => diagnostic.code)
-        .join(",");
-      const assets = ctx.assets.document({
-        islandStyles: [...ssr.stylesheets, ...island.stylesheets],
-        clientEntries: ["src/main.ts"],
-      });
-      return {
-        html: "<!doctype html><html><head>" + assets.headHtml + "</head><body data-render=\\"" + renders + "\\" data-diagnostics=\\"" + diagnostics + "\\"><div class=\\"layout nested\\"><main>" + route.marker + "</main></div></body></html>",
-        dependencies: [...ssr.dependencies, ...island.dependencies],
-      };
-    },
-  })),
-};
-`;
-}
-
-function markers(html: string): string[] {
-  return [...html.matchAll(/assets\/([a-z-]+)-[^"]+\.css/gu)].map((match) => match[1]);
-}
-
-async function readLinkedCss(root: string, html: string): Promise<string> {
-  const files = [...html.matchAll(/href="\/docs\/([^"]+\.css)"/gu)].map((match) =>
-    path.join(root, "dist", match[1]),
-  );
-  return (await Promise.all(files.map((file) => fs.readFile(file, "utf8")))).join("\n");
-}
-
-async function readDistJs(root: string): Promise<string> {
-  return readDist(root, ".js");
-}
-
-async function readDist(root: string, extension: string): Promise<string> {
-  const assetDir = path.join(root, "dist", "assets");
-  const files = (await fs.readdir(assetDir)).filter((file) => file.endsWith(extension));
-  return (
-    await Promise.all(files.map((file) => fs.readFile(path.join(assetDir, file), "utf8")))
-  ).join("\n");
-}
-
-async function trackDevServer(serverPromise: Promise<ViteDevServer>): Promise<ViteDevServer> {
-  const server = await serverPromise;
-  activeServers.push(server);
-  return server;
-}
-
-async function listen(server: ViteDevServer): Promise<{ port: number }> {
-  const listener = http.createServer(server.middlewares);
-  activeListeners.push(listener);
-  await new Promise<void>((resolve) => listener.listen(0, "127.0.0.1", resolve));
-  return { port: (listener.address() as AddressInfo).port };
-}
-
-async function read(port: number, requestPath: string) {
-  const response = await fetch(`http://127.0.0.1:${port}${requestPath}`);
-  return { status: response.status, headers: response.headers, text: await response.text() };
-}
-
-function wait(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function closeHttpServer(server: http.Server): Promise<void> {
-  return new Promise((resolve) => {
-    server.close(() => resolve());
-  });
-}

--- a/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.ts
@@ -1,30 +1,20 @@
-import * as fs from "node:fs/promises";
-import * as path from "node:path";
-import { glob } from "glob";
 import type { DocumentAssetManifest } from "./document-assets";
 import {
+  isSsrStylesheetVirtualId,
   resolveBuildSsrStylesheetRecords,
-  ssrStylesheetEntryName,
-  writeSsrStylesheetArtifact,
+  resolveSsrStylesheetBundleOutput,
+  type SsrStylesheetOutputBundle,
+  ssrStylesheetVirtualCss,
+  ssrStylesheetVirtualId,
 } from "./custom-host-ssr-build-stylesheets";
-import { resolveStaticDevSsrStylesheets } from "./custom-host-ssr-dev-stylesheets";
 import {
-  cleanModulePath,
-  dynamicDiagnostic,
-  fileFromModuleId,
-  hasGlobSyntax,
-  isLocalSpecifier,
-  isSourceFile,
-  isStyleFile,
-  isWithinRoot,
-  moduleIdCandidates,
-  normalizeFilePath,
-  outsideRootDiagnostic,
-  parseImports,
-  publicModuleId,
-  unresolvedDiagnostic,
-  unique,
-} from "./custom-host-ssr-imports";
+  discoverRoot,
+  expandConfiguredModules,
+  findRecord,
+  type RootRecord,
+} from "./custom-host-ssr-discovery";
+import { resolveStaticDevSsrStylesheets } from "./custom-host-ssr-dev-stylesheets";
+import { hasGlobSyntax } from "./custom-host-ssr-imports";
 import {
   resolveCustomHostStylesheets,
   type CustomHostDevModuleGraph,
@@ -42,6 +32,12 @@ import type {
 
 export interface CustomHostSsrStylesheetController {
   buildStart(context: CustomHostSsrRollupContext, root: string): Promise<void>;
+  resolveId(id: string): string | undefined;
+  load(id: string): string | undefined;
+  writeBundle(
+    bundle: SsrStylesheetOutputBundle,
+    getFileName: (referenceId: string) => string,
+  ): void;
   write(outDir: string): Promise<void>;
   resolve(input: ResolveCustomHostSsrStylesheetsInput): OxContentCustomHostSsrStylesheetsResult;
   dependencies(): OxContentCustomHostDependency[];
@@ -53,6 +49,7 @@ export interface CustomHostSsrRollupContext {
     importer?: string,
     options?: { skipSelf?: boolean },
   ): Promise<{ id: string; external?: boolean | "absolute" | "relative" } | null>;
+  emitFile(file: { type: "chunk"; id: string; name?: string }): string;
   addWatchFile(id: string): void;
 }
 
@@ -62,27 +59,14 @@ export interface ResolveCustomHostSsrStylesheetsInput extends OxContentCustomHos
   moduleGraph?: CustomHostDevModuleGraph;
 }
 
-type CssRecord = {
-  moduleId: string;
-  file: string;
-};
-
-type RootRecord = {
-  moduleId: string;
-  file: string;
-  entryName: string;
-  css: CssRecord[];
-  dependencies: string[];
-  diagnostics: OxContentCustomHostStylesheetDiagnostic[];
-  stylesheet?: OxContentCustomHostStylesheet;
-};
-
 export function createCustomHostSsrStylesheetController(
   options: false | OxContentCustomHostSsrStylesheetsOptions | undefined,
 ): CustomHostSsrStylesheetController {
   let buildRoot: string | undefined;
   let buildRecords: RootRecord[] = [];
   let records = new Map<string, RootRecord>();
+  let virtualModules = new Map<string, string>();
+  const configuredModules = options && options !== false ? options.modules : [];
   let configured = false;
 
   return {
@@ -90,22 +74,39 @@ export function createCustomHostSsrStylesheetController(
       buildRoot = root;
       buildRecords = [];
       records = new Map();
-      configured = !!options && options.modules.length > 0;
+      virtualModules = new Map();
+      configured = configuredModules.length > 0;
       if (!configured) {
         return;
       }
-      for (const moduleId of await expandConfiguredModules(options.modules, root)) {
+      for (const moduleId of await expandConfiguredModules(configuredModules, root)) {
         const record = await discoverRoot(context, moduleId, root);
+        if (record.css.length > 0) {
+          const virtualId = ssrStylesheetVirtualId(record.entryName);
+          virtualModules.set(virtualId, ssrStylesheetVirtualCss(record, root));
+          record.referenceId = context.emitFile({
+            type: "chunk",
+            id: virtualId,
+            name: record.entryName,
+          });
+        }
         buildRecords.push(record);
         records.set(record.file, record);
         records.set(record.moduleId, record);
       }
     },
-    async write(outDir) {
+    resolveId(id) {
+      return isSsrStylesheetVirtualId(id) ? id : undefined;
+    },
+    load(id) {
+      return virtualModules.get(id);
+    },
+    writeBundle(bundle, getFileName) {
       for (const record of buildRecords) {
-        record.stylesheet = await writeSsrStylesheetArtifact(record, outDir);
+        record.stylesheet = resolveSsrStylesheetBundleOutput(record, bundle, getFileName);
       }
     },
+    async write(_outDir) {},
     resolve(input) {
       if (input.manifest || buildRoot) {
         return resolveBuild(input, records, configured, buildRoot);
@@ -116,7 +117,7 @@ export function createCustomHostSsrStylesheetController(
       return missingResolverResult(input.modules);
     },
     dependencies() {
-      return (options?.modules ?? []).map((moduleId) => ({
+      return configuredModules.map((moduleId) => ({
         path: moduleId,
         kind: hasGlobSyntax(moduleId) ? "glob" : "file",
       }));
@@ -215,136 +216,4 @@ function missingResolverResult(
         "Add custom-host ssrStylesheets.modules entries for production builds.",
     })),
   };
-}
-
-async function expandConfiguredModules(
-  modules: readonly string[],
-  root: string,
-): Promise<string[]> {
-  const expanded: string[] = [];
-  for (const moduleId of modules) {
-    if (!hasGlobSyntax(moduleId)) {
-      expanded.push(moduleId);
-      continue;
-    }
-    expanded.push(...(await glob(moduleId, { absolute: true, cwd: root, nodir: true })));
-  }
-  return unique(expanded);
-}
-
-async function discoverRoot(
-  context: CustomHostSsrRollupContext,
-  moduleId: string,
-  root: string,
-): Promise<RootRecord> {
-  const resolved = await resolveModule(context, moduleId, undefined, root);
-  const fallback = fileFromModuleId(moduleId, root) ?? path.resolve(root, moduleId);
-  const file = resolved?.file ?? normalizeFilePath(fallback);
-  const record: RootRecord = {
-    moduleId: publicModuleId(file, root),
-    file,
-    entryName: ssrStylesheetEntryName(file, root),
-    css: [],
-    dependencies: [],
-    diagnostics: resolved
-      ? []
-      : [
-          {
-            code: "missing-module",
-            moduleId,
-            message: `SSR stylesheet root "${moduleId}" could not be resolved.`,
-          },
-        ],
-  };
-  if (resolved) {
-    await visitSource(context, resolved.file, root, record, new Set());
-  }
-  return record;
-}
-
-async function visitSource(
-  context: CustomHostSsrRollupContext,
-  file: string,
-  root: string,
-  record: RootRecord,
-  seen: Set<string>,
-): Promise<void> {
-  const clean = normalizeFilePath(file);
-  if (seen.has(clean)) {
-    return;
-  }
-  seen.add(clean);
-  record.dependencies.push(clean);
-  context.addWatchFile(clean);
-
-  const source = await fs.readFile(clean, "utf8");
-  for (const item of parseImports(source)) {
-    if (!isLocalSpecifier(item.specifier)) {
-      continue;
-    }
-    if (item.dynamic) {
-      record.diagnostics.push(dynamicDiagnostic(record.moduleId, item.specifier, clean));
-      continue;
-    }
-    const resolved = await resolveModule(context, item.specifier, clean, root);
-    if (resolved?.kind === "outside-root") {
-      record.diagnostics.push(outsideRootDiagnostic(record.moduleId, item.specifier, clean));
-      continue;
-    }
-    if (!resolved) {
-      record.diagnostics.push(unresolvedDiagnostic(record.moduleId, item.specifier, clean));
-      continue;
-    }
-    if (resolved.kind === "style") {
-      record.dependencies.push(resolved.file);
-      context.addWatchFile(resolved.file);
-      record.css.push({ moduleId: resolved.file, file: resolved.file });
-    } else {
-      await visitSource(context, resolved.file, root, record, seen);
-    }
-  }
-}
-
-async function resolveModule(
-  context: CustomHostSsrRollupContext,
-  specifier: string,
-  importer: string | undefined,
-  root: string,
-): Promise<{ file: string; kind: "outside-root" | "source" | "style" } | undefined> {
-  const resolved = await context.resolve(specifier, importer, { skipSelf: true });
-  const resolvedId = resolved?.id ?? specifier;
-  const file = fileFromModuleId(resolvedId, root);
-  const clean = cleanModulePath(resolvedId);
-  if (!file && path.isAbsolute(clean) && isStyleFile(clean)) {
-    return { file: normalizeFilePath(clean), kind: "outside-root" };
-  }
-  if (!file || !isWithinRoot(file, root) || !(await fileExists(file))) {
-    return undefined;
-  }
-  if (isStyleFile(file)) {
-    return { file, kind: "style" };
-  }
-  return isSourceFile(file) ? { file, kind: "source" } : undefined;
-}
-
-async function fileExists(file: string): Promise<boolean> {
-  try {
-    return (await fs.stat(file)).isFile();
-  } catch {
-    return false;
-  }
-}
-
-function findRecord(
-  records: Map<string, RootRecord>,
-  moduleId: string,
-  root: string | undefined,
-): RootRecord | undefined {
-  for (const candidate of moduleIdCandidates(moduleId, root)) {
-    const record = records.get(candidate);
-    if (record) {
-      return record;
-    }
-  }
-  return undefined;
 }

--- a/npm/vite-plugin-ox-content/src/custom-host.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host.ts
@@ -100,6 +100,18 @@ export function createOxContentCustomHostPlugin(input: OxContentCustomHostOption
       await ssrStylesheets.buildStart(this, config.root);
     },
 
+    resolveId(id) {
+      return ssrStylesheets.resolveId(id);
+    },
+
+    load(id) {
+      return ssrStylesheets.load(id);
+    },
+
+    writeBundle(_options, bundle) {
+      ssrStylesheets.writeBundle(bundle, (referenceId) => this.getFileName(referenceId));
+    },
+
     async closeBundle() {
       if (!config || command !== "build" || input.build?.enabled === false) {
         return;


### PR DESCRIPTION
## Triage

Issue #1347 is valid. The existing SSR stylesheet artifact writer concatenated discovered CSS bytes directly, so production output skipped Vite CSS import resolution, package CSS resolution, asset URL emission, and CSS minification.

## Changes

- emit discovered SSR stylesheet roots as virtual CSS entries during Vite build
- resolve stylesheet descriptors from Vite's generated CSS assets instead of raw concatenated files
- keep stylesheetContent() pointed at the same processed build artifact
- split SSR stylesheet discovery into a focused helper module to keep line guards intact
- add a production regression covering local CSS imports, bare package CSS imports, url() assets, minification, HTTP resource checks, and server-only JS exclusion

## Verification

- vp check --fix npm/vite-plugin-ox-content/src/custom-host.ts npm/vite-plugin-ox-content/src/custom-host-ssr-build-stylesheets.ts npm/vite-plugin-ox-content/src/custom-host-ssr-discovery.ts npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.ts npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.fixture.ts npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.test.ts
- vp exec --filter @ox-content/vite-plugin -- vp test src/custom-host-ssr-stylesheets.test.ts src/custom-host-stylesheet-content.test.ts
- vp run --filter @ox-content/vite-plugin build
- node tools/scripts/check-file-lines.ts
- git diff --check

Closes #1347

Co-authored-by: ryoppippi <1560508+ryoppippi@users.noreply.github.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791369970&installation_model_id=422833&pr_number=1355&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1355&signature=37a1be3e5a0fc4c587c6c124b36f927863db352dd2e1b9adb54c2426cc189473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->