### PR TITLE
fix(renderer): run hooks in footnote definitions

### DIFF
--- a/crates/ox_content_renderer/src/html/renderer/footnotes.rs
+++ b/crates/ox_content_renderer/src/html/renderer/footnotes.rs
@@ -17,7 +17,7 @@ use ox_content_ast::{FootnoteDefinition, FootnoteReference, Span};
 
 use super::super::escape::write_escaped_into;
 use super::super::heading::slugify_heading_into;
-use super::HtmlRenderer;
+use super::{HtmlRenderHooks, HtmlRenderer};
 
 /// First `-N` tried when a slug repeats, matching the ids the scan produced.
 const FIRST_SUFFIX: usize = 2;
@@ -53,6 +53,19 @@ impl HtmlRenderer {
             return;
         }
         self.render_legacy_footnote_definition(footnote_def);
+    }
+
+    pub(in crate::html::renderer) fn render_footnote_definition_with_hooks<H: HtmlRenderHooks>(
+        &mut self,
+        footnote_def: &FootnoteDefinition<'_>,
+        hooks: &mut H,
+    ) {
+        crate::profile_span!("renderer::visit_footnote_def");
+        if self.options.semantic_footnotes {
+            self.collect_semantic_footnote_definition_with_hooks(footnote_def, hooks);
+            return;
+        }
+        self.render_legacy_footnote_definition_with_hooks(footnote_def, hooks);
     }
 
     pub(in crate::html::renderer) fn finish_semantic_footnotes(&mut self) {
@@ -130,6 +143,24 @@ impl HtmlRenderer {
         self.write("\">↩</a>\n</div>\n");
     }
 
+    fn render_legacy_footnote_definition_with_hooks<H: HtmlRenderHooks>(
+        &mut self,
+        footnote_def: &FootnoteDefinition<'_>,
+        hooks: &mut H,
+    ) {
+        self.write("<div id=\"fn-");
+        self.write_escaped(footnote_def.identifier);
+        self.write("\" class=\"footnote\"");
+        self.write_source_span_attr(footnote_def.span);
+        self.write(">\n");
+        for child in &footnote_def.children {
+            self.render_node_with_hooks(child, hooks);
+        }
+        self.write("<a href=\"#fnref-");
+        self.write_escaped(footnote_def.identifier);
+        self.write("\">↩</a>\n</div>\n");
+    }
+
     fn render_semantic_footnote_reference(&mut self, identifier: &str) {
         let index = self.footnote_index_of(identifier);
         let occurrence = {
@@ -159,6 +190,23 @@ impl HtmlRenderer {
         let start = self.output.len();
         for child in &footnote_def.children {
             self.render_node(child);
+        }
+        self.footnote_records[index].body_html = Some(self.output.split_off(start));
+        self.footnote_records[index].span = Some(footnote_def.span);
+    }
+
+    fn collect_semantic_footnote_definition_with_hooks<H: HtmlRenderHooks>(
+        &mut self,
+        footnote_def: &FootnoteDefinition<'_>,
+        hooks: &mut H,
+    ) {
+        let index = self.footnote_index_of(footnote_def.identifier);
+        if self.footnote_records[index].body_html.is_some() {
+            return;
+        }
+        let start = self.output.len();
+        for child in &footnote_def.children {
+            self.render_node_with_hooks(child, hooks);
         }
         self.footnote_records[index].body_html = Some(self.output.split_off(start));
         self.footnote_records[index].span = Some(footnote_def.span);

--- a/crates/ox_content_renderer/src/html/renderer/hooks.rs
+++ b/crates/ox_content_renderer/src/html/renderer/hooks.rs
@@ -231,7 +231,9 @@ impl HtmlRenderer {
             Node::Subscript(node) => self.render_subscript_with_hooks(node, hooks),
             Node::FootnoteReference(node) => self.render_footnote_reference(node),
             Node::Definition(_) => {}
-            Node::FootnoteDefinition(node) => self.render_footnote_definition(node),
+            Node::FootnoteDefinition(node) => {
+                self.render_footnote_definition_with_hooks(node, hooks);
+            }
             Node::MdxJsxFlowElement(node) => {
                 self.render_mdx_jsx_flow_element_with_hooks(node, hooks);
             }

--- a/crates/ox_content_renderer/tests/edge_render_hooks.rs
+++ b/crates/ox_content_renderer/tests/edge_render_hooks.rs
@@ -2,7 +2,8 @@ use ox_content_allocator::Allocator;
 use ox_content_ast::Node;
 use ox_content_parser::{Parser, ParserOptions};
 use ox_content_renderer::{
-    HtmlRenderContext, HtmlRenderControl, HtmlRenderHooks, HtmlRenderer, NoHtmlRenderHooks,
+    HtmlRenderContext, HtmlRenderControl, HtmlRenderHooks, HtmlRenderer, HtmlRendererOptions,
+    NoHtmlRenderHooks,
 };
 
 #[test]
@@ -181,6 +182,85 @@ fn render_hooks_reach_named_mdx_child_nodes() {
         html,
         "<div class=\"ox-island\" data-ox-island=\"Widget\"><section>child</section></div>\n"
     );
+}
+
+#[test]
+fn render_hooks_reach_inline_math_inside_footnote_definitions() {
+    struct Hooks;
+
+    impl HtmlRenderHooks for Hooks {
+        fn render_node(
+            &mut self,
+            node: &Node<'_>,
+            cx: &mut HtmlRenderContext<'_>,
+        ) -> HtmlRenderControl {
+            match node {
+                Node::InlineMath(math) => {
+                    cx.write("<span class=\"my-math\">");
+                    cx.write_escaped(math.value);
+                    cx.write("</span>");
+                    HtmlRenderControl::Handled
+                }
+                _ => HtmlRenderControl::Default,
+            }
+        }
+    }
+
+    let allocator = Allocator::new();
+    let document = Parser::with_options(
+        &allocator,
+        "text[^1]\n\n[^1]: footnote $x^2$ here\n",
+        ParserOptions { math: true, ..ParserOptions::gfm() },
+    )
+    .parse()
+    .unwrap();
+    let html = HtmlRenderer::new().render_with_hooks(&document, &mut Hooks);
+
+    assert!(html.contains("<p>footnote <span class=\"my-math\">x^2</span> here</p>"), "{html}");
+    assert!(!html.contains("ox-math"), "{html}");
+}
+
+#[test]
+fn render_hooks_reach_nested_blocks_inside_semantic_footnote_definitions() {
+    struct Hooks;
+
+    impl HtmlRenderHooks for Hooks {
+        fn render_node(
+            &mut self,
+            node: &Node<'_>,
+            cx: &mut HtmlRenderContext<'_>,
+        ) -> HtmlRenderControl {
+            match node {
+                Node::Strong(strong) => {
+                    cx.write("<mark>");
+                    cx.render_nodes(&strong.children, self);
+                    cx.write("</mark>");
+                    HtmlRenderControl::Handled
+                }
+                _ => HtmlRenderControl::Default,
+            }
+        }
+    }
+
+    let allocator = Allocator::new();
+    let document = Parser::with_options(
+        &allocator,
+        "note[^n]\n\n[^n]: > nested **value**\n",
+        ParserOptions::gfm(),
+    )
+    .parse()
+    .unwrap();
+    let html = HtmlRenderer::with_options(HtmlRendererOptions {
+        semantic_footnotes: true,
+        ..HtmlRendererOptions::default()
+    })
+    .render_with_hooks(&document, &mut Hooks);
+
+    assert!(
+        html.contains("<blockquote>\n<p>nested <mark>value</mark></p>\n</blockquote>"),
+        "{html}"
+    );
+    assert!(!html.contains("<strong>value</strong>"), "{html}");
 }
 
 #[test]


### PR DESCRIPTION
Summary
- route footnote definition children through hook-aware rendering in render_with_hooks
- cover inline math in legacy footnotes and nested block content in semantic footnotes

Tests
- cargo test -p ox_content_renderer --test edge_render_hooks
- cargo test -p ox_content_renderer --test edge_semantic_footnotes
- cargo fmt --check -p ox_content_renderer
- CI=1 node tools/scripts/check-file-lines.ts --base origin/main
- git diff --check origin/main...HEAD

Closes #1362

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791418770&installation_model_id=422833&pr_number=1364&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1364&signature=3c4d76b4e786b0d8d445f0670359ec00e9ad166fcdf4348162746c48f1e28361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rendering hooks now apply to content inside footnote definitions, including inline math and nested blocks.
  * Hook behavior works consistently for both semantic and legacy footnote rendering.

* **Tests**
  * Added coverage validating custom rendering behavior within footnotes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->