### PR TITLE
feat(parser): add heading attributes option

### DIFF
--- a/crates/ox_content_ast/src/ast.rs
+++ b/crates/ox_content_ast/src/ast.rs
@@ -115,6 +115,10 @@ pub struct Paragraph<'a> {
 pub struct Heading<'a> {
     /// Heading depth (1-6).
     pub depth: u8,
+    /// Explicit heading id from a trailing attribute block.
+    pub id: Option<&'a str>,
+    /// Explicit heading classes from a trailing attribute block.
+    pub classes: Vec<'a, &'a str>,
     /// Inline children.
     pub children: Vec<'a, Node<'a>>,
     /// Source span.

--- a/crates/ox_content_mdast/src/from_json.rs
+++ b/crates/ox_content_mdast/src/from_json.rs
@@ -17,8 +17,10 @@ use ox_content_ast::{
 };
 use serde_json::Value;
 
+mod heading_properties;
 mod mdx;
 
+use heading_properties::{heading_classes, heading_id};
 use mdx::mdx_attributes;
 
 /// Why an mdast payload could not be turned back into a document.
@@ -103,6 +105,8 @@ fn node<'a>(allocator: &'a Allocator, value: &Value) -> Result<Node<'a>, MdastJs
         ),
         "heading" => Node::Heading(allocator.boxed(Heading {
             depth: depth(value)?,
+            id: heading_id(allocator, value),
+            classes: heading_classes(allocator, value),
             children: nodes(allocator, value.get("children"))?,
             span,
         })),

--- a/crates/ox_content_mdast/src/from_json/heading_properties.rs
+++ b/crates/ox_content_mdast/src/from_json/heading_properties.rs
@@ -1,0 +1,42 @@
+use ox_content_allocator::{Allocator, Vec as ArenaVec};
+use serde_json::Value;
+
+pub(super) fn heading_id<'a>(allocator: &'a Allocator, value: &Value) -> Option<&'a str> {
+    heading_h_properties(value)
+        .and_then(|properties| properties.get("id"))
+        .and_then(Value::as_str)
+        .map(|id| allocator.alloc_str(id))
+}
+
+pub(super) fn heading_classes<'a>(
+    allocator: &'a Allocator,
+    value: &Value,
+) -> ArenaVec<'a, &'a str> {
+    let mut classes = allocator.new_vec();
+    let Some(class_name) =
+        heading_h_properties(value).and_then(|properties| properties.get("className"))
+    else {
+        return classes;
+    };
+
+    if let Some(class_name) = class_name.as_str() {
+        for item in class_name.split_whitespace() {
+            classes.push(allocator.alloc_str(item));
+        }
+        return classes;
+    }
+
+    let Some(items) = class_name.as_array() else {
+        return classes;
+    };
+    for item in items {
+        if let Some(class_name) = item.as_str() {
+            classes.push(allocator.alloc_str(class_name));
+        }
+    }
+    classes
+}
+
+fn heading_h_properties(value: &Value) -> Option<&serde_json::Map<String, Value>> {
+    value.get("data").and_then(Value::as_object)?.get("hProperties").and_then(Value::as_object)
+}

--- a/crates/ox_content_mdast/src/from_json/tests.rs
+++ b/crates/ox_content_mdast/src/from_json/tests.rs
@@ -114,6 +114,24 @@ fn a_hand_written_tree_rebuilds() {
 }
 
 #[test]
