### PR TITLE
feat(parser): add opt-in wiki links

### DIFF
--- a/crates/ox_content_mdast/src/mdast/tests.rs
+++ b/crates/ox_content_mdast/src/mdast/tests.rs
@@ -45,6 +45,21 @@ fn serializes_heading_attributes_as_h_properties() {
 }
 
 #[test]
+fn serializes_wiki_links_as_links() {
+    let json = parse_json(
+        "[[README|Back to **index**]]",
+        ParserOptions { wiki_links: true, ..ParserOptions::default() },
+    );
+    let link = &json["children"][0]["children"][0];
+
+    assert_eq!(link["type"], "link");
+    assert_eq!(link["url"], "README");
+    assert_eq!(link["title"], serde_json::Value::Null);
+    assert_eq!(link["children"][0]["value"], "Back to ");
+    assert_eq!(link["children"][1]["type"], "strong");
+}
+
+#[test]
 fn serializes_mdx_nodes_and_attributes() {
     let json = parse_json(
         "import Alert from './Alert'\n\n<Alert title=\"Hi\" count={count} {...props}>Hello {name}</Alert>\n",

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -1981,6 +1981,12 @@ export interface JsParserOptions {
    * Default: `false`.
    */
   headingAttributes?: boolean
+  /**
+   * Enable Obsidian-style wiki links as link nodes.
+   *
+   * Default: `false`.
+   */
+  wikiLinks?: boolean
 }
 
 /** Opt-in parameterized Markdown partials. */

--- a/crates/ox_content_napi/src/parser_options.rs
+++ b/crates/ox_content_napi/src/parser_options.rs
@@ -92,6 +92,11 @@ pub struct JsParserOptions {
     ///
     /// Default: `false`.
     pub heading_attributes: Option<bool>,
+
+    /// Enable Obsidian-style wiki links as link nodes.
+    ///
+    /// Default: `false`.
+    pub wiki_links: Option<bool>,
 }
 
 impl From<JsParserOptions> for ParserOptions {
@@ -134,6 +139,9 @@ impl From<JsParserOptions> for ParserOptions {
         }
         if let Some(v) = opts.heading_attributes {
             options.heading_attributes = v;
+        }
+        if let Some(v) = opts.wiki_links {
+            options.wiki_links = v;
         }
 
         options
@@ -198,6 +206,7 @@ impl FromNapiValue for JsParserOptions {
             math: unsafe { read_flag(env, napi_val, c"math") }?,
             definition_lists: unsafe { read_flag(env, napi_val, c"definitionLists") }?,
             heading_attributes: unsafe { read_flag(env, napi_val, c"headingAttributes") }?,
+            wiki_links: unsafe { read_flag(env, napi_val, c"wikiLinks") }?,
         })
     }
 }
@@ -220,5 +229,20 @@ mod tests {
 
         let defaults = ParserOptions::from(JsParserOptions::default());
         assert!(!defaults.mdx);
+    }
+
+    #[test]
+    fn wiki_links_flag_maps_to_parser_options_without_gfm() {
+        let enabled = ParserOptions::from(JsParserOptions {
+            gfm: Some(true),
+            wiki_links: Some(true),
+            ..JsParserOptions::default()
+        });
+        assert!(enabled.gfm);
+        assert!(enabled.wiki_links);
+
+        let gfm =
+            ParserOptions::from(JsParserOptions { gfm: Some(true), ..JsParserOptions::default() });
+        assert!(!gfm.wiki_links);
     }
 }

--- a/crates/ox_content_napi/src/tests/mdx_bindings.rs
+++ b/crates/ox_content_napi/src/tests/mdx_bindings.rs
@@ -26,6 +26,20 @@ fn mdx_flag_reaches_parse_and_transform_bindings() {
 }
 
 #[test]
