### PR TITLE
fix(custom-host): canonicalize deleted watch paths

### DIFF
--- a/npm/vite-plugin-ox-content/src/custom-host-utils.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-utils.ts
@@ -159,8 +159,24 @@ export function canonicalFilePath(file: string): string {
   try {
     return fsSync.realpathSync.native(resolved);
   } catch {
-    return resolved;
+    return canonicalMissingPath(resolved);
   }
+}
+
+function canonicalMissingPath(file: string): string {
+  const root = path.parse(file).root;
+  let current = file;
+  const trailingSegments: string[] = [];
+  while (current !== root) {
+    trailingSegments.unshift(path.basename(current));
+    current = path.dirname(current);
+    try {
+      return path.join(fsSync.realpathSync.native(current), ...trailingSegments);
+    } catch {
+      // Keep walking until an existing ancestor can anchor the canonical path.
+    }
+  }
+  return file;
 }
 
 export function clearKeyDeps(


### PR DESCRIPTION
## Summary
- canonicalize deleted watcher paths through the nearest existing ancestor before dependency matching
- restores directory dependency invalidation for removed custom-host route files

## Validation
- vp exec --filter @ox-content/vite-plugin -- vp test src/custom-host-dev-lifecycle.test.ts
- vp exec --filter @ox-content/vite-plugin -- vp test src/custom-host-dev-cache.test.ts src/custom-host-dev-lifecycle.test.ts src/custom-host-collection-assets-context.test.ts src/custom-host-dev-feeds.test.ts src/custom-host-markdown.test.ts src/custom-host-ssr-stylesheets.test.ts src/custom-host-stylesheets.test.ts src/custom-host.test.ts
- vp run check:ts
- node tools/scripts/check-file-lines.ts

Follow-up for #1347.

Co-authored-by: ryoppippi <1560508+ryoppippi@users.noreply.github.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791372289&installation_model_id=422833&pr_number=1357&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1357&signature=55865c1f2a315b1d68cf3ae6af20d83ac34317e5e0f0ab52ba6836bf31729d9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved path resolution for files that do not yet exist.
  - Paths are now resolved more reliably when parts of their directory structure are available, reducing potential inconsistencies during content processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->