### PR TITLE
fix(parser): preserve table escaped pipe spans

### DIFF
--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -32,6 +32,7 @@ mod prepass;
 mod reference;
 mod spans;
 mod table;
+mod table_cell_source;
 
 #[cfg(test)]
 mod tests;

--- a/crates/ox_content_parser/src/parser/table.rs
+++ b/crates/ox_content_parser/src/parser/table.rs
@@ -4,6 +4,9 @@ use ox_content_ast::{AlignKind, Node, Span, Table, TableCell, TableRow};
 
 use super::Parser;
 use super::line_scan::{line_end, next_line_start};
+use super::table_cell_source::{
+    is_escaped_table_pipe, remap_table_cell_inline_spans, unescape_table_pipes,
+};
 use crate::error::ParseResult;
 #[allow(unused_imports)]
 use crate::{profile_span, profile_span_detail};
@@ -120,8 +123,17 @@ impl<'a> Parser<'a> {
         for (cell_content, cell_start, cell_end) in
             Self::table_row_cells_with_offsets(line).take(column_count)
         {
-            let cell_content = self.unescape_table_pipes(cell_content);
-            let cell_children = self.parse_inline_block(cell_content, line_start + cell_start)?;
+            let cell_content = unescape_table_pipes(self.allocator, cell_content);
+            let cell_children = if let Some(source_offsets) = &cell_content.source_offsets {
+                let mut children = self.parse_inline_block(cell_content.content, 0)?;
+                let source_offset = (line_start + cell_start) as u32;
+                for child in &mut children {
+                    remap_table_cell_inline_spans(child, source_offset, source_offsets);
+                }
+                children
+            } else {
+                self.parse_inline_block(cell_content.content, line_start + cell_start)?
+            };
             cells.push(TableCell {
                 children: cell_children,
                 span: Span::new((line_start + cell_start) as u32, (line_start + cell_end) as u32),
@@ -134,38 +146,6 @@ impl<'a> Parser<'a> {
             });
         }
         Ok(TableRow { children: cells, span: Span::new(line_start as u32, line_end as u32) })
-    }
-
-    /// Removes the table-level escape from pipes before inline parsing.
-    ///
-    /// GFM treats `\|` as a literal pipe even inside code spans. Normal inline
-    /// parsing already handles the escape in prose, but code spans preserve
-    /// backslashes, so the table parser must consume it first.
-    fn unescape_table_pipes(&self, content: &'a str) -> &'a str {
-        let bytes = content.as_bytes();
-        if !bytes
-            .iter()
-            .enumerate()
-            .any(|(index, &byte)| byte == b'|' && is_escaped_table_pipe(bytes, index))
-        {
-            return content;
-        }
-
-        let mut unescaped =
-            ox_content_allocator::String::with_capacity_in(content.len(), self.allocator.bump());
-        let mut copied_through = 0;
-        let mut search_start = 0;
-        while let Some(relative) = memchr(b'|', &bytes[search_start..]) {
-            let pipe = search_start + relative;
-            if is_escaped_table_pipe(bytes, pipe) {
-                unescaped.push_str(&content[copied_through..pipe - 1]);
-                unescaped.push('|');
-                copied_through = pipe + 1;
-            }
-            search_start = pipe + 1;
-        }
-        unescaped.push_str(&content[copied_through..]);
-        unescaped.into_bump_str()
     }
 
     /// Iterates table row cells from a line.
@@ -229,10 +209,6 @@ fn trim_cell(cell: &str, offset: usize) -> (&str, usize, usize) {
     let start = offset + cell.len() - cell.trim_start().len();
     let end = start + trimmed.len();
     (trimmed, start, end)
-}
-
-fn is_escaped_table_pipe(bytes: &[u8], pipe: usize) -> bool {
-    bytes[..pipe].iter().rev().take_while(|&&byte| byte == b'\\').count() % 2 == 1
 }
 
 fn delimiter_alignment(cell: &str) -> Option<AlignKind> {

--- a/crates/ox_content_parser/src/parser/table_cell_source.rs
+++ b/crates/ox_content_parser/src/parser/table_cell_source.rs
@@ -1,0 +1,197 @@
+use memchr::memchr;
+use ox_content_allocator::{Allocator, Vec};
+use ox_content_ast::{MdxJsxAttributeEntry, MdxJsxAttributeValue, Node, Span};
+
+pub(super) struct TableCellContent<'a> {
+    pub content: &'a str,
+    pub source_offsets: Option<Vec<'a, u32>>,
+}
+
+/// Removes the table-level escape from pipes before inline parsing.
+///
+/// GFM treats `\|` as a literal pipe even inside code spans. Normal inline
+/// parsing already handles the escape in prose, but code spans preserve
+/// backslashes, so the table parser must consume it first.
+pub(super) fn unescape_table_pipes<'a>(
+    allocator: &'a Allocator,
+    content: &'a str,
+) -> TableCellContent<'a> {
+    let bytes = content.as_bytes();
+    if !bytes
+        .iter()
+        .enumerate()
+        .any(|(index, &byte)| byte == b'|' && is_escaped_table_pipe(bytes, index))
+    {
+        return TableCellContent { content, source_offsets: None };
+    }
+
+    let mut unescaped =
+        ox_content_allocator::String::with_capacity_in(content.len(), allocator.bump());
+    let mut source_offsets: Vec<'a, u32> = allocator.new_vec();
+    let mut copied_through = 0;
+    let mut search_start = 0;
+    while let Some(relative) = memchr(b'|', &bytes[search_start..]) {
+        let pipe = search_start + relative;
+        if is_escaped_table_pipe(bytes, pipe) {
+            push_mapped_table_cell_slice(
+                content,
+                copied_through,
+                pipe - 1,
+                &mut unescaped,
+                &mut source_offsets,
+            );
+            unescaped.push('|');
+            source_offsets.push((pipe + 1) as u32);
+            copied_through = pipe + 1;
+        }
+        search_start = pipe + 1;
+    }
+    push_mapped_table_cell_slice(
+        content,
+        copied_through,
+        content.len(),
+        &mut unescaped,
+        &mut source_offsets,
+    );
+    TableCellContent { content: unescaped.into_bump_str(), source_offsets: Some(source_offsets) }
+}
+
+fn push_mapped_table_cell_slice(
+    source: &str,
+    start: usize,
+    end: usize,
+    unescaped: &mut ox_content_allocator::String<'_>,
+    source_offsets: &mut Vec<'_, u32>,
+) {
+    if start >= end {
+        if source_offsets.is_empty() {
+            source_offsets.push(start as u32);
+        }
+        return;
+    }
+
+    if source_offsets.is_empty() {
+        source_offsets.push(start as u32);
+    }
+    unescaped.push_str(&source[start..end]);
+
+    let mut source_offset = start + 1;
+    while source_offsets.len() < unescaped.len() + 1 {
+        source_offsets.push(source_offset.min(end) as u32);
+        source_offset += 1;
+    }
+}
+
+pub(super) fn remap_table_cell_inline_spans(
+    node: &mut Node<'_>,
+    source_offset: u32,
+    offsets: &[u32],
+) {
+    match node {
+        Node::Text(node) => remap_table_cell_span(&mut node.span, source_offset, offsets),
+        Node::Emphasis(node) => {
+            remap_table_cell_span(&mut node.span, source_offset, offsets);
+            for child in &mut node.children {
+                remap_table_cell_inline_spans(child, source_offset, offsets);
+            }
+        }
+        Node::Strong(node) => {
+            remap_table_cell_span(&mut node.span, source_offset, offsets);
+            for child in &mut node.children {
+                remap_table_cell_inline_spans(child, source_offset, offsets);
+            }
+        }
+        Node::InlineCode(node) => remap_table_cell_span(&mut node.span, source_offset, offsets),
+        Node::InlineMath(node) => remap_table_cell_span(&mut node.span, source_offset, offsets),
+        Node::Break(node) => remap_table_cell_span(&mut node.span, source_offset, offsets),
+        Node::Link(node) => {
+            remap_table_cell_span(&mut node.span, source_offset, offsets);
+            for child in &mut node.children {
+                remap_table_cell_inline_spans(child, source_offset, offsets);
+            }
+        }
+        Node::Image(node) => remap_table_cell_span(&mut node.span, source_offset, offsets),
+        Node::Delete(node) => {
+            remap_table_cell_span(&mut node.span, source_offset, offsets);
+            for child in &mut node.children {
+                remap_table_cell_inline_spans(child, source_offset, offsets);
+            }
+        }
+        Node::Superscript(node) => {
+            remap_table_cell_span(&mut node.span, source_offset, offsets);
+            for child in &mut node.children {
+                remap_table_cell_inline_spans(child, source_offset, offsets);
+            }
+        }
+        Node::Subscript(node) => {
+            remap_table_cell_span(&mut node.span, source_offset, offsets);
+            for child in &mut node.children {
+                remap_table_cell_inline_spans(child, source_offset, offsets);
+            }
+        }
+        Node::FootnoteReference(node) => {
+            remap_table_cell_span(&mut node.span, source_offset, offsets);
+        }
+        Node::Html(node) => remap_table_cell_span(&mut node.span, source_offset, offsets),
+        Node::MdxJsxTextElement(node) => {
+            remap_table_cell_span(&mut node.span, source_offset, offsets);
+            for attribute in &mut node.attributes {
+                remap_table_cell_mdx_attribute_entry(attribute, source_offset, offsets);
+            }
+            for child in &mut node.children {
+                remap_table_cell_inline_spans(child, source_offset, offsets);
+            }
+        }
+        Node::MdxTextExpression(node) => {
+            remap_table_cell_span(&mut node.span, source_offset, offsets);
+        }
+        Node::Paragraph(_)
+        | Node::Heading(_)
+        | Node::ThematicBreak(_)
+        | Node::BlockQuote(_)
+        | Node::List(_)
+        | Node::ListItem(_)
+        | Node::CodeBlock(_)
+        | Node::MathBlock(_)
+        | Node::Table(_)
+        | Node::DefinitionList(_)
+        | Node::DefinitionListTerm(_)
+        | Node::DefinitionListDefinition(_)
+        | Node::Definition(_)
+        | Node::FootnoteDefinition(_)
+        | Node::MdxJsxFlowElement(_)
+        | Node::MdxjsEsm(_)
+        | Node::MdxFlowExpression(_) => {}
+    }
+}
+
+fn remap_table_cell_mdx_attribute_entry(
+    entry: &mut MdxJsxAttributeEntry<'_>,
+    source_offset: u32,
+    offsets: &[u32],
+) {
+    match entry {
+        MdxJsxAttributeEntry::Attribute(attribute) => {
+            remap_table_cell_span(&mut attribute.span, source_offset, offsets);
+            if let Some(MdxJsxAttributeValue::Expression(expr)) = &mut attribute.value {
+                remap_table_cell_span(&mut expr.span, source_offset, offsets);
+            }
+        }
+        MdxJsxAttributeEntry::Expression(expr) => {
+            remap_table_cell_span(&mut expr.span, source_offset, offsets);
+        }
+    }
+}
+
+fn remap_table_cell_span(span: &mut Span, source_offset: u32, offsets: &[u32]) {
+    span.start = source_offset + table_cell_boundary_offset(span.start as usize, offsets);
+    span.end = source_offset + table_cell_boundary_offset(span.end as usize, offsets);
+}
+
+fn table_cell_boundary_offset(index: usize, offsets: &[u32]) -> u32 {
+    offsets.get(index).copied().unwrap_or_else(|| offsets.last().copied().unwrap_or_default())
+}
+
+pub(super) fn is_escaped_table_pipe(bytes: &[u8], pipe: usize) -> bool {
+    bytes[..pipe].iter().rev().take_while(|&&byte| byte == b'\\').count() % 2 == 1
+}

