### PR TITLE
fix(custom-host): repair SSR stylesheet and route invalidation

### DIFF
--- a/npm/vite-plugin-ox-content/src/custom-host-dev-eager-glob.test.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-dev-eager-glob.test.ts
@@ -1,0 +1,172 @@
+import * as fs from "node:fs/promises";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { createServer, type InlineConfig, type ViteDevServer } from "vite";
+import { oxContentCustomHost, type OxContentCustomHostOptions } from ".";
+
+const tempDirs: string[] = [];
+const activeServers: ViteDevServer[] = [];
+const activeListeners: http.Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(activeListeners.splice(0).map((server) => closeHttpServer(server)));
+  await Promise.all(activeServers.splice(0).map((server) => server.close().catch(() => {})));
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("custom host dev eager-glob route catalogues", () => {
+  it("refreshes eager-glob routes after watched module add and remove", async () => {
+    const root = await createEagerGlobRouteProject();
+    const server = await trackDevServer(
+      createServer(eagerGlobRouteViteConfig(root, { reloadDebounceMs: 1 })),
+    );
+    const listener = await listen(server);
+
+    expect(await text(listener.port, "/one/")).toMatchObject({ status: 200, text: "one" });
+    expect((await text(listener.port, "/adoption-watch-probe/")).status).toBe(404);
+
+    const probe = path.join(root, "src", "pages", "adoption-watch-probe", "index.ts");
+    await fs.mkdir(path.dirname(probe), { recursive: true });
+    await fs.writeFile(probe, pageRouteSource("/adoption-watch-probe/", "route-watch-3.1"));
+    server.watcher.emit("add", probe);
+    await wait(120);
+
+    expect(await text(listener.port, "/adoption-watch-probe/")).toMatchObject({
+      status: 200,
+      text: "route-watch-3.1",
+    });
+
+    await fs.rm(probe);
+    server.watcher.emit("unlink", probe);
+    await wait(120);
+
+    expect((await text(listener.port, "/adoption-watch-probe/")).status).toBe(404);
+  });
+});
+
+async function createEagerGlobRouteProject(): Promise<string> {
+  const root = await createBaseProject("ox-custom-host-eager-glob-routes-");
+  await fs.mkdir(path.join(root, "src", "pages", "one"), { recursive: true });
+  await fs.mkdir(path.join(root, "src", "utils"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, "src", "pages", "one", "index.ts"),
+    pageRouteSource("/one/", "one"),
+  );
+  await fs.writeFile(path.join(root, "src", "utils", "routes.ts"), eagerGlobRoutesSource());
+  await fs.writeFile(path.join(root, "src", "host.ts"), eagerGlobHostSource());
+  return root;
+}
+
+async function createBaseProject(prefix: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(root);
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.mkdir(path.join(root, "content"), { recursive: true });
+  await fs.writeFile(path.join(root, "package.json"), '{"type":"module"}\n');
+  await fs.writeFile(path.join(root, "src", "main.ts"), "export {};\n");
+  return root;
+}
+
+function eagerGlobRouteViteConfig(
+  root: string,
+  dev: { reloadDebounceMs?: number } = {},
+): InlineConfig {
+  return customHostConfig(root, {
+    dev: {
+      ...dev,
+      routeDependencies: [
+        { path: "src/pages", kind: "directory" },
+        { path: "src/utils", kind: "directory" },
+      ],
+    },
+  });
+}
+
+function customHostConfig(root: string, input: Partial<OxContentCustomHostOptions>): InlineConfig {
+  return {
+    root,
+    configFile: false,
+    appType: "custom",
+    logLevel: "silent",
+    plugins: [
+      ...oxContentCustomHost({
+        host: "./src/host.ts",
+        oxContent: { srcDir: "content", outDir: "dist", docs: false, search: false },
+        ...input,
+      }),
+    ],
+    build: {
+      outDir: "dist",
+      emptyOutDir: true,
+      manifest: true,
+      rollupOptions: { input: path.join(root, "src", "main.ts") },
+    },
+  };
+}
+
+function eagerGlobHostSource(): string {
+  return `
+import { createPageRoutes } from "./utils/routes.ts";
+
+export default {
+  routes() {
+    return createPageRoutes();
+  },
+};
+`;
+}
+
+function eagerGlobRoutesSource(): string {
+  return `
+const modules = import.meta.glob("/src/pages/**/index.ts", { eager: true });
+
+export function createPageRoutes() {
+  return Object.values(modules).flatMap((module) => module.routes());
+}
+`;
+}
+
+function pageRouteSource(routePath: string, body: string): string {
+  return `
+export function routes() {
+  return [
+    {
+      path: ${JSON.stringify(routePath)},
+      render: () => ({ text: ${JSON.stringify(body)}, contentType: "text/plain" }),
+    },
+  ];
+}
+`;
+}
+
+async function trackDevServer(serverPromise: Promise<ViteDevServer>): Promise<ViteDevServer> {
+  const server = await serverPromise;
+  activeServers.push(server);
+  return server;
+}
+
+async function listen(server: ViteDevServer): Promise<{ port: number }> {
+  const listener = http.createServer(server.middlewares);
+  activeListeners.push(listener);
+  await new Promise<void>((resolve) => listener.listen(0, "127.0.0.1", resolve));
+  const address = listener.address() as AddressInfo;
+  return { port: address.port };
+}
+
+async function text(port: number, requestPath: string) {
+  const response = await fetch(`http://127.0.0.1:${port}${requestPath}`);
+  return { status: response.status, text: await response.text() };
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function closeHttpServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}