+fn wiki_links_flag_reaches_parse_binding() {
+    let parsed = crate::parse(
+        "[[README|Back to **index**]]\n".to_string(),
+        Some(crate::JsParserOptions { wiki_links: Some(true), ..Default::default() }),
+    );
+    assert!(parsed.errors.is_empty());
+    let ast: serde_json::Value = serde_json::from_str(&parsed.ast).unwrap();
+    let link = &ast["children"][0]["children"][0];
+    assert_eq!(link["type"], "link");
+    assert_eq!(link["url"], "README");
+    assert_eq!(link["children"][1]["type"], "strong");
+}
+
+#[test]
 fn mdx_transform_exports_module_metadata() {
     let transformed = crate::transform(
         concat!(

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -1985,6 +1985,12 @@ export interface JsParserOptions {
    * Default: `false`.
    */
   headingAttributes?: boolean
+  /**
+   * Enable Obsidian-style wiki links as link nodes.
+   *
+   * Default: `false`.
+   */
+  wikiLinks?: boolean
 }
 
 /** Opt-in parameterized Markdown partials. */

--- a/crates/ox_content_parser/src/parser/inline_link.rs
+++ b/crates/ox_content_parser/src/parser/inline_link.rs
@@ -44,6 +44,15 @@ impl<'a> Parser<'a> {
             return Ok(());
         }
 
+        if self.options.wiki_links
+            && bytes.get(link_start + 1) == Some(&b'[')
+            && let Some((link, end)) = self.try_parse_wiki_link(content, offset, link_start)?
+        {
+            children.push(link);
+            *pos = end;
+            return Ok(());
+        }
+
         *pos += 1;
         let text_start = *pos;
         *pos = Self::scan_balanced(content, *pos, b'[', b']');
@@ -145,6 +154,74 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
+    fn try_parse_wiki_link(
+        &self,
+        content: &'a str,
+        offset: usize,
+        link_start: usize,
+    ) -> ParseResult<Option<(Node<'a>, usize)>> {
+        let Some(close) = Self::scan_wiki_link_close(content.as_bytes(), link_start + 2) else {
+            return Ok(None);
+        };
+        let (inner, inner_offset) =
+            trim_with_offset(&content[link_start + 2..close], link_start + 2);
+        if inner.is_empty() {
+            return Ok(None);
+        }
+
+        let (target_part, label_part, label_part_offset) =
+            split_wiki_link_inner(inner, inner_offset);
+        let (target, target_offset) = trim_with_offset(target_part, inner_offset);
+        if target.is_empty() {
+            return Ok(None);
+        }
+
+        let (label, label_offset) = if let Some(label_part) = label_part {
+            let (label, label_offset) = trim_with_offset(label_part, label_part_offset);
+            if label.is_empty() { (target, target_offset) } else { (label, label_offset) }
+        } else {
+            (target, target_offset)
+        };
+
+        let mut label_nodes = None;
+        if memchr::memchr(b'[', label.as_bytes()).is_some()
+            && self.probe_link_text(label, offset + label_offset, &mut label_nodes)
+        {
+            return Ok(None);
+        }
+
+        let children = match label_nodes.take() {
+            Some(nodes) => nodes,
+            None => self.parse_inline(label, offset + label_offset)?,
+        };
+        Ok(Some((
+            Node::Link(self.allocator.boxed(Link {
+                url: target,
+                title: None,
+                children,
+                span: Span::new((offset + link_start) as u32, (offset + close + 2) as u32),
+            })),
+            close + 2,
+        )))
+    }
+
+    fn scan_wiki_link_close(bytes: &[u8], mut cursor: usize) -> Option<usize> {
+        while cursor + 1 < bytes.len() {
+            match bytes[cursor] {
+                b'\\' => {
+                    cursor += 2;
+                }
+                b'`' => {
+                    cursor = Self::closed_code_span_end(bytes, cursor)
+                        .unwrap_or_else(|| cursor.saturating_add(1));
+                }
+                b']' if bytes[cursor + 1] == b']' => return Some(cursor),
+                _ => cursor += 1,
+            }
+        }
+        None
+    }
+
     /// Reports whether `link_text` already parses to something containing a
     /// link, so the surrounding bracket cannot become one.
     ///
@@ -173,6 +250,20 @@ impl<'a> Parser<'a> {
         *nodes = Some(parsed);
         verdict
     }
+}
+
+fn split_wiki_link_inner(inner: &str, offset: usize) -> (&str, Option<&str>, usize) {
+    if let Some((target, label)) = inner.split_once('|') {
+        (target, Some(label), offset + target.len() + 1)
+    } else {
+        (inner, None, offset)
+    }
+}
+
+fn trim_with_offset(value: &str, offset: usize) -> (&str, usize) {
+    let trimmed_start = value.trim_start();
+    let leading = value.len() - trimmed_start.len();
+    (trimmed_start.trim_end(), offset + leading)
 }
 
 /// Does any node in the tree contain a link?

--- a/crates/ox_content_parser/src/parser/options.rs
+++ b/crates/ox_content_parser/src/parser/options.rs
@@ -72,6 +72,16 @@ pub struct ParserOptions {
     /// Default: `false`; not enabled by [`ParserOptions::gfm`].
     pub heading_attributes: bool,
 
+    /// Enable Obsidian-style wiki links as link nodes.
+    ///
+    /// When set, `[[target]]` and `[[target|label]]` parse as
+    /// [`ox_content_ast::Link`] with the raw target stored in
+    /// [`ox_content_ast::Link::url`]. The renderer then sees the construct
+    /// as a normal link and consumers can rewrite the target in link hooks.
+    ///
+    /// Default: `false`; not enabled by [`ParserOptions::gfm`].
+    pub wiki_links: bool,
+
     /// Recognize emphasis whose delimiters sit against East Asian punctuation.
     ///
     /// CommonMark decides whether a `*`/`_` run may open or close from the
@@ -133,6 +143,7 @@ impl Default for ParserOptions {
             math: false,
             definition_lists: false,
             heading_attributes: false,
+            wiki_links: false,
             cjk_emphasis: false,
             mdx: false,
             // Not `0`: an unbounded parse of hostile input overflows the
@@ -167,6 +178,7 @@ impl ParserOptions {
             math: false,
             definition_lists: false,
             heading_attributes: false,
+            wiki_links: false,
             // Not part of GFM: GitHub renders these runs per CommonMark too.
             cjk_emphasis: false,
             mdx: false,

--- a/crates/ox_content_parser/tests/edge_cases/inline.rs
+++ b/crates/ox_content_parser/tests/edge_cases/inline.rs
@@ -23,6 +23,87 @@ fn inline_link_handles_nested_parentheses() {
 }
 
 #[test]
+fn wiki_links_are_opt_in_and_use_raw_targets() {
+    let allocator = Allocator::new();
+    let doc = parse_with_options(
+        &allocator,
+        "See [[README]] and [[Guide Page#Install|the **guide**]].",
+        ParserOptions { wiki_links: true, ..ParserOptions::default() },
+    );
+
+    match &doc.children[0] {
+        Node::Paragraph(paragraph) => {
+            assert_eq!(first_text(&paragraph.children[1]), Some("README"));
+            match &paragraph.children[1] {
+                Node::Link(link) => {
+                    assert_eq!(link.url, "README");
+                    assert_eq!(link.title, None);
+                }
+                other => panic!("expected wiki link, got {other:?}"),
+            }
+            match &paragraph.children[3] {
+                Node::Link(link) => {
+                    assert_eq!(link.url, "Guide Page#Install");
+                    assert!(link.children.iter().any(|node| matches!(node, Node::Strong(_))));
+                }
+                other => panic!("expected labelled wiki link, got {other:?}"),
+            }
+        }
+        other => panic!("expected paragraph, got {other:?}"),
+    }
+}
+
+#[test]
+fn wiki_links_stay_literal_without_the_option_or_in_gfm() {
+    for options in [ParserOptions::default(), ParserOptions::gfm()] {
+        let allocator = Allocator::new();
+        let doc = parse_with_options(&allocator, "[[README]]", options);
+        match &doc.children[0] {
+            Node::Paragraph(paragraph) => {
+                assert!(paragraph.children.iter().all(|node| !matches!(node, Node::Link(_))));
+                assert_eq!(
+                    paragraph.children.iter().map(super::flatten_text).collect::<String>(),
+                    "[[README]]"
+                );
+            }
+            other => panic!("expected paragraph, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn wiki_links_reject_empty_targets_and_nested_links() {
+    let allocator = Allocator::new();
+    let options = ParserOptions { wiki_links: true, ..ParserOptions::default() };
+
+    let empty = parse_with_options(&allocator, "[[ |Label]]", options.clone());
+    match &empty.children[0] {
+        Node::Paragraph(paragraph) => {
+            assert!(paragraph.children.iter().all(|node| !matches!(node, Node::Link(_))));
+            assert_eq!(
+                paragraph.children.iter().map(super::flatten_text).collect::<String>(),
+                "[[ |Label]]"
+            );
+        }
+        other => panic!("expected paragraph, got {other:?}"),
+    }
+
+    let nested = parse_with_options(&allocator, "[outer [[README]]](https://example.com)", options);
+    match &nested.children[0] {
+        Node::Paragraph(paragraph) => {
+            assert!(matches!(&paragraph.children[0], Node::Text(text) if text.value == "["));
+            assert!(
+                paragraph
+                    .children
+                    .iter()
+                    .any(|node| matches!(node, Node::Link(link) if link.url == "README"))
+            );
+        }
+        other => panic!("expected paragraph, got {other:?}"),
+    }
+}
+
+#[test]
 fn inline_raw_html_is_preserved_as_html_node() {
     let allocator = Allocator::new();
     let doc = parse_with_options(

--- a/crates/ox_content_parser/tests/unclosed_brackets.rs
+++ b/crates/ox_content_parser/tests/unclosed_brackets.rs
@@ -55,15 +55,19 @@ fn repeat_to(unit: &str, bytes: usize) -> String {
 /// time instead of hanging it. Best of two, so one scheduling stall on a
 /// busy runner cannot fail the build.
 fn parse_within_budget(source: &str) -> Duration {
+    parse_within_budget_with_options(source, ParserOptions::gfm())
+}
+
+fn parse_within_budget_with_options(source: &str, options: ParserOptions) -> Duration {
     let mut best = BUDGET;
     for _ in 0..2 {
         let owned = source.to_string();
+        let options = options.clone();
         let (sender, receiver) = mpsc::channel();
         thread::spawn(move || {
             let started = Instant::now();
             let allocator = Allocator::new();
-            let parsed =
-                Parser::with_options(&allocator, &owned, ParserOptions::gfm()).parse().is_ok();
+            let parsed = Parser::with_options(&allocator, &owned, options).parse().is_ok();
             let _ = sender.send((parsed, started.elapsed()));
         });
         let (parsed, elapsed) = receiver
@@ -73,6 +77,23 @@ fn parse_within_budget(source: &str) -> Duration {
         best = best.min(elapsed);
     }
     best
+}
+
+#[test]
+fn wiki_links_do_not_scan_unclosed_double_brackets_quadratically() {
+    let options = ParserOptions { wiki_links: true, ..ParserOptions::default() };
+
+    for unit in ["[[", "[[ ", "[[Page|Label "] {
+        let small = parse_within_budget_with_options(&repeat_to(unit, 32 * 1024), options.clone());
+        let large = parse_within_budget_with_options(&repeat_to(unit, 128 * 1024), options.clone());
+
+        let ratio = large.as_secs_f64() / small.as_secs_f64().max(1e-9);
+        assert!(
+            ratio < 8.0,
+            "{unit:?}: 128 KiB took {large:?} against {small:?} for 32 KiB (x{ratio:.1}); \
+             linear is about x4, quadratic about x16"
+        );
+    }
 }
 
 #[test]

--- a/crates/ox_content_renderer/src/html/tests/inline_media.rs
+++ b/crates/ox_content_renderer/src/html/tests/inline_media.rs
@@ -23,6 +23,21 @@ fn test_render_strikethrough() {
 }
 
 #[test]
+fn test_render_wiki_link_parser_option() {
+    let allocator = Allocator::new();
+    let doc = Parser::with_options(
+        &allocator,
+        "See [[Guide Page#Install|the guide]]",
+        ox_content_parser::ParserOptions { wiki_links: true, ..Default::default() },
+    )
+    .parse()
+    .unwrap();
+    let mut renderer = HtmlRenderer::new();
+    let html = renderer.render(&doc);
+    assert_eq!(html, "<p>See <a href=\"Guide%20Page#Install\">the guide</a></p>\n");
+}
+
+#[test]
 fn test_render_hard_break() {
     let allocator = Allocator::new();
     let doc = Parser::new(&allocator, "line 1\\\nline 2").parse().unwrap();

--- a/crates/ox_content_wasm/src/options.rs
+++ b/crates/ox_content_wasm/src/options.rs
@@ -25,6 +25,7 @@ pub struct WasmParserOptions {
     pub(crate) math: bool,
     pub(crate) definition_lists: bool,
     pub(crate) heading_attributes: bool,
+    pub(crate) wiki_links: bool,
     pub(crate) toc_max_depth: u8,
     pub(crate) autolink_urls: bool,
     pub(crate) autolink_patterns: Vec<String>,
@@ -61,6 +62,7 @@ impl WasmParserOptions {
             math: false,
             definition_lists: false,
             heading_attributes: false,
+            wiki_links: false,
             toc_max_depth: 3,
             autolink_urls: true,
             autolink_patterns: vec!["http://".to_string(), "https://".to_string()],
@@ -150,6 +152,12 @@ impl WasmParserOptions {
         self.heading_attributes = value;
     }
 
+    /// Enables Obsidian-style wiki links as link nodes.
+    #[wasm_bindgen(setter = wikiLinks)]
+    pub fn set_wiki_links(&mut self, value: bool) {
+        self.wiki_links = value;
+    }
+
     /// Sets the maximum heading depth included in inline TOCs.
     #[wasm_bindgen(setter = tocMaxDepth)]
     pub fn set_toc_max_depth(&mut self, value: u8) {
@@ -225,6 +233,7 @@ impl From<&WasmParserOptions> for ParserOptions {
         options.math = opts.math;
         options.definition_lists = opts.definition_lists;
         options.heading_attributes = opts.heading_attributes;
+        options.wiki_links = opts.wiki_links;
 
         options
     }
@@ -244,5 +253,18 @@ mod tests {
         let mut enabled = WasmParserOptions::new();
         enabled.set_mdx(true);
         assert!(ParserOptions::from(&enabled).mdx);
+    }
+
+    #[test]
+    fn wiki_links_setter_maps_to_parser_options_without_gfm() {
+        let defaults = ParserOptions::from(&WasmParserOptions::new());
+        assert!(!defaults.wiki_links);
+
+        let mut enabled = WasmParserOptions::new();
+        enabled.set_gfm(true);
+        enabled.set_wiki_links(true);
+        let options = ParserOptions::from(&enabled);
+        assert!(options.gfm);
+        assert!(options.wiki_links);
     }
 }

--- a/npm/unplugin-ox-content/src/mdast-options.ts
+++ b/npm/unplugin-ox-content/src/mdast-options.ts
@@ -16,6 +16,7 @@ export interface NapiBindings {
       math?: boolean;
       definitionLists?: boolean;
       headingAttributes?: boolean;
+      wikiLinks?: boolean;
     },
   ) => Uint8Array;
 }
@@ -101,6 +102,12 @@ export interface OxContentMdastOptions {
    * @default false
    */
   headingAttributes?: boolean;
+
+  /**
+   * Enable Obsidian-style wiki links as link nodes.
+   * @default false
+   */
+  wikiLinks?: boolean;
 }
 
 const DEFAULT_MDAST_OPTIONS: Required<OxContentMdastOptions> = {
@@ -117,6 +124,7 @@ const DEFAULT_MDAST_OPTIONS: Required<OxContentMdastOptions> = {
   math: false,
   definitionLists: false,
   headingAttributes: false,
+  wikiLinks: false,
 };
 
 export function resolveMdastOptions(
@@ -136,5 +144,6 @@ export function resolveMdastOptions(
     math: options.math ?? DEFAULT_MDAST_OPTIONS.math,
     definitionLists: options.definitionLists ?? DEFAULT_MDAST_OPTIONS.definitionLists,
     headingAttributes: options.headingAttributes ?? DEFAULT_MDAST_OPTIONS.headingAttributes,
+    wikiLinks: options.wikiLinks ?? DEFAULT_MDAST_OPTIONS.wikiLinks,
   };
 }

--- a/npm/unplugin-ox-content/src/mdast.ts
+++ b/npm/unplugin-ox-content/src/mdast.ts
@@ -65,6 +65,7 @@ export function parseMarkdownToMdast(
     math: resolvedOptions.math,
     definitionLists: resolvedOptions.definitionLists,
     headingAttributes: resolvedOptions.headingAttributes,
+    wikiLinks: resolvedOptions.wikiLinks,
   };
   const buffer = requireNapiMethod(napi.parseTransferRaw, "parseTransferRaw")(
     source,


### PR DESCRIPTION
## Triage
- #1349 is valid as a feature request: `[[Page]]` / `[[Page|Label]]` currently remains literal and the current AST split makes a consumer-side render hook impractical.
- Scope is intentionally parser-option only and off by default, so CommonMark/GFM behavior stays unchanged unless consumers opt in.

## Changes
- Add `ParserOptions::wiki_links` and parse wiki links into normal link nodes with the raw target in `Link::url`.
- Thread `wikiLinks` through NAPI, WASM, and the unplugin mdast parser options.
- Add parser, mdast, renderer, binding, and unclosed-bracket performance regressions.

## Validation
- `cargo test -p ox_content_parser --test edge_cases wiki_links`
- `cargo test -p ox_content_parser --test unclosed_brackets`
- `cargo test -p ox_content_parser --test edge_cases`
- `cargo test -p ox_content_renderer`
- `cargo test -p ox_content_mdast`
- `cargo test -p ox_content_napi parser_options`
- `cargo test -p ox_content_napi wiki_links_flag_reaches_parse_binding`
- `cargo test -p ox_content_napi --lib tests::runtime_features::javascript_wrapper_and_declarations_cover_expected_exports`
- `cargo test -p ox_content_wasm options`
- `vp exec --filter @ox-content/unplugin -- vp test src/mdast-raw.test.ts`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `vp run check:ts` (0 errors; existing warnings only)
- `cargo fmt --check`
- `node tools/scripts/check-file-lines.ts`
- `git diff --check`

Closes #1349

Co-authored-by: lambdalisue <546312+lambdalisue@users.noreply.github.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791373565&installation_model_id=422833&pr_number=1358&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1358&signature=5e506daf5a5f8eaef4fc24819c862eadd0130a3eb011daa3f0aad1afa31fe2b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->