+fn heading_h_properties_rebuild() {
+    let allocator = Allocator::new();
+    let json = r#"{"type":"root","children":[{
+        "type":"heading",
+        "depth":2,
+        "data":{"hProperties":{"id":"custom-heading-id","className":["highlight","wide"]}},
+        "children":[{"type":"text","value":"Custom identifier"}]
+    }]}"#;
+
+    let document = from_mdast_json(&allocator, json).expect("payload rebuilds");
+
+    assert_eq!(
+        to_mdast_json(&document),
+        r#"{"type":"root","children":[{"type":"heading","depth":2,"data":{"hProperties":{"id":"custom-heading-id","className":["highlight","wide"]}},"children":[{"type":"text","value":"Custom identifier"}]}]}"#
+    );
+}
+
+#[test]
 fn missing_children_are_read_as_empty() {
     let allocator = Allocator::new();
 

--- a/crates/ox_content_mdast/src/mdast.rs
+++ b/crates/ox_content_mdast/src/mdast.rs
@@ -80,9 +80,39 @@ impl MdastJsonSerializer {
     fn write_heading(&mut self, heading: &Heading<'_>) {
         self.output.push_str("{\"type\":\"heading\",\"depth\":");
         self.write_u32(u32::from(heading.depth));
+        self.write_heading_data(heading);
         self.output.push_str(",\"children\":");
         self.write_nodes(&heading.children);
         self.output.push('}');
+    }
+
+    fn write_heading_data(&mut self, heading: &Heading<'_>) {
+        if heading.id.is_none() && heading.classes.is_empty() {
+            return;
+        }
+
+        self.output.push_str(",\"data\":{\"hProperties\":{");
+        let wrote = if let Some(id) = heading.id {
+            self.output.push_str("\"id\":");
+            self.write_string(id);
+            true
+        } else {
+            false
+        };
+        if !heading.classes.is_empty() {
+            if wrote {
+                self.output.push(',');
+            }
+            self.output.push_str("\"className\":[");
+            for (index, class_name) in heading.classes.iter().enumerate() {
+                if index > 0 {
+                    self.output.push(',');
+                }
+                self.write_string(class_name);
+            }
+            self.output.push(']');
+        }
+        self.output.push_str("}}");
     }
 
     fn write_thematic_break(&mut self, _thematic_break: &ThematicBreak) {

--- a/crates/ox_content_mdast/src/mdast/tests.rs
+++ b/crates/ox_content_mdast/src/mdast/tests.rs
@@ -31,6 +31,20 @@ fn serializes_gfm_nodes() {
 }
 
 #[test]
+fn serializes_heading_attributes_as_h_properties() {
+    let json = parse_json(
+        "## Custom identifier {#custom-heading-id .highlight .wide}\n",
+        ParserOptions { heading_attributes: true, ..ParserOptions::default() },
+    );
+    let heading = &json["children"][0];
+
+    assert_eq!(heading["children"][0]["value"], "Custom identifier");
+    assert_eq!(heading["data"]["hProperties"]["id"], "custom-heading-id");
+    assert_eq!(heading["data"]["hProperties"]["className"][0], "highlight");
+    assert_eq!(heading["data"]["hProperties"]["className"][1], "wide");
+}
+
+#[test]
 fn serializes_mdx_nodes_and_attributes() {
     let json = parse_json(
         "import Alert from './Alert'\n\n<Alert title=\"Hi\" count={count} {...props}>Hello {name}</Alert>\n",

--- a/crates/ox_content_mdast/src/mdast_raw/blocks.rs
+++ b/crates/ox_content_mdast/src/mdast_raw/blocks.rs
@@ -25,6 +25,11 @@ impl MdastRawSerializer {
         let mut record = RawNodeRecord::new(KIND_HEADING, node.span);
         self.write_child_nodes(&mut record, &node.children)?;
         record.num0 = u32::from(node.depth);
+        self.write_string_into_slot(&mut record, 0, node.id)?;
+        if !node.classes.is_empty() {
+            let joined = node.classes.iter().copied().collect::<Vec<_>>().join(" ");
+            self.write_string_into_slot(&mut record, 1, Some(&joined))?;
+        }
         self.push_record(record)
     }
 

--- a/crates/ox_content_mdast/src/mdast_raw/tests.rs
+++ b/crates/ox_content_mdast/src/mdast_raw/tests.rs
@@ -144,6 +144,19 @@ fn preserves_utf8_spans_as_byte_offsets() {
 }
 
 #[test]
+fn serializes_heading_attributes() {
+    let bytes = parse_to_raw_bytes_with_options(
+        "## Custom identifier {#custom-heading-id .highlight .wide}\n",
+        ParserOptions { heading_attributes: true, ..ParserOptions::default() },
+    );
+
+    let heading_base = find_node_base(&bytes, KIND_HEADING);
+
+    assert_eq!(read_node_string(&bytes, heading_base, 0), Some("custom-heading-id"));
+    assert_eq!(read_node_string(&bytes, heading_base, 1), Some("highlight wide"));
+}
+
+#[test]
 fn serializes_every_mdx_kind_and_preserves_jsx_attributes() {
     let source = "import Alert from './Alert'\n\n{count}\n\n<Alert title=\"Hi\" count={count} {...props} />\n\nHello <Badge /> {name}\n";
     let bytes = parse_to_raw_bytes_with_options(source, ParserOptions::mdx());

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -1975,6 +1975,12 @@ export interface JsParserOptions {
    * Default: `false`.
    */
   definitionLists?: boolean
+  /**
+   * Enable Pandoc-style `{#id .class}` heading attribute blocks.
+   *
+   * Default: `false`.
+   */
+  headingAttributes?: boolean
 }
 
 /** Opt-in parameterized Markdown partials. */
@@ -2873,6 +2879,12 @@ export interface JsTransformOptions {
    * Default: `false`.
    */
   smartPunctuation?: boolean
+  /**
+   * Enable Pandoc-style `{#id .class}` heading attribute blocks.
+   *
+   * Default: `false`.
+   */
+  headingAttributes?: boolean
   /**
    * Parse YAML frontmatter before transforming.
    *

--- a/crates/ox_content_napi/src/parser_options.rs
+++ b/crates/ox_content_napi/src/parser_options.rs
@@ -87,6 +87,11 @@ pub struct JsParserOptions {
     ///
     /// Default: `false`.
     pub definition_lists: Option<bool>,
+
+    /// Enable Pandoc-style `{#id .class}` heading attribute blocks.
+    ///
+    /// Default: `false`.
+    pub heading_attributes: Option<bool>,
 }
 
 impl From<JsParserOptions> for ParserOptions {
@@ -126,6 +131,9 @@ impl From<JsParserOptions> for ParserOptions {
         }
         if let Some(v) = opts.definition_lists {
             options.definition_lists = v;
+        }
+        if let Some(v) = opts.heading_attributes {
+            options.heading_attributes = v;
         }
 
         options
@@ -189,6 +197,7 @@ impl FromNapiValue for JsParserOptions {
             smart_punctuation: unsafe { read_flag(env, napi_val, c"smartPunctuation") }?,
             math: unsafe { read_flag(env, napi_val, c"math") }?,
             definition_lists: unsafe { read_flag(env, napi_val, c"definitionLists") }?,
+            heading_attributes: unsafe { read_flag(env, napi_val, c"headingAttributes") }?,
         })
     }
 }

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -1979,6 +1979,12 @@ export interface JsParserOptions {
    * Default: `false`.
    */
   definitionLists?: boolean
+  /**
+   * Enable Pandoc-style `{#id .class}` heading attribute blocks.
+   *
+   * Default: `false`.
+   */
+  headingAttributes?: boolean
 }
 
 /** Opt-in parameterized Markdown partials. */
@@ -2877,6 +2883,12 @@ export interface JsTransformOptions {
    * Default: `false`.
    */
   smartPunctuation?: boolean
+  /**
+   * Enable Pandoc-style `{#id .class}` heading attribute blocks.
+   *
+   * Default: `false`.
+   */
+  headingAttributes?: boolean
   /**
    * Parse YAML frontmatter before transforming.
    *

--- a/crates/ox_content_napi/src/transform_bindings/transform_options.rs
+++ b/crates/ox_content_napi/src/transform_bindings/transform_options.rs
@@ -74,6 +74,11 @@ pub struct JsTransformOptions {
     /// Default: `false`.
     pub smart_punctuation: Option<bool>,
 
+    /// Enable Pandoc-style `{#id .class}` heading attribute blocks.
+    ///
+    /// Default: `false`.
+    pub heading_attributes: Option<bool>,
+
     /// Parse YAML frontmatter before transforming.
     ///
     /// Default: `false`.

--- a/crates/ox_content_napi/src/transform_bindings/transform_options/convert.rs
+++ b/crates/ox_content_napi/src/transform_bindings/transform_options/convert.rs
@@ -17,6 +17,7 @@ impl From<JsTransformOptions> for TransformOptions {
             superscript: value.superscript,
             subscript: value.subscript,
             smart_punctuation: value.smart_punctuation,
+            heading_attributes: value.heading_attributes,
             frontmatter: value.frontmatter,
             toc_max_depth: value.toc_max_depth,
             convert_md_links: value.convert_md_links,

--- a/crates/ox_content_parser/src/parser/block.rs
+++ b/crates/ox_content_parser/src/parser/block.rs
@@ -236,9 +236,12 @@ impl<'a> Parser<'a> {
                 let heading_end = scan_next_line_start(bytes, line_start);
                 self.position = heading_end;
                 let content = self.source[start..content_end].trim();
+                let (content, id, classes) = self.split_heading_attributes(content);
                 let children = self.parse_inline_block(content, start)?;
                 return Ok(Some(Node::Heading(self.allocator.boxed(Heading {
                     depth,
+                    id,
+                    classes,
                     children,
                     span: Span::new(start as u32, heading_end as u32),
                 }))));

--- a/crates/ox_content_parser/src/parser/leaf.rs
+++ b/crates/ox_content_parser/src/parser/leaf.rs
@@ -1,3 +1,4 @@
+use ox_content_allocator::Vec as ArenaVec;
 use ox_content_ast::{Node, Span};
 
 use super::Parser;
@@ -119,6 +120,8 @@ impl<'a> Parser<'a> {
 
         let span = Span::new(start as u32, self.position as u32);
 
+        let (content, id, classes) = self.split_heading_attributes(content);
+
         // Parse inline content
         let children = if !content.is_empty() {
             self.parse_inline_block(content, content_start)?
@@ -128,9 +131,56 @@ impl<'a> Parser<'a> {
 
         Ok(Some(Node::Heading(self.allocator.boxed(ox_content_ast::Heading {
             depth,
+            id,
+            classes,
             children,
             span,
         }))))
+    }
+
+    pub(super) fn split_heading_attributes(
+        &self,
+        content: &'a str,
+    ) -> (&'a str, Option<&'a str>, ArenaVec<'a, &'a str>) {
+        let mut classes = self.allocator.new_vec();
+        if !self.options.heading_attributes {
+            return (content, None, classes);
+        }
+
+        let trimmed = content.trim_end_matches(char::is_whitespace);
+        if !trimmed.ends_with('}') {
+            return (content, None, classes);
+        }
+
+        let Some(open) = trimmed.rfind('{') else {
+            return (content, None, classes);
+        };
+        if open > 0 && !ends_with_whitespace(&trimmed[..open]) {
+            return (content, None, classes);
+        }
+
+        let mut id = None;
+        let mut has_attribute = false;
+        let attrs = &trimmed[open + 1..trimmed.len() - 1];
+        for token in attrs.split_whitespace() {
+            if let Some(name) = token.strip_prefix('#') {
+                if !name.is_empty() && id.is_none() {
+                    id = Some(name);
+                    has_attribute = true;
+                }
+            } else if let Some(name) = token.strip_prefix('.')
+                && !name.is_empty()
+            {
+                classes.push(name);
+                has_attribute = true;
+            }
+        }
+
+        if !has_attribute {
+            return (content, None, classes);
+        }
+
+        (trimmed[..open].trim_end_matches(char::is_whitespace), id, classes)
     }
 
     /// Parses a thematic break.
@@ -144,6 +194,10 @@ impl<'a> Parser<'a> {
         let span = Span::new(start as u32, self.position as u32);
         Ok(Some(Node::ThematicBreak(ox_content_ast::ThematicBreak { span })))
     }
+}
+
+fn ends_with_whitespace(value: &str) -> bool {
+    value.chars().next_back().is_some_and(char::is_whitespace)
 }
 
 fn is_atx_heading_prefix(bytes: &[u8]) -> bool {

--- a/crates/ox_content_parser/src/parser/options.rs
+++ b/crates/ox_content_parser/src/parser/options.rs
@@ -63,6 +63,15 @@ pub struct ParserOptions {
     /// Default: `false`; not enabled by [`ParserOptions::gfm`].
     pub definition_lists: bool,
 
+    /// Enable Pandoc-style heading attribute blocks.
+    ///
+    /// When set, a trailing `{#id .class}` block on an ATX or setext heading
+    /// becomes [`ox_content_ast::Heading::id`] and
+    /// [`ox_content_ast::Heading::classes`] instead of rendered text.
+    ///
+    /// Default: `false`; not enabled by [`ParserOptions::gfm`].
+    pub heading_attributes: bool,
+
     /// Recognize emphasis whose delimiters sit against East Asian punctuation.
     ///
     /// CommonMark decides whether a `*`/`_` run may open or close from the
@@ -123,6 +132,7 @@ impl Default for ParserOptions {
             smart_punctuation: false,
             math: false,
             definition_lists: false,
+            heading_attributes: false,
             cjk_emphasis: false,
             mdx: false,
             // Not `0`: an unbounded parse of hostile input overflows the
@@ -156,6 +166,7 @@ impl ParserOptions {
             smart_punctuation: false,
             math: false,
             definition_lists: false,
+            heading_attributes: false,
             // Not part of GFM: GitHub renders these runs per CommonMark too.
             cjk_emphasis: false,
             mdx: false,

--- a/crates/ox_content_parser/tests/edge_cases/blocks.rs
+++ b/crates/ox_content_parser/tests/edge_cases/blocks.rs
@@ -25,6 +25,90 @@ fn heading_trims_closing_hashes() {
 }
 
 #[test]
+fn heading_attributes_default_off_stay_literal() {
+    let allocator = Allocator::new();
+    let doc = parse_with_options(
+        &allocator,
+        "### Custom identifier {#custom-heading-id .highlight}\n",
+        ParserOptions::default(),
+    );
+
+    match &doc.children[0] {
+        Node::Heading(heading) => {
+            assert_eq!(heading.id, None);
+            assert!(heading.classes.is_empty());
+            assert_eq!(
+                first_text_in_nodes(heading.children.iter()),
+                Some("Custom identifier {#custom-heading-id .highlight}")
+            );
+        }
+        other => panic!("expected heading, got {other:?}"),
+    }
+}
+
+#[test]
+fn heading_attributes_parse_id_classes_and_strip_text() {
+    let allocator = Allocator::new();
+    let doc = parse_with_options(
+        &allocator,
+        "### Custom identifier {#custom-heading-id .highlight .wide ignored}\n",
+        ParserOptions { heading_attributes: true, ..ParserOptions::default() },
+    );
+
+    match &doc.children[0] {
+        Node::Heading(heading) => {
+            assert_eq!(heading.id, Some("custom-heading-id"));
+            assert_eq!(heading.classes.iter().copied().collect::<Vec<_>>(), ["highlight", "wide"]);
+            assert_eq!(first_text_in_nodes(heading.children.iter()), Some("Custom identifier"));
+        }
+        other => panic!("expected heading, got {other:?}"),
+    }
+}
+
+#[test]
+fn heading_attributes_leave_unusable_blocks_as_prose() {
+    let allocator = Allocator::new();
+    for source in ["## A sentence {like this}\n", "## A sentence {}\n"] {
+        let doc = parse_with_options(
+            &allocator,
+            source,
+            ParserOptions { heading_attributes: true, ..ParserOptions::default() },
+        );
+
+        match &doc.children[0] {
+            Node::Heading(heading) => {
+                assert_eq!(heading.id, None);
+                assert!(heading.classes.is_empty());
+                assert!(first_text_in_nodes(heading.children.iter()).is_some_and(|text| {
+                    text == "A sentence {like this}" || text == "A sentence {}"
+                }));
+            }
+            other => panic!("expected heading, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn heading_attributes_apply_to_setext_headings() {
+    let allocator = Allocator::new();
+    let doc = parse_with_options(
+        &allocator,
+        "Custom identifier {#custom-heading-id .highlight}\n---\n",
+        ParserOptions { heading_attributes: true, ..ParserOptions::default() },
+    );
+
+    match &doc.children[0] {
+        Node::Heading(heading) => {
+            assert_eq!(heading.depth, 2);
+            assert_eq!(heading.id, Some("custom-heading-id"));
+            assert_eq!(heading.classes.iter().copied().collect::<Vec<_>>(), ["highlight"]);
+            assert_eq!(first_text_in_nodes(heading.children.iter()), Some("Custom identifier"));
+        }
+        other => panic!("expected heading, got {other:?}"),
+    }
+}
+
+#[test]
 fn invalid_atx_heading_without_space_stays_paragraph() {
     let allocator = Allocator::new();
     let doc = parse_with_options(&allocator, "#Title", ParserOptions::default());

--- a/crates/ox_content_renderer/src/html/renderer/blocks.rs
+++ b/crates/ox_content_renderer/src/html/renderer/blocks.rs
@@ -52,6 +52,16 @@ impl HtmlRenderer {
         // written straight into `self.output`.
         self.write_heading_id(heading);
         self.output.push('"');
+        if !heading.classes.is_empty() {
+            self.output.push_str(" class=\"");
+            for (index, class_name) in heading.classes.iter().enumerate() {
+                if index > 0 {
+                    self.output.push(' ');
+                }
+                self.write_attribute_escaped(class_name);
+            }
+            self.output.push('"');
+        }
         self.write_source_span_attr(heading.span);
         self.output.push('>');
         for child in &heading.children {

--- a/crates/ox_content_renderer/src/html/renderer/write.rs
+++ b/crates/ox_content_renderer/src/html/renderer/write.rs
@@ -223,7 +223,8 @@ impl HtmlRenderer {
     pub(in crate::html::renderer) fn write_heading_id(&mut self, heading: &Heading<'_>) {
         crate::profile_span!("renderer::write_heading_id");
         self.prepare_heading_id(heading);
-        self.output.push_str(&self.heading_id_scratch);
+        let id = self.heading_id_scratch.clone();
+        self.write_attribute_escaped(&id);
     }
 
     pub(in crate::html::renderer) fn write_heading_permalink_if_needed(
@@ -239,7 +240,8 @@ impl HtmlRenderer {
         self.output.push_str("<a class=\"");
         self.output.push_str(HEADING_PERMALINK_CLASS);
         self.output.push_str("\" href=\"#");
-        self.output.push_str(&self.heading_id_scratch);
+        let id = self.heading_id_scratch.clone();
+        self.write_attribute_escaped(&id);
         if self.heading_text_scratch.is_empty() {
             self.output.push_str("\" aria-label=\"Permalink to this section\">#</a>");
             return;
@@ -252,6 +254,16 @@ impl HtmlRenderer {
     fn prepare_heading_id(&mut self, heading: &Heading<'_>) {
         self.heading_text_scratch.clear();
         collect_heading_text_into(&heading.children, &mut self.heading_text_scratch);
+        if let Some(id) = heading.id {
+            self.heading_id_scratch.clear();
+            self.heading_id_scratch.push_str(id);
+            if let Some(count) = self.heading_id_counts.get_mut(id) {
+                *count += 1;
+            } else {
+                self.heading_id_counts.insert(CompactString::from(id), 1);
+            }
+            return;
+        }
         self.heading_slug_scratch.clear();
         slugify_heading_into(&self.heading_text_scratch, &mut self.heading_slug_scratch);
 

--- a/crates/ox_content_renderer/src/html/tests/blocks.rs
+++ b/crates/ox_content_renderer/src/html/tests/blocks.rs
@@ -1,6 +1,6 @@
 use crate::html::{HtmlRenderer, HtmlRendererOptions};
 use ox_content_allocator::Allocator;
-use ox_content_parser::Parser;
+use ox_content_parser::{Parser, ParserOptions};
 
 #[test]
 fn test_render_paragraph() {
@@ -18,6 +18,29 @@ fn test_render_heading() {
     let mut renderer = HtmlRenderer::new();
     let html = renderer.render(&doc);
     assert_eq!(html, "<h1 id=\"hello\">Hello</h1>\n");
+}
+
+#[test]
+fn test_render_heading_attributes_use_explicit_id_and_classes() {
+    let html = render_html_with_options(
+        "### Custom identifier {#custom-heading-id .highlight .wide}",
+        ParserOptions { heading_attributes: true, ..ParserOptions::default() },
+    );
+
+    assert_eq!(
+        html,
+        "<h3 id=\"custom-heading-id\" class=\"highlight wide\">Custom identifier</h3>\n"
+    );
+}
+
+#[test]
+fn test_render_heading_attributes_escape_explicit_attrs() {
+    let html = render_html_with_options(
+        "### Custom {#a\"b .x<y}",
+        ParserOptions { heading_attributes: true, ..ParserOptions::default() },
+    );
+
+    assert_eq!(html, "<h3 id=\"a&quot;b\" class=\"x&lt;y\">Custom</h3>\n");
 }
 
 #[test]
@@ -41,6 +64,13 @@ fn test_render_heading_ids_are_unique_and_unicode() {
 fn render_html(source: &str) -> String {
     let allocator = Allocator::new();
     let doc = Parser::new(&allocator, source).parse().unwrap();
+    let mut renderer = HtmlRenderer::new();
+    renderer.render(&doc)
+}
+
+fn render_html_with_options(source: &str, options: ParserOptions) -> String {
+    let allocator = Allocator::new();
+    let doc = Parser::with_options(&allocator, source, options).parse().unwrap();
     let mut renderer = HtmlRenderer::new();
     renderer.render(&doc)
 }
@@ -139,6 +169,24 @@ fn test_render_inline_toc_uses_unique_and_unicode_ids() {
     let html = renderer.render(&doc);
 
     insta::assert_snapshot!(html);
+}
+
+#[test]
+fn test_render_inline_toc_uses_heading_attribute_id() {
+    let allocator = Allocator::new();
+    let doc = Parser::with_options(
+        &allocator,
+        "[[toc]]\n\n## Custom identifier {#custom-heading-id .highlight}\n",
+        ParserOptions { heading_attributes: true, ..ParserOptions::default() },
+    )
+    .parse()
+    .unwrap();
+    let mut renderer = HtmlRenderer::new();
+    let html = renderer.render(&doc);
+
+    assert!(html.contains("<a href=\"#custom-heading-id\">Custom identifier</a>"), "{html}");
+    assert!(html.contains("<h2 id=\"custom-heading-id\" class=\"highlight\">"), "{html}");
+    assert!(!html.contains("{#custom-heading-id"), "{html}");
 }
 
 #[test]

--- a/crates/ox_content_renderer/src/html/toc.rs
+++ b/crates/ox_content_renderer/src/html/toc.rs
@@ -156,6 +156,21 @@ fn collect_inline_toc_node(
         Node::Heading(heading) => {
             let include_heading = heading.depth <= max_depth;
             let text = collect_heading_text(&heading.children);
+            if let Some(explicit_id) = heading.id {
+                if let Some(count) = counts.get_mut(explicit_id) {
+                    *count += 1;
+                } else {
+                    counts.insert(explicit_id.to_string(), 1);
+                }
+                if include_heading {
+                    entries.push(InlineTocEntry {
+                        depth: heading.depth,
+                        text,
+                        id: explicit_id.to_string(),
+                    });
+                }
+                return;
+            }
             let mut slug = slugify_heading(&text);
             let id = if let Some(count) = counts.get_mut(slug.as_str()) {
                 let suffix = *count;

--- a/crates/ox_content_search/src/indexer.rs
+++ b/crates/ox_content_search/src/indexer.rs
@@ -213,6 +213,8 @@ mod tests {
 
         children.push(Node::Heading(allocator.boxed(Heading {
             depth: 1,
+            id: None,
+            classes: ox_content_allocator::Vec::new_in(&allocator),
             children: heading_children,
             span: Span::new(0, 12),
         })));

--- a/crates/ox_content_transform/src/options.rs
+++ b/crates/ox_content_transform/src/options.rs
@@ -12,6 +12,7 @@ pub struct TransformOptions {
     pub superscript: Option<bool>,
     pub subscript: Option<bool>,
     pub smart_punctuation: Option<bool>,
+    pub heading_attributes: Option<bool>,
     pub frontmatter: Option<bool>,
     pub toc_max_depth: Option<u8>,
     pub convert_md_links: Option<bool>,

--- a/crates/ox_content_transform/src/transformer/options.rs
+++ b/crates/ox_content_transform/src/transformer/options.rs
@@ -31,6 +31,9 @@ pub(super) fn transform_options_to_parser_options(opts: &TransformOptions) -> Pa
     if let Some(v) = opts.smart_punctuation {
         options.smart_punctuation = v;
     }
+    if let Some(v) = opts.heading_attributes {
+        options.heading_attributes = v;
+    }
     if let Some(v) = opts.mdx {
         options.mdx = v;
     }

--- a/crates/ox_content_transform/src/transformer/tests.rs
+++ b/crates/ox_content_transform/src/transformer/tests.rs
@@ -169,6 +169,24 @@ fn heading_permalinks_compose_with_explicit_ids() {
 }
 
 #[test]
+fn heading_attributes_reach_html_and_toc() {
+    let result = MarkdownTransformer::from_options(&TransformOptions {
+        gfm: Some(true),
+        heading_attributes: Some(true),
+        ..Default::default()
+    })
+    .transform("## Custom identifier {#custom-heading-id .highlight}");
+
+    assert!(result.errors.is_empty(), "unexpected transform errors: {:?}", result.errors);
+    assert_eq!(
+        result.html,
+        "<h2 id=\"custom-heading-id\" class=\"highlight\">Custom identifier</h2>\n"
+    );
+    assert_eq!(result.toc[0].text, "Custom identifier");
+    assert_eq!(result.toc[0].slug, "custom-heading-id");
+}
+
+#[test]
 fn toc_slugs_are_unique_and_match_heading_ids() {
     let allocator = Allocator::new();
     let doc = Parser::new(

--- a/crates/ox_content_transform/src/transformer/toc.rs
+++ b/crates/ox_content_transform/src/transformer/toc.rs
@@ -14,7 +14,12 @@ pub(super) fn extract_toc(doc: &Document, max_depth: u8) -> Vec<TocEntry> {
             && heading.depth <= max_depth
         {
             let text = extract_heading_text(heading);
-            let slug = unique_slug(slugify_heading(&text), &mut slug_counts);
+            let slug = if let Some(id) = heading.id {
+                reserve_slug(id, &mut slug_counts);
+                id.to_string()
+            } else {
+                unique_slug(slugify_heading(&text), &mut slug_counts)
+            };
             push_nested_toc_entry(
                 &mut entries,
                 TocEntry { depth: heading.depth, text, slug, children: Vec::new() },
@@ -88,4 +93,8 @@ fn unique_slug(slug: String, counts: &mut FxHashMap<String, usize>) -> String {
     let unique = if *count == 0 { slug } else { format!("{slug}-{count}") };
     *count += 1;
     unique
+}
+
+fn reserve_slug(slug: &str, counts: &mut FxHashMap<String, usize>) {
+    *counts.entry(slug.to_string()).or_insert(0) += 1;
 }

--- a/crates/ox_content_transform/tests/pipeline_fuzz.rs
+++ b/crates/ox_content_transform/tests/pipeline_fuzz.rs
@@ -47,6 +47,7 @@ fn all_features() -> TransformOptions {
         superscript: Some(true),
         subscript: Some(true),
         smart_punctuation: Some(true),
+        heading_attributes: Some(true),
         frontmatter: Some(true),
         toc_max_depth: Some(6),
         convert_md_links: Some(true),

--- a/crates/ox_content_wasm/src/options.rs
+++ b/crates/ox_content_wasm/src/options.rs
@@ -24,6 +24,7 @@ pub struct WasmParserOptions {
     pub(crate) smart_punctuation: bool,
     pub(crate) math: bool,
     pub(crate) definition_lists: bool,
+    pub(crate) heading_attributes: bool,
     pub(crate) toc_max_depth: u8,
     pub(crate) autolink_urls: bool,
     pub(crate) autolink_patterns: Vec<String>,
@@ -59,6 +60,7 @@ impl WasmParserOptions {
             smart_punctuation: false,
             math: false,
             definition_lists: false,
+            heading_attributes: false,
             toc_max_depth: 3,
             autolink_urls: true,
             autolink_patterns: vec!["http://".to_string(), "https://".to_string()],
@@ -142,6 +144,12 @@ impl WasmParserOptions {
         self.definition_lists = value;
     }
 
+    /// Enables Pandoc-style `{#id .class}` heading attribute blocks.
+    #[wasm_bindgen(setter = headingAttributes)]
+    pub fn set_heading_attributes(&mut self, value: bool) {
+        self.heading_attributes = value;
+    }
+
     /// Sets the maximum heading depth included in inline TOCs.
     #[wasm_bindgen(setter = tocMaxDepth)]
     pub fn set_toc_max_depth(&mut self, value: u8) {
@@ -216,6 +224,7 @@ impl From<&WasmParserOptions> for ParserOptions {
         options.smart_punctuation = opts.smart_punctuation;
         options.math = opts.math;
         options.definition_lists = opts.definition_lists;
+        options.heading_attributes = opts.heading_attributes;
 
         options
     }

--- a/npm/unplugin-ox-content/src/index.ts
+++ b/npm/unplugin-ox-content/src/index.ts
@@ -101,6 +101,7 @@ function resolveOptions(options: OxContentOptions): ResolvedOptions {
     superscript: options.superscript ?? false,
     subscript: options.subscript ?? false,
     smartPunctuation: options.smartPunctuation ?? false,
+    headingAttributes: options.headingAttributes ?? false,
     highlight: options.highlight ?? false,
     codeAnnotations: resolveCodeAnnotationsOptions(options.codeAnnotations),
     mermaid: options.mermaid ?? false,

--- a/npm/unplugin-ox-content/src/mdast-options.ts
+++ b/npm/unplugin-ox-content/src/mdast-options.ts
@@ -15,6 +15,7 @@ export interface NapiBindings {
       smartPunctuation?: boolean;
       math?: boolean;
       definitionLists?: boolean;
+      headingAttributes?: boolean;
     },
   ) => Uint8Array;
 }
@@ -94,6 +95,12 @@ export interface OxContentMdastOptions {
    * @default false
    */
   definitionLists?: boolean;
+
+  /**
+   * Enable Pandoc-style heading attribute blocks.
+   * @default false
+   */
+  headingAttributes?: boolean;
 }
 
 const DEFAULT_MDAST_OPTIONS: Required<OxContentMdastOptions> = {
@@ -109,6 +116,7 @@ const DEFAULT_MDAST_OPTIONS: Required<OxContentMdastOptions> = {
   smartPunctuation: false,
   math: false,
   definitionLists: false,
+  headingAttributes: false,
 };
 
 export function resolveMdastOptions(
@@ -127,5 +135,6 @@ export function resolveMdastOptions(
     smartPunctuation: options.smartPunctuation ?? DEFAULT_MDAST_OPTIONS.smartPunctuation,
     math: options.math ?? DEFAULT_MDAST_OPTIONS.math,
     definitionLists: options.definitionLists ?? DEFAULT_MDAST_OPTIONS.definitionLists,
+    headingAttributes: options.headingAttributes ?? DEFAULT_MDAST_OPTIONS.headingAttributes,
   };
 }

--- a/npm/unplugin-ox-content/src/mdast-raw.test.ts
+++ b/npm/unplugin-ox-content/src/mdast-raw.test.ts
@@ -181,6 +181,79 @@ function createExtensionBuffer(): Uint8Array {
   return buffer;
 }
 
+function createHeadingAttributeBuffer(): Uint8Array {
+  const encoder = new TextEncoder();
+  const strings = ["Custom identifier", "custom-heading-id", "highlight wide"];
+  const stringOffsets = new Map<string, [number, number]>();
+  let stringBytesLength = 0;
+  for (const value of strings) {
+    const bytes = encoder.encode(value);
+    stringOffsets.set(value, [stringBytesLength, bytes.length]);
+    stringBytesLength += bytes.length;
+  }
+
+  const nodeCount = 3;
+  const childIndices = [0, 1];
+  const nodesOffset = HEADER_LEN;
+  const childIndicesOffset = nodesOffset + nodeCount * NODE_RECORD_LEN;
+  const stringsOffset = childIndicesOffset + childIndices.length * 4;
+  const buffer = new Uint8Array(stringsOffset + stringBytesLength);
+  const view = new DataView(buffer.buffer);
+  const stringRange = (value?: string): [number, number] =>
+    value === undefined ? [NONE_U32, 0] : stringOffsets.get(value)!;
+  const writeNode = (
+    index: number,
+    kind: number,
+    childStart = 0,
+    childLen = 0,
+    num0 = 0,
+    str0?: string,
+    str1?: string,
+  ) => {
+    const base = nodesOffset + index * NODE_RECORD_LEN;
+    const [str0Offset, str0Len] = stringRange(str0);
+    const [str1Offset, str1Len] = stringRange(str1);
+    view.setUint8(base, kind);
+    view.setUint8(base + 1, 0);
+    view.setUint16(base + 2, 0, true);
+    view.setUint32(base + 4, 0, true);
+    view.setUint32(base + 8, 0, true);
+    view.setUint32(base + 12, childStart, true);
+    view.setUint32(base + 16, childLen, true);
+    view.setUint32(base + 20, num0, true);
+    view.setUint32(base + 24, 0, true);
+    view.setUint32(base + 28, str0Offset, true);
+    view.setUint32(base + 32, str0Len, true);
+    view.setUint32(base + 36, str1Offset, true);
+    view.setUint32(base + 40, str1Len, true);
+    view.setUint32(base + 44, NONE_U32, true);
+    view.setUint32(base + 48, 0, true);
+    view.setUint32(base + 52, NONE_U32, true);
+    view.setUint32(base + 56, 0, true);
+  };
+
+  view.setUint32(0, MAGIC, true);
+  view.setUint32(4, VERSION, true);
+  view.setUint32(8, nodeCount, true);
+  view.setUint32(12, childIndices.length, true);
+  view.setUint32(16, 0, true);
+  view.setUint32(20, stringBytesLength, true);
+  view.setUint32(24, 2, true);
+
+  writeNode(0, 12, 0, 0, 0, "Custom identifier");
+  writeNode(1, 2, 0, 1, 2, "custom-heading-id", "highlight wide");
+  writeNode(2, 0, 1, 1);
+
+  childIndices.forEach((child, index) => {
+    view.setUint32(childIndicesOffset + index * 4, child, true);
+  });
+  for (const value of strings) {
+    const [offset] = stringOffsets.get(value)!;
+    buffer.set(encoder.encode(value), stringsOffset + offset);
+  }
+  return buffer;
+}
+
 describe("MDX raw mdast transfer", () => {
   it("decodes JSX, ESM, expressions, attributes, and children", () => {
     const root = deserializeMdastFromRaw(createMdxBuffer(), "");
@@ -247,5 +320,21 @@ describe("MDX raw mdast transfer", () => {
       ],
     });
     expect(root.children[1]).toMatchObject({ type: "math", value: "x^2" });
+  });
+
+  it("decodes heading attributes as hProperties", () => {
+    const root = deserializeMdastFromRaw(createHeadingAttributeBuffer(), "");
+
+    expect(root.children[0]).toMatchObject({
+      type: "heading",
+      depth: 2,
+      data: {
+        hProperties: {
+          id: "custom-heading-id",
+          className: ["highlight", "wide"],
+        },
+      },
+      children: [{ type: "text", value: "Custom identifier" }],
+    });
   });
 });

--- a/npm/unplugin-ox-content/src/mdast-raw.ts
+++ b/npm/unplugin-ox-content/src/mdast-raw.ts
@@ -192,8 +192,25 @@ export function deserializeMdastFromRaw(buffer: Uint8Array, source: string): Mda
         return { type: "root", children: children ?? [], position } as MdastRoot;
       case KIND_PARAGRAPH:
         return { type: "paragraph", children: children ?? [], position };
-      case KIND_HEADING:
-        return { type: "heading", depth: num0, children: children ?? [], position };
+      case KIND_HEADING: {
+        const node: MdastNode = {
+          type: "heading",
+          depth: num0,
+          children: children ?? [],
+          position,
+        };
+        if (str0 !== undefined || str1 !== undefined) {
+          const hProperties: Record<string, unknown> = {};
+          if (str0 !== undefined) {
+            hProperties.id = str0;
+          }
+          if (str1 !== undefined) {
+            hProperties.className = str1.split(/\s+/).filter(Boolean);
+          }
+          node.data = { hProperties };
+        }
+        return node;
+      }
       case KIND_THEMATIC_BREAK:
         return { type: "thematicBreak", position };
       case KIND_BLOCKQUOTE:
@@ -368,7 +385,7 @@ export function deserializeMdastFromRaw(buffer: Uint8Array, source: string): Mda
     throw new Error("[ox-content] Native parser returned an invalid mdast root.");
   }
 
-  return root;
+  return root as MdastRoot;
 }
 
 function parseMdxAttributes(value: string | undefined): unknown[] {

--- a/npm/unplugin-ox-content/src/mdast.ts
+++ b/npm/unplugin-ox-content/src/mdast.ts
@@ -64,6 +64,7 @@ export function parseMarkdownToMdast(
     smartPunctuation: resolvedOptions.smartPunctuation,
     math: resolvedOptions.math,
     definitionLists: resolvedOptions.definitionLists,
+    headingAttributes: resolvedOptions.headingAttributes,
   };
   const buffer = requireNapiMethod(napi.parseTransferRaw, "parseTransferRaw")(
     source,
@@ -108,7 +109,7 @@ export function extractTocFromMdast(root: MdastRoot, maxDepth: number): TocEntry
     headings.push({
       depth,
       text,
-      slug: slugify(text),
+      slug: explicitHeadingId(node) ?? slugify(text),
       children: [],
     });
   });
@@ -233,6 +234,21 @@ function collectMdastText(node: { value?: unknown; children?: unknown }): string
   }
 
   return node.children.map((child) => collectMdastText(child as { value?: unknown })).join("");
+}
+
+function explicitHeadingId(node: MdastNode): string | undefined {
+  const data = node.data;
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    return undefined;
+  }
+
+  const hProperties = (data as { hProperties?: unknown }).hProperties;
+  if (!hProperties || typeof hProperties !== "object" || Array.isArray(hProperties)) {
+    return undefined;
+  }
+
+  const id = (hProperties as { id?: unknown }).id;
+  return typeof id === "string" && id.length > 0 ? id : undefined;
 }
 
 function slugify(text: string): string {

--- a/npm/unplugin-ox-content/src/transform.ts
+++ b/npm/unplugin-ox-content/src/transform.ts
@@ -59,6 +59,7 @@ interface NapiBindings {
       smartPunctuation?: boolean;
       math?: boolean;
       definitionLists?: boolean;
+      headingAttributes?: boolean;
     },
   ) => Uint8Array;
   transformMdastRaw: (
@@ -74,6 +75,7 @@ interface NapiBindings {
       superscript?: boolean;
       subscript?: boolean;
       smartPunctuation?: boolean;
+      headingAttributes?: boolean;
       frontmatter?: boolean;
       tocMaxDepth?: number;
       codeAnnotations?: boolean;
@@ -98,6 +100,7 @@ interface NapiBindings {
       superscript?: boolean;
       subscript?: boolean;
       smartPunctuation?: boolean;
+      headingAttributes?: boolean;
       frontmatter?: boolean;
       tocMaxDepth?: number;
       codeAnnotations?: boolean;
@@ -261,12 +264,13 @@ function createNapiTransformOptions(
   superscript: boolean;
   subscript: boolean;
   smartPunctuation: boolean;
+  headingAttributes: boolean;
   frontmatter: boolean;
   tocMaxDepth: number;
   codeAnnotations: boolean;
   codeAnnotationMetaKey: string;
   math?: boolean;
-  definitionLists?: boolean;
+  definitionLists?: { enabled?: boolean };
 } {
   const codeAnnotations = options.codeAnnotations ?? {
     enabled: false,
@@ -285,6 +289,7 @@ function createNapiTransformOptions(
     superscript: options.superscript,
     subscript: options.subscript,
     smartPunctuation: options.smartPunctuation,
+    headingAttributes: options.headingAttributes,
     frontmatter: options.frontmatter,
     tocMaxDepth: options.tocMaxDepth,
     codeAnnotations: codeAnnotations.enabled,
@@ -792,6 +797,7 @@ function installUnifiedParser(
     superscript: options.superscript,
     subscript: options.subscript,
     smartPunctuation: options.smartPunctuation,
+    headingAttributes: options.headingAttributes,
     math: options.math,
     definitionLists: options.definitionLists,
   });

--- a/npm/unplugin-ox-content/src/types.ts
+++ b/npm/unplugin-ox-content/src/types.ts
@@ -50,6 +50,7 @@ export interface MdastNode {
   align?: Array<"left" | "center" | "right" | null>;
   identifier?: string;
   label?: string;
+  data?: Record<string, unknown>;
   [key: string]: unknown;
 }
 
@@ -376,6 +377,12 @@ export interface OxContentOptions {
   smartPunctuation?: boolean;
 
   /**
+   * Enable Pandoc-style heading attribute blocks.
+   * @default false
+   */
+  headingAttributes?: boolean;
+
+  /**
    * Enable syntax highlighting for code blocks.
    * @default false
    */
@@ -499,6 +506,7 @@ export interface ResolvedOptions {
   superscript: boolean;
   subscript: boolean;
   smartPunctuation: boolean;
+  headingAttributes: boolean;
   highlight: boolean;
   codeAnnotations: ResolvedCodeAnnotationsOptions;
   mermaid: boolean;

--- a/npm/vite-plugin-ox-content/src/collections.ts
+++ b/npm/vite-plugin-ox-content/src/collections.ts
@@ -36,6 +36,7 @@ type NativeTransformOptions = {
   superscript?: boolean;
   subscript?: boolean;
   smartPunctuation?: boolean;
+  headingAttributes?: boolean;
   autolinkUrls?: boolean;
   autolinkTargetBlank?: boolean;
   linkTargetBlank?: boolean;
@@ -62,9 +63,7 @@ type NativeTransformOptions = {
     terms?: Record<string, string>;
     firstUseOnly?: boolean;
   };
-  definitionLists?: {
-    enabled?: boolean;
-  };
+  definitionLists?: { enabled?: boolean };
   magicLinks?: {
     enabled?: boolean;
     aliases?: Record<string, { href: string; label?: string; image?: string }>;
@@ -238,6 +237,7 @@ function createNativeTransformOptions(options: ResolvedOptions): NativeTransform
     superscript: options.superscript ?? false,
     subscript: options.subscript ?? false,
     smartPunctuation: options.smartPunctuation ?? false,
+    headingAttributes: options.headingAttributes ?? false,
     autolinkUrls: options.autolinks,
     autolinkTargetBlank: options.autolinkTargetBlank ?? true,
     linkTargetBlank: options.linkTargetBlank ?? true,

--- a/npm/vite-plugin-ox-content/src/framework.ts
+++ b/npm/vite-plugin-ox-content/src/framework.ts
@@ -15,6 +15,7 @@ export interface FrameworkMarkdownOptions {
   superscript?: boolean;
   subscript?: boolean;
   smartPunctuation?: boolean;
+  headingAttributes?: boolean;
   linkTargetBlank?: boolean;
   sourceSpans?: boolean;
   toc: boolean;
@@ -85,6 +86,7 @@ export function createFrameworkMarkdownOptions(options: FrameworkMarkdownOptions
     superscript: options.superscript ?? false,
     subscript: options.subscript ?? false,
     smartPunctuation: options.smartPunctuation ?? false,
+    headingAttributes: options.headingAttributes ?? false,
     autolinkTargetBlank: true,
     linkTargetBlank: options.linkTargetBlank ?? true,
     sourceSpans: options.sourceSpans ?? false,

--- a/npm/vite-plugin-ox-content/src/resolve-options.ts
+++ b/npm/vite-plugin-ox-content/src/resolve-options.ts
@@ -76,6 +76,7 @@ export function resolveOptions(options: OxContentOptions): ResolvedOptions {
     superscript: options.superscript ?? false,
     subscript: options.subscript ?? false,
     smartPunctuation: options.smartPunctuation ?? false,
+    headingAttributes: options.headingAttributes ?? false,
     autolinkTargetBlank: options.autolinkTargetBlank ?? true,
     linkTargetBlank: options.linkTargetBlank ?? true,
     sourceSpans: options.sourceSpans ?? false,

--- a/npm/vite-plugin-ox-content/src/transform.ts
+++ b/npm/vite-plugin-ox-content/src/transform.ts
@@ -254,6 +254,7 @@ interface JsTransformOptions {
   superscript?: boolean;
   subscript?: boolean;
   smartPunctuation?: boolean;
+  headingAttributes?: boolean;
 
   /**
    * Linkify bare URLs while rendering.
@@ -714,6 +715,7 @@ export async function transformMarkdown(
     superscript: options.superscript ?? false,
     subscript: options.subscript ?? false,
     smartPunctuation: options.smartPunctuation ?? false,
+    headingAttributes: options.headingAttributes ?? false,
     autolinkUrls: options.autolinks,
     autolinkTargetBlank: options.autolinkTargetBlank ?? true,
     linkTargetBlank: options.linkTargetBlank ?? true,

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -1744,6 +1744,17 @@ export interface OxContentOptions {
   smartPunctuation?: boolean;
 
   /**
+   * Enable Pandoc-style heading attribute blocks.
+   *
+   * A trailing `{#id .class}` block on a heading becomes the rendered
+   * heading's id/classes and is excluded from visible heading text and slug
+   * generation.
+   *
+   * @default false
+   */
+  headingAttributes?: boolean;
+
+  /**
    * Add `target="_blank" rel="noopener noreferrer"` to linkified bare URLs.
    * @default true
    */
@@ -2329,6 +2340,7 @@ export interface ResolvedOptions {
   superscript: boolean;
   subscript: boolean;
   smartPunctuation: boolean;
+  headingAttributes: boolean;
   autolinkTargetBlank?: boolean;
   linkTargetBlank?: boolean;
   sourceSpans?: boolean;

--- a/npm/vite-plugin-ox-content/test/fixtures/docs-fixture.ts
+++ b/npm/vite-plugin-ox-content/test/fixtures/docs-fixture.ts
@@ -134,6 +134,7 @@ export function createDocsResolvedOptions(
     superscript: false,
     subscript: false,
     smartPunctuation: false,
+    headingAttributes: false,
     autolinkTargetBlank: true,
     linkTargetBlank: true,
     sourceSpans: false,


### PR DESCRIPTION
## Triage
- Valid feature request: pulldown-cmark-compatible heading attributes were lost during migration, and the literal `{#id .class}` text changed generated slugs.
- Scope kept to #1350: parser option, AST/mdast transfer, renderer, TOC, and JS option plumbing.

## Changes
- Adds `ParserOptions::heading_attributes` / `headingAttributes` (default off).
- Parses trailing heading `{#id .class}` blocks into heading id/classes for ATX and setext headings.
- Excludes parsed attributes from visible heading text, generated slugs, inline TOC, transform TOC, and mdast transfer text.
- Keeps unusable blocks such as `{}` and `{like this}` as prose.

## Validation
- `cargo test -p ox_content_parser --test edge_cases heading_attributes`
- `cargo test -p ox_content_parser --test edge_cases`
- `cargo test -p ox_content_renderer test_render_heading_attributes`
- `cargo test -p ox_content_renderer test_render_inline_toc_uses_heading_attribute_id`
- `cargo test -p ox_content_renderer`
- `cargo test -p ox_content_mdast`
- `cargo test -p ox_content_transform heading_attributes_reach_html_and_toc`
- `cargo test -p ox_content_transform`
- `cargo test -p ox_content_napi parser_options`
- `cargo test -p ox_content_wasm options`
- `vp exec --filter @ox-content/unplugin -- vp test src/mdast-raw.test.ts`
- `vp check --fix <changed TS files>`
- `cargo fmt --check`
- `node tools/scripts/check-file-lines.ts`
- `git diff --check`

Closes #1350

Co-authored-by: lambdalisue <546312+lambdalisue@users.noreply.github.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791371420&installation_model_id=422833&pr_number=1356&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1356&signature=748aef0ab0e50813d69e319dfcdbd9fba9478e1cc75aa43e393dc1e1d9a16675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in support for Pandoc-style heading attributes, such as `{`#custom-id` .highlight}`.
  * Custom heading IDs and classes are preserved in MDAST and raw MDAST output.
  * Rendered HTML headings now include configured IDs and classes, with support for escaped values.
  * Table of contents links now use explicit heading IDs when provided.
  * Added `headingAttributes` configuration across JavaScript, WASM, Vite, and transformation APIs; disabled by default.

* **Bug Fixes**
  * Improved preservation and handling of heading metadata across parsing and transformation pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->