--- a/npm/vite-plugin-ox-content/src/custom-host-dev-state.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-dev-state.ts
@@ -1,0 +1,6 @@
+import type { OxContentCustomHostMemo, OxContentCustomHostRoute } from "./custom-host-types";
+
+export type DevRoutesState = {
+  routes: readonly OxContentCustomHostRoute[];
+  memo: OxContentCustomHostMemo;
+};

--- a/npm/vite-plugin-ox-content/src/custom-host-dev.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-dev.ts
@@ -4,6 +4,8 @@ import {
   createCustomHostCollectionAssetsDevController,
   type CustomHostCollectionAssetsDevController,
 } from "./custom-host-collection-assets";
+import type { DevRoutesState } from "./custom-host-dev-state";
+import { hasRouteHostImportMetaGlob } from "./custom-host-route-glob";
 import type { CustomHostSsrStylesheetController } from "./custom-host-ssr-stylesheets";
 import {
   createBaseContext,
@@ -17,10 +19,8 @@ import { createTrackedContext, devResponse } from "./custom-host-dev-response";
 import type {
   DevCacheEntry,
   OxContentCustomHostDependency,
-  OxContentCustomHostMemo,
   OxContentCustomHostModule,
   OxContentCustomHostOptions,
-  OxContentCustomHostRoute,
   ResolvedThemeTokens,
 } from "./custom-host-types";
 import {
@@ -46,11 +46,6 @@ import {
   type NormalizedCustomHostDependency,
 } from "./custom-host-watch";
 import type { OxContentOptions, ResolvedOptions } from "./types";
-
-type DevRoutesState = {
-  routes: readonly OxContentCustomHostRoute[];
-  memo: OxContentCustomHostMemo;
-};
 
 export function configureDevServer(
   server: ViteDevServer,
@@ -90,6 +85,7 @@ export function configureDevServer(
   let hostPromise: Promise<OxContentCustomHostModule> | undefined;
   let routesStatePromise: Promise<DevRoutesState> | undefined;
   let routesGeneration = 0;
+  let routeHostUsesImportMetaGlob = false;
   let reloadTimer: ReturnType<typeof setTimeout> | undefined;
   const addedWatchPaths = new Set<string>();
 
@@ -193,6 +189,7 @@ export function configureDevServer(
         .then((host) => loadRoutes(host, context))
         .then((routes) => {
           if (routesStatePromise === current && routesGeneration === generation) {
+            routeHostUsesImportMetaGlob = hasRouteHostImportMetaGlob(server, input.host, root);
             const inferred = normalizeCustomHostDependencies(root, [...trackedDependencies]);
             routeCatalogueDependencies = [...configuredRouteDependencies, ...inferred];
             addWatchPaths(dependencyWatchPaths(routeCatalogueDependencies));
@@ -251,7 +248,7 @@ export function configureDevServer(
     if (anyCustomHostDependencyMatches(routeCatalogueDependencies, changed)) {
       ssrVersion += 1;
       invalidateViteModules(server, changed, true);
-      clearRoutes();
+      (routeHostUsesImportMetaGlob ? clearHost : clearRoutes)();
       scheduleReload();
       return;
     }

--- a/npm/vite-plugin-ox-content/src/custom-host-route-glob.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-route-glob.ts
@@ -1,0 +1,27 @@
+import * as fsSync from "node:fs";
+import type { ViteDevServer } from "vite";
+import { collectDevModuleDependencies } from "./custom-host-module-deps";
+import type { OxContentCustomHostOptions } from "./custom-host-types";
+import { normalizeHostModuleId } from "./custom-host-loader";
+
+export function hasRouteHostImportMetaGlob(
+  server: ViteDevServer,
+  host: OxContentCustomHostOptions["host"],
+  root: string,
+): boolean {
+  if (typeof host !== "string") {
+    return false;
+  }
+  const hostModuleId = normalizeHostModuleId(host, root);
+  return collectDevModuleDependencies(server.moduleGraph, hostModuleId, root).some(
+    sourceUsesImportMetaGlob,
+  );
+}
+
+function sourceUsesImportMetaGlob(file: string): boolean {
+  try {
+    return fsSync.readFileSync(file, "utf8").includes("import.meta.glob");
+  } catch {
+    return false;
+  }
+}

--- a/npm/vite-plugin-ox-content/src/custom-host-ssr-build-stylesheets.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-ssr-build-stylesheets.ts
@@ -65,7 +65,7 @@ export function ssrStylesheetEntryName(file: string, root: string): string {
 }
 
 export function ssrStylesheetVirtualId(entryName: string): string {
-  return `${VIRTUAL_SSR_STYLESHEET_PREFIX}${entryName}.css`;
+  return `${VIRTUAL_SSR_STYLESHEET_PREFIX}${entryName}.js`;
 }
 
 export function isSsrStylesheetVirtualId(id: string): boolean {
@@ -77,8 +77,21 @@ export function ssrStylesheetVirtualCss(
   root: string,
 ): string {
   return `${record.css
-    .map((stylesheet) => `@import ${JSON.stringify(publicModuleId(stylesheet.file, root))};`)
+    .map((stylesheet, index) => stylesheetImport(stylesheet.file, root, index))
     .join("\n")}\n`;
+}
+
+function stylesheetImport(file: string, root: string, index: number): string {
+  const moduleId = JSON.stringify(publicModuleId(file, root));
+  if (isCssModuleFile(file)) {
+    const binding = `__oxContentSsrCssModule${index}`;
+    return `import ${binding} from ${moduleId};\nexport const ${binding}ClassNames = Object.values(${binding});`;
+  }
+  return `import ${moduleId};`;
+}
+
+function isCssModuleFile(file: string): boolean {
+  return /\.module\.css(?:[?#].*)?$/u.test(file);
 }
 
 export function resolveSsrStylesheetBundleOutput(

--- a/npm/vite-plugin-ox-content/src/custom-host-ssr-dev-stylesheets.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-ssr-dev-stylesheets.ts
@@ -33,7 +33,7 @@ export function resolveStaticDevSsrStylesheets(input: {
   const diagnostics: OxContentCustomHostStylesheetDiagnostic[] = [];
   const dependencies = new Set<string>();
   const descriptors: OxContentCustomHostSsrStylesheetDescriptor[] = [];
-  const seenCss = new Set<string>();
+  const seenAggregateCss = new Set<string>();
 
   for (const moduleId of input.modules) {
     const rootFile = resolveRootModule(moduleId, input.root);
@@ -45,8 +45,13 @@ export function resolveStaticDevSsrStylesheets(input: {
       });
       continue;
     }
-    const record = collectRoot(moduleId, rootFile, input.root, input.base, seenCss, dependencies);
-    stylesheets.push(...record.stylesheets);
+    const record = collectRoot(moduleId, rootFile, input.root, input.base, dependencies);
+    for (const stylesheet of record.stylesheets) {
+      if (!seenAggregateCss.has(stylesheet.href)) {
+        seenAggregateCss.add(stylesheet.href);
+        stylesheets.push(stylesheet);
+      }
+    }
     diagnostics.push(...record.diagnostics);
     descriptors.push({
       moduleId,
@@ -66,12 +71,12 @@ function collectRoot(
   rootFile: string,
   root: string,
   base: string | undefined,
-  seenCss: Set<string>,
   dependencies: Set<string>,
 ) {
   const stylesheets: OxContentCustomHostStylesheet[] = [];
   const diagnostics: OxContentCustomHostStylesheetDiagnostic[] = [];
   const rootDependencies = new Set<string>();
+  const seenRootCss = new Set<string>();
 
   const visit = (file: string, seen: Set<string>) => {
     const clean = normalizeFilePath(file);
@@ -103,8 +108,8 @@ function collectRoot(
       rootDependencies.add(imported);
       if (isStyleFile(imported)) {
         const href = withBase(base ?? "/", publicModuleId(imported, root));
-        if (!seenCss.has(href)) {
-          seenCss.add(href);
+        if (!seenRootCss.has(href)) {
+          seenRootCss.add(href);
           stylesheets.push({ kind: "style", href, moduleId });
         }
       } else {

--- a/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.fixture.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.fixture.ts
@@ -178,7 +178,7 @@ async function writeSourceFiles(root: string): Promise<void> {
   await writeProjectFile(
     root,
     "src/layout.ts",
-    'import "./layout.css";\nimport { nested } from "./components/Nested.ts";\nexport function layout(body) { return `<div class="layout ${nested}">${body}</div>`; }\n',
+    'import styles from "./layout.module.css";\nimport "./layout.css";\nimport { nested } from "./components/Nested.ts";\nexport const layoutClass = styles.layoutScoped;\nexport function layout(body) { return `<div class="${styles.layoutScoped} ${nested}">${body}</div>`; }\n',
   );
   await writeProjectFile(
     root,
@@ -188,12 +188,12 @@ async function writeSourceFiles(root: string): Promise<void> {
   await writeProjectFile(
     root,
     "src/pages/home/page.ts",
-    'import "./home.css";\nexport const marker = "home server-only";\n',
+    'import styles from "./home.module.css";\nimport "./home.css";\nexport const marker = "home server-only";\nexport const className = styles.homeTitle;\n',
   );
   await writeProjectFile(
     root,
     "src/pages/work/page.ts",
-    'import "./work.css";\nexport const marker = "work server-only";\n',
+    'import styles from "./work.module.css";\nimport "./work.css";\nexport const marker = "work server-only";\nexport const className = styles.workTitle;\n',
   );
   await writeProjectFile(
     root,
@@ -207,6 +207,11 @@ async function writeSourceFiles(root: string): Promise<void> {
   );
   await writeProjectFile(
     root,
+    "src/layout.module.css",
+    '.layoutScoped{display:grid}\n:global(body[data-page-style="layout"]){--layout-style:ready}\n',
+  );
+  await writeProjectFile(
+    root,
     "src/styles/prose.css",
     '@font-face{font-family:"prose";src:url("./prose.woff2") format("woff2")}.prose{line-height:1.6}\n',
   );
@@ -217,9 +222,31 @@ async function writeSourceFiles(root: string): Promise<void> {
     "src/pages/home/home.css",
     '.home{color:green;background:url("./home.png")}\n',
   );
+  await writeProjectFile(
+    root,
+    "src/pages/home/home.module.css",
+    '.homeTitle{color:green}\n:global(body[data-page-style="home"]){--home-style:ready}\n',
+  );
   await writeProjectFile(root, "src/pages/home/home.png", "home-image");
   await writeProjectFile(root, "src/pages/work/work.css", ".work{color:blue}\n");
+  await writeProjectFile(root, "src/pages/work/work.module.css", ".workTitle{color:blue}\n");
   await writeProjectFile(root, "src/islands/island.css", ".island{color:purple}\n");
+  await writeProjectFile(root, "src/shared.css", ".shared{color:gold}\n");
+  await writeProjectFile(
+    root,
+    "src/shared-a.ts",
+    'import "./shared.css";\nexport const a = true;\n',
+  );
+  await writeProjectFile(
+    root,
+    "src/shared-child.ts",
+    'import "./shared.css";\nexport const child = true;\n',
+  );
+  await writeProjectFile(
+    root,
+    "src/shared-b.ts",
+    'import { child } from "./shared-child.ts";\nexport const b = child;\n',
+  );
 }
 
 function hostModuleSource(): string {
@@ -232,33 +259,56 @@ const routes = [
 ];
 
 export default {
-  routes: routes.map((route) => ({
-    path: route.path,
-    async render(ctx) {
-      renders += 1;
-      const ssr = ctx.assets.ssrStylesheets({
-        modules: ["/src/layout.ts", route.moduleId],
-      });
-      const island = ctx.assets.stylesheets({ modules: ["/src/islands/client.ts"] });
-      const diagnostics = [...ssr.diagnostics, ...island.diagnostics]
-        .map((diagnostic) => diagnostic.code)
-        .join(",");
-      const content = await ctx.assets.stylesheetContent({ stylesheets: ssr.stylesheets });
-      const assets = ctx.assets.document({
-        islandStyles: [...ssr.stylesheets, ...island.stylesheets],
-        inlineStyles: content.stylesheets.map((stylesheet) => ({
-          key: "critical:" + stylesheet.href,
-          content: stylesheet.content,
-          attrs: { "data-critical": stylesheet.href },
-        })),
-        clientEntries: ["src/main.ts"],
-      });
-      return {
-        html: "<!doctype html><html><head>" + assets.headHtml + "</head><body data-render=\\"" + renders + "\\" data-diagnostics=\\"" + diagnostics + "\\" data-style-content-diagnostics=\\"" + content.diagnostics.map((diagnostic) => diagnostic.code).join(",") + "\\"><div class=\\"layout nested\\"><main>" + route.marker + "</main></div></body></html>",
-        dependencies: [...ssr.dependencies, ...island.dependencies],
-      };
+  routes: [
+    ...routes.map((route) => ({
+      path: route.path,
+      async render(ctx) {
+        renders += 1;
+        const layoutModule = ctx.mode === "build" ? await ctx.loadModule("/src/layout.ts") : { layoutClass: "layout" };
+        const pageModule = ctx.mode === "build" ? await ctx.loadModule(route.moduleId) : { className: route.marker };
+        const ssr = ctx.assets.ssrStylesheets({
+          modules: ["/src/layout.ts", route.moduleId],
+        });
+        const island = ctx.assets.stylesheets({ modules: ["/src/islands/client.ts"] });
+        const diagnostics = [...ssr.diagnostics, ...island.diagnostics]
+          .map((diagnostic) => diagnostic.code)
+          .join(",");
+        const content = await ctx.assets.stylesheetContent({ stylesheets: ssr.stylesheets });
+        const assets = ctx.assets.document({
+          islandStyles: [...ssr.stylesheets, ...island.stylesheets],
+          inlineStyles: content.stylesheets.map((stylesheet) => ({
+            key: "critical:" + stylesheet.href,
+            content: stylesheet.content,
+            attrs: { "data-critical": stylesheet.href },
+          })),
+          clientEntries: ["src/main.ts"],
+        });
+        return {
+          html: "<!doctype html><html><head>" + assets.headHtml + "</head><body data-render=\\"" + renders + "\\" data-page-style=\\"" + route.marker + "\\" data-diagnostics=\\"" + diagnostics + "\\" data-style-content-diagnostics=\\"" + content.diagnostics.map((diagnostic) => diagnostic.code).join(",") + "\\"><div class=\\"" + layoutModule.layoutClass + " nested\\"><main class=\\"" + pageModule.className + "\\">" + route.marker + "</main></div></body></html>",
+          dependencies: [...ssr.dependencies, ...island.dependencies],
+        };
+      },
+    })),
+    {
+      path: "/shared",
+      render(ctx) {
+        const ssr = ctx.assets.ssrStylesheets({
+          modules: ["/src/shared-a.ts", "/src/shared-b.ts"],
+        });
+        return {
+          text: JSON.stringify({
+            stylesheets: ssr.stylesheets.map((stylesheet) => stylesheet.href),
+            descriptors: ssr.descriptors.map((descriptor) => ({
+              moduleId: descriptor.moduleId,
+              stylesheets: descriptor.stylesheets.map((stylesheet) => stylesheet.href),
+            })),
+          }),
+          contentType: "application/json",
+          dependencies: ssr.dependencies,
+        };
+      },
     },
-  })),
+  ],
 };
 `;
 }

--- a/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.test.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.test.ts
@@ -41,6 +41,18 @@ describe("custom host SSR stylesheets", () => {
     expect(home).not.toContain("server-only");
 
     const homeCss = await readLinkedCss(root, home);
+    const homeTitleClass = elementClass(home, "main");
+    const layoutClass = elementClass(home, "div");
+    expect(homeTitleClass).not.toBe("homeTitle");
+    expect(layoutClass).not.toBe("layoutScoped");
+    expect(homeCss).toContain(cssClassSelector(homeTitleClass));
+    expect(homeCss).toContain(cssClassSelector(layoutClass));
+    expect(homeCss).not.toContain(".homeTitle{");
+    expect(homeCss).not.toContain(".layoutScoped{");
+    expect(homeCss).not.toContain(":global");
+    expect(homeCss).toMatch(/body\[data-page-style=home\]/u);
+    expect(home).toContain(cssClassSelector(homeTitleClass));
+    expect(home).toContain(cssClassSelector(layoutClass));
     expect(homeCss).toContain(".layout");
     expect(homeCss).toContain(".nested");
     expect(homeCss).toContain(".home");
@@ -95,6 +107,22 @@ describe("custom host SSR stylesheets", () => {
     expect(updated.text).toContain('href="/docs/src/components/nested-extra.css"');
   });
 
+  it("keeps shared static dev SSR styles in every root descriptor", async () => {
+    const root = await createProject("ox-custom-host-ssr-style-shared-dev-");
+    const server = await trackDevServer(createServer(viteConfig(root, { reloadDebounceMs: 1 })));
+    const listener = await listen(server);
+
+    const response = await read(listener.port, "/docs/shared");
+    expect(response.status).toBe(200);
+    const result = JSON.parse(response.text);
+
+    expect(result.stylesheets).toEqual(["/docs/src/shared.css"]);
+    expect(result.descriptors).toEqual([
+      { moduleId: "/src/shared-a.ts", stylesheets: ["/docs/src/shared.css"] },
+      { moduleId: "/src/shared-b.ts", stylesheets: ["/docs/src/shared.css"] },
+    ]);
+  });
+
   it("reports unsupported local dynamic SSR imports", async () => {
     const root = await createProject("ox-custom-host-ssr-style-diagnostic-");
     await writeProjectFile(
@@ -111,3 +139,19 @@ describe("custom host SSR stylesheets", () => {
     expect(await readLinkedCss(root, home)).not.toContain(".late");
   });
 });
+
+function elementClass(html: string, tag: "div" | "main"): string {
+  const match =
+    tag === "div"
+      ? /<div class="([^"]+) nested">/u.exec(html)
+      : /<main class="([^"]+)">/u.exec(html);
+  const value = match?.[1]?.split(/\s+/u)[0];
+  if (!value) {
+    throw new Error(`Missing ${tag} class in ${html}`);
+  }
+  return value;
+}
+
+function cssClassSelector(className: string): string {
+  return `.${className}`;
+}

--- a/npm/vite-plugin-ox-content/src/custom-host-utils.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-utils.ts
@@ -7,6 +7,7 @@ import type {
   OxContentCustomHostRenderResult,
   SerializedResponse,
 } from "./custom-host-types";
+export { invalidateViteModules } from "./custom-host-vite-invalidation";
 import type { ResolvedOptions } from "./types";
 
 export function resultBody(result: OxContentCustomHostRenderResult): string | Uint8Array {
@@ -133,19 +134,6 @@ export function versionedModuleId(moduleId: string, version: number): string {
 
 export function isFileLikeModuleId(moduleId: string): boolean {
   return moduleId.startsWith("/") || moduleId.startsWith(".") || moduleId.includes("\\");
-}
-
-export function invalidateViteModules(server: ViteDevServer, file: string, all = false): void {
-  const moduleGraph = server.moduleGraph as ViteDevServer["moduleGraph"] & {
-    invalidateAll?: () => void;
-  };
-  if (all && typeof moduleGraph.invalidateAll === "function") {
-    moduleGraph.invalidateAll();
-    return;
-  }
-  for (const mod of server.moduleGraph.getModulesByFile(file) ?? []) {
-    server.moduleGraph.invalidateModule(mod);
-  }
 }
 
 export function resolveDependency(root: string, dependency: string): string {

--- a/npm/vite-plugin-ox-content/src/custom-host-vite-invalidation.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-vite-invalidation.ts
@@ -1,0 +1,85 @@
+import type { ViteDevServer } from "vite";
+
+export function invalidateViteModules(server: ViteDevServer, file: string, all = false): void {
+  for (const moduleGraph of viteModuleGraphs(server)) {
+    if (all) {
+      if (typeof moduleGraph.invalidateAll === "function") {
+        moduleGraph.invalidateAll();
+      } else {
+        for (const mod of moduleGraph.idToModuleMap?.values() ?? []) {
+          moduleGraph.invalidateModule(mod);
+        }
+      }
+      continue;
+    }
+    for (const mod of moduleGraph.getModulesByFile(file) ?? []) {
+      moduleGraph.invalidateModule(mod);
+    }
+  }
+  for (const evaluatedModules of viteEvaluatedModules(server)) {
+    if (all) {
+      evaluatedModules.clear();
+      continue;
+    }
+    for (const mod of evaluatedModules.getModulesByFile(file) ?? []) {
+      evaluatedModules.invalidateModule(mod);
+    }
+  }
+}
+
+type InvalidatableViteModuleGraph = {
+  idToModuleMap?: Map<string, unknown>;
+  getModulesByFile(file: string): Set<unknown> | undefined;
+  invalidateAll?: () => void;
+  invalidateModule(mod: unknown): void;
+};
+
+function viteModuleGraphs(server: ViteDevServer): InvalidatableViteModuleGraph[] {
+  const graphs = new Set<InvalidatableViteModuleGraph>();
+  graphs.add(server.moduleGraph as unknown as InvalidatableViteModuleGraph);
+  const environments = (
+    server as ViteDevServer & {
+      environments?: Record<string, ViteEnvironmentWithCaches>;
+    }
+  ).environments;
+  for (const environment of Object.values(environments ?? {})) {
+    if (environment.moduleGraph) {
+      graphs.add(environment.moduleGraph);
+    }
+  }
+  return [...graphs];
+}
+
+type ViteEnvironmentWithCaches = {
+  moduleGraph?: InvalidatableViteModuleGraph;
+  runner?: { evaluatedModules?: InvalidatableEvaluatedModules };
+};
+
+type InvalidatableEvaluatedModules = {
+  getModulesByFile(file: string): Set<unknown> | undefined;
+  invalidateModule(mod: unknown): void;
+  clear(): void;
+};
+
+function viteEvaluatedModules(server: ViteDevServer): InvalidatableEvaluatedModules[] {
+  const modules = new Set<InvalidatableEvaluatedModules>();
+  const compatRunner = (
+    server as ViteDevServer & {
+      _ssrCompatModuleRunner?: { evaluatedModules?: InvalidatableEvaluatedModules };
+    }
+  )._ssrCompatModuleRunner;
+  if (compatRunner?.evaluatedModules) {
+    modules.add(compatRunner.evaluatedModules);
+  }
+  const environments = (
+    server as ViteDevServer & {
+      environments?: Record<string, ViteEnvironmentWithCaches>;
+    }
+  ).environments;
+  for (const environment of Object.values(environments ?? {})) {
+    if (environment.runner?.evaluatedModules) {
+      modules.add(environment.runner.evaluatedModules);
+    }
+  }
+  return [...modules];
+}


### PR DESCRIPTION
## Summary
- preserve CSS Modules in production SSR stylesheet artifacts by keeping module class exports live in generated style entries
- keep shared static dev SSR CSS on each root descriptor while deduplicating aggregate stylesheet output
- refresh eager-glob route catalogues after watched module add/remove without resetting normal route host state

## Verification
- vp test npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.test.ts npm/vite-plugin-ox-content/src/custom-host-stylesheets.test.ts npm/vite-plugin-ox-content/src/custom-host-dev-lifecycle.test.ts npm/vite-plugin-ox-content/src/custom-host-dev-cache.test.ts npm/vite-plugin-ox-content/src/custom-host-dev-eager-glob.test.ts
- vp check npm/vite-plugin-ox-content
- node tools/scripts/check-file-lines.ts
- git diff --check

Closes #1359
Closes #1360
Closes #1361

Co-authored-by: ryoppippi <1560508+ryoppippi@users.noreply.github.com>