--- a/crates/ox_content_parser/tests/edge_cases/spans.rs
+++ b/crates/ox_content_parser/tests/edge_cases/spans.rs
@@ -119,6 +119,71 @@ fn table_rows_cells_and_inline_children_index_source() {
     assert_all_spans_index_source(source, &doc.children);
 }
 
+#[test]
+fn table_inline_strong_spans_after_escaped_pipes_index_document_source() {
+    for (source, text_value, text_source, cell_source) in [
+        ("| a **bold** |\n| --- |\n", "a ", "a ", "a **bold**"),
+        ("| a\\|b **bold** |\n| --- |\n", "a|b ", "a\\|b ", "a\\|b **bold**"),
+        ("| a\\|b\\|c **bold** |\n| --- |\n", "a|b|c ", "a\\|b\\|c ", "a\\|b\\|c **bold**"),
+    ] {
+        let allocator = Allocator::new();
+        let doc = parse_with_options(&allocator, source, ParserOptions::gfm());
+
+        let Node::Table(table) = &doc.children[0] else {
+            panic!("expected table, got {:?}", doc.children[0]);
+        };
+        let cell = &table.children[0].children[0];
+        let cell_start = source.find(cell_source).expect("cell source") as u32;
+        assert_eq!(cell.span, Span::new(cell_start, cell_start + cell_source.len() as u32));
+        assert_eq!(cell.span.source_text(source), cell_source);
+
+        let Node::Text(text) = &cell.children[0] else {
+            panic!("expected leading text, got {:?}", cell.children[0]);
+        };
+        let text_start = source.find(text_source).expect("text source") as u32;
+        assert_eq!(text.value, text_value);
+        assert_eq!(text.span, Span::new(text_start, text_start + text_source.len() as u32));
+        assert_eq!(text.span.source_text(source), text_source);
+
+        let Node::Strong(strong) = &cell.children[1] else {
+            panic!("expected strong, got {:?}", cell.children[1]);
+        };
+        let strong_start = source.find("**bold**").expect("strong source") as u32;
+        assert_eq!(strong.span, Span::new(strong_start, strong_start + 8));
+        assert_eq!(strong.span.source_text(source), "**bold**");
+        assert_all_spans_index_source(source, &doc.children);
+    }
+}
+
+#[test]
+fn table_wiki_link_span_after_escaped_pipes_indexes_document_source() {
+    let allocator = Allocator::new();
+    let source = "| a\\|b\\|c [[Guide\\|Label]] |\n| --- |\n";
+    let options = ParserOptions { wiki_links: true, ..ParserOptions::gfm() };
+    let doc = parse_with_options(&allocator, source, options);
+
+    let Node::Table(table) = &doc.children[0] else {
+        panic!("expected table, got {:?}", doc.children[0]);
+    };
+    let cell = &table.children[0].children[0];
+    let Node::Link(link) = &cell.children[1] else {
+        panic!("expected wiki link, got {:?}", cell.children[1]);
+    };
+
+    assert_eq!(link.url, "Guide");
+    let link_source = "[[Guide\\|Label]]";
+    let link_start = source.find(link_source).expect("link source") as u32;
+    assert_eq!(link.span, Span::new(link_start, link_start + link_source.len() as u32));
+    assert_eq!(link.span.source_text(source), link_source);
+
+    let Node::Text(label) = &link.children[0] else {
+        panic!("expected wiki link label, got {:?}", link.children[0]);
+    };
+    assert_eq!(label.value, "Label");
+    assert_eq!(label.span.source_text(source), "Label");
+    assert_all_spans_index_source(source, &doc.children);
+}
+
 fn assert_all_spans_index_source(source: &str, nodes: &[Node<'_>]) {
     for node in nodes {
         assert_node_span_indexes_source(source, node);


### PR DESCRIPTION
## Summary
- Preserve source-indexed inline spans after table-level escaped pipes are unescaped in GFM table cells.
- Keep table cell spans and escaped-pipe rendering behavior unchanged.
- Add focused regression coverage for zero, one, and two escaped pipes before inline strong nodes, plus a wiki-link-style link span case.

## Tests
- cargo fmt --all --check
- cargo test -p ox_content_parser --test edge_cases escaped_pipes
- cargo test -p ox_content_parser --test edge_cases table_
- cargo test -p ox_content_parser test_parse_table_preserves_escaped_pipes
- cargo test -p ox_content_renderer --test snapshot_tables_html html_table_preserves_escaped_pipes
- cargo test -p ox_content_parser

Closes #1363

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791419275&installation_model_id=422833&pr_number=1365&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1365&signature=18ce11e51ed980b5de4889972ffc70157a3fc60b3f84b8b1f4b0433a66b6e251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source-position tracking for formatted text and links inside table cells containing escaped pipe characters.
  * Corrected inline element spans so they accurately correspond to their locations in the original document source.
  * Preserved expected text values while removing escape characters from rendered table-cell content.

* **Tests**
  * Added coverage for bold text and wiki links with escaped pipes in table cells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->