### PR TITLE
fix(custom-host): include imported SSR chunk CSS

### DIFF
--- a/npm/vite-plugin-ox-content/src/custom-host-ssr-build-stylesheets.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-ssr-build-stylesheets.ts
@@ -10,7 +10,7 @@ const VIRTUAL_SSR_STYLESHEET_PREFIX = "\0ox-content:custom-host-ssr-stylesheet:"
 
 export type SsrStylesheetBuildRecord = {
   moduleId: string;
-  stylesheet?: OxContentCustomHostStylesheet;
+  stylesheets?: readonly OxContentCustomHostStylesheet[];
 };
 
 export type WritableSsrStylesheetBuildRecord = SsrStylesheetBuildRecord & {
@@ -29,6 +29,7 @@ type SsrStylesheetBundleEntry =
   | {
       type: "chunk";
       fileName?: string;
+      imports?: string[];
       viteMetadata?: { importedCss?: Set<string> | string[] };
     };
 
@@ -40,16 +41,15 @@ export function resolveBuildSsrStylesheetRecords(input: {
   const seen = new Set<string>();
 
   for (const record of input.records) {
-    if (!record.stylesheet) {
-      continue;
-    }
-    const stylesheet = {
-      ...record.stylesheet,
-      href: withBase(input.base ?? "/", record.stylesheet.href),
-    };
-    if (!seen.has(stylesheet.href)) {
-      seen.add(stylesheet.href);
-      stylesheets.push(stylesheet);
+    for (const recordStylesheet of record.stylesheets ?? []) {
+      const stylesheet = {
+        ...recordStylesheet,
+        href: withBase(input.base ?? "/", recordStylesheet.href),
+      };
+      if (!seen.has(stylesheet.href)) {
+        seen.add(stylesheet.href);
+        stylesheets.push(stylesheet);
+      }
     }
   }
 
@@ -98,54 +98,83 @@ export function resolveSsrStylesheetBundleOutput(
   record: WritableSsrStylesheetBuildRecord,
   bundle: SsrStylesheetOutputBundle,
   getFileName: (referenceId: string) => string,
-): OxContentCustomHostStylesheet | undefined {
+): OxContentCustomHostStylesheet[] {
   if (record.css.length === 0) {
-    return undefined;
+    return [];
   }
   if (!record.referenceId) {
-    return undefined;
+    return [];
   }
-  const outputPath = cssOutputPath(bundle, getFileName(record.referenceId), record.entryName);
-  if (!outputPath) {
-    return undefined;
-  }
-  return {
-    kind: "style",
-    href: `/${outputPath}`,
-    moduleId: record.moduleId,
-    outputPath,
-  };
+  return cssOutputPaths(bundle, getFileName(record.referenceId), record.entryName).map(
+    (outputPath) => ({
+      kind: "style",
+      href: `/${outputPath}`,
+      moduleId: record.moduleId,
+      outputPath,
+    }),
+  );
 }
 
-function cssOutputPath(
+function cssOutputPaths(
   bundle: SsrStylesheetOutputBundle,
   fileName: string,
   entryName: string,
-): string | undefined {
-  const entry = bundle[fileName];
-  if (entry?.type === "asset" && fileName.endsWith(".css")) {
-    return fileName;
-  }
-  if (entry?.type === "chunk") {
-    const importedCss = viteImportedCss(entry);
-    if (importedCss[0]) {
-      return importedCss[0];
+): string[] {
+  const paths: string[] = [];
+  const seenCss = new Set<string>();
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+
+  const addCss = (css: string) => {
+    if (!seenCss.has(css)) {
+      seenCss.add(css);
+      paths.push(css);
+    }
+  };
+
+  const visit = (chunkFileName: string) => {
+    if (visiting.has(chunkFileName) || visited.has(chunkFileName)) {
+      return;
+    }
+    const entry = bundle[chunkFileName];
+    if (!entry) {
+      return;
+    }
+    if (entry.type === "asset") {
+      if (chunkFileName.endsWith(".css")) {
+        addCss(chunkFileName);
+      }
+      return;
+    }
+    visiting.add(chunkFileName);
+    for (const imported of entry.imports ?? []) {
+      visit(imported);
+    }
+    for (const css of viteImportedCss(entry)) {
+      addCss(css);
+    }
+    visiting.delete(chunkFileName);
+    visited.add(chunkFileName);
+  };
+
+  visit(fileName);
+  if (paths.length === 0) {
+    for (const css of findNamedCssAssets(bundle, entryName)) {
+      addCss(css);
     }
   }
-  return findNamedCssAsset(bundle, entryName);
+  return paths;
 }
 
-function findNamedCssAsset(
-  bundle: SsrStylesheetOutputBundle,
-  entryName: string,
-): string | undefined {
+function findNamedCssAssets(bundle: SsrStylesheetOutputBundle, entryName: string): string[] {
   const prefix = `assets/${entryName}-`;
+  const matches: string[] = [];
   for (const [fileName, entry] of Object.entries(bundle)) {
     if (entry.type === "asset" && fileName.startsWith(prefix) && fileName.endsWith(".css")) {
-      return fileName;
+      matches.push(fileName);
     }
   }
-  return undefined;
+  return matches;
 }
 
 function viteImportedCss(chunk: Extract<SsrStylesheetBundleEntry, { type: "chunk" }>): string[] {

--- a/npm/vite-plugin-ox-content/src/custom-host-ssr-discovery.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-ssr-discovery.ts
@@ -38,7 +38,7 @@ export type RootRecord = {
   dependencies: string[];
   diagnostics: OxContentCustomHostStylesheetDiagnostic[];
   referenceId?: string;
-  stylesheet?: OxContentCustomHostStylesheet;
+  stylesheets?: readonly OxContentCustomHostStylesheet[];
 };
 
 export async function expandConfiguredModules(

--- a/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.fixture.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.fixture.ts
@@ -188,12 +188,17 @@ async function writeSourceFiles(root: string): Promise<void> {
   await writeProjectFile(
     root,
     "src/pages/home/page.ts",
-    'import styles from "./home.module.css";\nimport "./home.css";\nexport const marker = "home server-only";\nexport const className = styles.homeTitle;\n',
+    'import { sharedNavClass } from "../../components/SharedNav.ts";\nimport styles from "./home.module.css";\nimport "./home.css";\nexport const marker = "home server-only";\nexport const className = styles.homeTitle;\nexport { sharedNavClass };\n',
   );
   await writeProjectFile(
     root,
     "src/pages/work/page.ts",
-    'import styles from "./work.module.css";\nimport "./work.css";\nexport const marker = "work server-only";\nexport const className = styles.workTitle;\n',
+    'import { sharedNavClass } from "../../components/SharedNav.ts";\nimport styles from "./work.module.css";\nimport "./work.css";\nexport const marker = "work server-only";\nexport const className = styles.workTitle;\nexport { sharedNavClass };\n',
+  );
+  await writeProjectFile(
+    root,
+    "src/components/SharedNav.ts",
+    'import styles from "./shared-nav.module.css";\nexport const sharedNavClass = styles.sharedNavigation;\n',
   );
   await writeProjectFile(
     root,
@@ -217,6 +222,11 @@ async function writeSourceFiles(root: string): Promise<void> {
   );
   await writeProjectFile(root, "src/styles/prose.woff2", "prose-font");
   await writeProjectFile(root, "src/components/nested.css", ".nested{padding:1px}\n");
+  await writeProjectFile(
+    root,
+    "src/components/shared-nav.module.css",
+    ".sharedNavigation{display:flex}\n",
+  );
   await writeProjectFile(
     root,
     "src/pages/home/home.css",
@@ -266,6 +276,7 @@ export default {
         renders += 1;
         const layoutModule = ctx.mode === "build" ? await ctx.loadModule("/src/layout.ts") : { layoutClass: "layout" };
         const pageModule = ctx.mode === "build" ? await ctx.loadModule(route.moduleId) : { className: route.marker };
+        const sharedNavClass = pageModule.sharedNavClass || "sharedNavigation";
         const ssr = ctx.assets.ssrStylesheets({
           modules: ["/src/layout.ts", route.moduleId],
         });
@@ -284,7 +295,7 @@ export default {
           clientEntries: ["src/main.ts"],
         });
         return {
-          html: "<!doctype html><html><head>" + assets.headHtml + "</head><body data-render=\\"" + renders + "\\" data-page-style=\\"" + route.marker + "\\" data-diagnostics=\\"" + diagnostics + "\\" data-style-content-diagnostics=\\"" + content.diagnostics.map((diagnostic) => diagnostic.code).join(",") + "\\"><div class=\\"" + layoutModule.layoutClass + " nested\\"><main class=\\"" + pageModule.className + "\\">" + route.marker + "</main></div></body></html>",
+          html: "<!doctype html><html><head>" + assets.headHtml + "</head><body data-render=\\"" + renders + "\\" data-page-style=\\"" + route.marker + "\\" data-diagnostics=\\"" + diagnostics + "\\" data-style-content-diagnostics=\\"" + content.diagnostics.map((diagnostic) => diagnostic.code).join(",") + "\\"><div class=\\"" + layoutModule.layoutClass + " nested\\"><nav class=\\"" + sharedNavClass + "\\">shared</nav><main class=\\"" + pageModule.className + "\\">" + route.marker + "</main></div></body></html>",
           dependencies: [...ssr.dependencies, ...island.dependencies],
         };
       },

--- a/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.test.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it } from "vite-plus/test";
 import { build as viteBuild, createServer } from "vite";
 import {
+  resolveSsrStylesheetBundleOutput,
+  type SsrStylesheetOutputBundle,
+} from "./custom-host-ssr-build-stylesheets";
+import {
   cleanupCustomHostSsrFixtures,
   createProject,
   hasMarker,
@@ -20,6 +24,37 @@ import {
 afterEach(cleanupCustomHostSsrFixtures);
 
 describe("custom host SSR stylesheets", () => {
+  it("collects imported build chunk CSS before direct root CSS", () => {
+    const bundle = {
+      "assets/root.js": {
+        type: "chunk",
+        imports: ["assets/shared.js"],
+        viteMetadata: { importedCss: new Set(["assets/root-a.css", "assets/root-b.css"]) },
+      },
+      "assets/shared.js": {
+        type: "chunk",
+        viteMetadata: { importedCss: ["assets/shared.css", "assets/root-a.css"] },
+      },
+    } satisfies SsrStylesheetOutputBundle;
+
+    const stylesheets = resolveSsrStylesheetBundleOutput(
+      {
+        moduleId: "/src/root.ts",
+        entryName: "src-root",
+        css: [{ file: "/repo/src/root.css" }],
+        referenceId: "root-reference",
+      },
+      bundle,
+      () => "assets/root.js",
+    );
+
+    expect(stylesheets.map((stylesheet) => stylesheet.href)).toEqual([
+      "/assets/shared.css",
+      "/assets/root-a.css",
+      "/assets/root-b.css",
+    ]);
+  });
+
   it("emits route-specific SSR styles without browser-bundling server modules", async () => {
     const root = await createProject("ox-custom-host-ssr-style-build-");
 
@@ -43,12 +78,16 @@ describe("custom host SSR stylesheets", () => {
     const homeCss = await readLinkedCss(root, home);
     const homeTitleClass = elementClass(home, "main");
     const layoutClass = elementClass(home, "div");
+    const sharedNavClass = elementClass(home, "nav");
     expect(homeTitleClass).not.toBe("homeTitle");
     expect(layoutClass).not.toBe("layoutScoped");
+    expect(sharedNavClass).not.toBe("sharedNavigation");
     expect(homeCss).toContain(cssClassSelector(homeTitleClass));
     expect(homeCss).toContain(cssClassSelector(layoutClass));
+    expect(homeCss).toContain(cssClassSelector(sharedNavClass));
     expect(homeCss).not.toContain(".homeTitle{");
     expect(homeCss).not.toContain(".layoutScoped{");
+    expect(homeCss).not.toContain(".sharedNavigation{");
     expect(homeCss).not.toContain(":global");
     expect(homeCss).toMatch(/body\[data-page-style=home\]/u);
     expect(home).toContain(cssClassSelector(homeTitleClass));
@@ -71,6 +110,9 @@ describe("custom host SSR stylesheets", () => {
     }
 
     const workCss = await readLinkedCss(root, work);
+    const workSharedNavClass = elementClass(work, "nav");
+    expect(workSharedNavClass).toBe(sharedNavClass);
+    expect(workCss).toContain(cssClassSelector(workSharedNavClass));
     expect(workCss).toContain(".work");
     expect(workCss).not.toContain(".home");
 
@@ -140,11 +182,13 @@ describe("custom host SSR stylesheets", () => {
   });
 });
 
-function elementClass(html: string, tag: "div" | "main"): string {
+function elementClass(html: string, tag: "div" | "main" | "nav"): string {
   const match =
     tag === "div"
       ? /<div class="([^"]+) nested">/u.exec(html)
-      : /<main class="([^"]+)">/u.exec(html);
+      : tag === "main"
+        ? /<main class="([^"]+)">/u.exec(html)
+        : /<nav class="([^"]+)">/u.exec(html);
   const value = match?.[1]?.split(/\s+/u)[0];
   if (!value) {
     throw new Error(`Missing ${tag} class in ${html}`);

--- a/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.ts
@@ -103,7 +103,7 @@ export function createCustomHostSsrStylesheetController(
     },
     writeBundle(bundle, getFileName) {
       for (const record of buildRecords) {
-        record.stylesheet = resolveSsrStylesheetBundleOutput(record, bundle, getFileName);
+        record.stylesheets = resolveSsrStylesheetBundleOutput(record, bundle, getFileName);
       }
     },
     async write(_outDir) {},
@@ -135,7 +135,10 @@ function resolveBuild(
     return missingResolverResult(input.modules);
   }
   const descriptors: OxContentCustomHostSsrStylesheetDescriptor[] = [];
-  const styleRecords: { moduleId: string; stylesheet?: OxContentCustomHostStylesheet }[] = [];
+  const styleRecords: {
+    moduleId: string;
+    stylesheets?: readonly OxContentCustomHostStylesheet[];
+  }[] = [];
   const diagnostics: OxContentCustomHostStylesheetDiagnostic[] = [];
 
   for (const moduleId of input.modules) {
@@ -148,7 +151,7 @@ function resolveBuild(
       });
       continue;
     }
-    const buildRecord = { moduleId, stylesheet: record.stylesheet };
+    const buildRecord = { moduleId, stylesheets: record.stylesheets };
     styleRecords.push(buildRecord);
     diagnostics.push(...record.diagnostics);
     descriptors.push({


### PR DESCRIPTION
## Summary

- Resolve SSR stylesheet build outputs as an ordered CSS dependency graph instead of a single root artifact.
- Include CSS emitted for imported/shared chunks while preserving per-root descriptors and aggregate dedupe.
- Add a production regression fixture with two SSR roots sharing a nested CSS Module and selector/content checks.

Closes #1367

## Verification

- `vp test npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.test.ts npm/vite-plugin-ox-content/src/custom-host-stylesheet-content.test.ts`
- `vp test --typecheck npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.test.ts npm/vite-plugin-ox-content/src/custom-host-stylesheet-content.test.ts`
- `vp run --filter @ox-content/vite-plugin build`
- `node tools/scripts/check-file-lines.ts --base origin/main`
- `vp fmt --check npm/vite-plugin-ox-content/src/custom-host-ssr-build-stylesheets.ts npm/vite-plugin-ox-content/src/custom-host-ssr-discovery.ts npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.fixture.ts npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.test.ts npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.ts`
- `git diff --check`

Co-authored-by: ryoppippi <1560508+ryoppippi@users.noreply.github.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791444756&installation_model_id=422833&pr_number=1368&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1368&signature=acd731ec032c89127fc27ee7d336f851b4d813d80634cd800341e7ae2ec53d54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - SSR builds now support multiple stylesheets per page.
  - Shared stylesheets imported through build chunks are automatically discovered and included.
  - Stylesheets are deduplicated and ordered consistently, with shared styles appearing before page-specific styles.
  - Shared navigation styling is now reflected consistently across related pages.

- **Bug Fixes**
  - Prevented unhashed shared styles from being emitted in SSR output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->