### PR TITLE
fix(vite-plugin): publish stable MPA navigation CSS

### DIFF
--- a/crates/ox_content_ssg/src/html/mpa_navigation.css
+++ b/crates/ox_content_ssg/src/html/mpa_navigation.css
@@ -13,6 +13,6 @@
      browser whose blend arrives late, or a transition that is skipped partway,
      still has the page color behind it rather than a black or white gap. */
   ::view-transition {
-    background-color: var(--octc-color-bg);
+    background-color: var(--ox-content-mpa-navigation-bg, var(--octc-color-bg, Canvas));
   }
 }

--- a/crates/ox_content_ssg/src/html/mpa_navigation.rs
+++ b/crates/ox_content_ssg/src/html/mpa_navigation.rs
@@ -37,7 +37,9 @@ mod tests {
         // Whatever the snapshots leave transparent has to land on the page
         // color rather than on the compositor's own backdrop.
         assert!(MPA_NAVIGATION_CSS.contains("::view-transition {"));
-        assert!(MPA_NAVIGATION_CSS.contains("background-color: var(--octc-color-bg);"));
+        assert!(MPA_NAVIGATION_CSS.contains(
+            "background-color: var(--ox-content-mpa-navigation-bg, var(--octc-color-bg, Canvas));"
+        ));
     }
 
     #[test]

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
@@ -2382,7 +2382,7 @@ a:hover {
      browser whose blend arrives late, or a transition that is skipped partway,
      still has the page color behind it rather than a black or white gap. */
   ::view-transition {
-    background-color: var(--octc-color-bg);
+    background-color: var(--ox-content-mpa-navigation-bg, var(--octc-color-bg, Canvas));
   }
 }
 

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
@@ -2379,7 +2379,7 @@ a:hover {
      browser whose blend arrives late, or a transition that is skipped partway,
      still has the page color behind it rather than a black or white gap. */
   ::view-transition {
-    background-color: var(--octc-color-bg);
+    background-color: var(--ox-content-mpa-navigation-bg, var(--octc-color-bg, Canvas));
   }
 }
 

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
@@ -2379,7 +2379,7 @@ a:hover {
      browser whose blend arrives late, or a transition that is skipped partway,
      still has the page color behind it rather than a black or white gap. */
   ::view-transition {
-    background-color: var(--octc-color-bg);
+    background-color: var(--ox-content-mpa-navigation-bg, var(--octc-color-bg, Canvas));
   }
 }
 

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
@@ -2379,7 +2379,7 @@ a:hover {
      browser whose blend arrives late, or a transition that is skipped partway,
      still has the page color behind it rather than a black or white gap. */
   ::view-transition {
-    background-color: var(--octc-color-bg);
+    background-color: var(--ox-content-mpa-navigation-bg, var(--octc-color-bg, Canvas));
   }
 }
 

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
@@ -2379,7 +2379,7 @@ a:hover {
      browser whose blend arrives late, or a transition that is skipped partway,
      still has the page color behind it rather than a black or white gap. */
   ::view-transition {
-    background-color: var(--octc-color-bg);
+    background-color: var(--ox-content-mpa-navigation-bg, var(--octc-color-bg, Canvas));
   }
 }
 

--- a/docs/content/built-in/component-styles.md
+++ b/docs/content/built-in/component-styles.md
@@ -21,7 +21,7 @@ Import what you render. Site-specific theming stays in your app.
 @import "@ox-content/vite-plugin/styles/reader-chrome.css";
 ```
 
-Or pull every feature sheet:
+Or pull every non-navigation feature sheet:
 
 ```css
 @import "@ox-content/vite-plugin/styles/all.css";
@@ -48,11 +48,17 @@ you can load compact Tweet chrome without the full-card sheet.
 | `styles/graphviz.css`        | Graphviz DOT diagrams                                                                                          |
 | `styles/citations.css`       | Citation links and generated bibliography sections                                                             |
 | `styles/not-by-ai.css`       | `<NotByAI />` authorship badge                                                                                 |
-| `styles/all.css`             | The feature sheets above, in that order                                                                        |
+| `styles/mpa-navigation.css`  | Opt-in cross-document View Transition navigation, with stable overlay background and reduced-motion guard      |
+| `styles/all.css`             | The non-navigation feature sheets above, in that order                                                         |
 
 Feature sheets that use `var(--octc-*)` expect `core.css` first, or the same
 tokens defined on your host. Full Tweet chrome defines its own `--ox-tweet-*`
 variables and does not require `core.css`.
+
+`styles/mpa-navigation.css` enables browser navigation transitions, so it is
+not included in `styles/all.css`. Import it only when your custom host wants
+MPA View Transitions. Set `--ox-content-mpa-navigation-bg` when your page
+background does not come from `--octc-color-bg`.
 
 These files are copied from `crates/ox_content_ssg` at package build time. The
 built-in SSG includes the same sources, so official chrome cannot drift from

--- a/docs/content/ja/built-in/component-styles.md
+++ b/docs/content/ja/built-in/component-styles.md
@@ -22,7 +22,7 @@ description: ssg: false と transformAllPlugins() 向けの、公式コンポー
 @import "@ox-content/vite-plugin/styles/reader-chrome.css";
 ```
 
-全部まとめて取るとき:
+navigation 以外の機能シートをまとめて取るとき:
 
 ```css
 @import "@ox-content/vite-plugin/styles/all.css";
@@ -49,11 +49,17 @@ import なので、コンパクトな Tweet だけ載せてフルカード用シ
 | `styles/graphviz.css`        | Graphviz DOT 図                                                                                               |
 | `styles/citations.css`       | 引用リンクと生成 bibliography section                                                                         |
 | `styles/not-by-ai.css`       | `<NotByAI />` 執筆開示バッジ                                                                                  |
-| `styles/all.css`             | 上の機能シートをこの順で全部                                                                                  |
+| `styles/mpa-navigation.css`  | 文書横断 View Transition ナビゲーション。安定した overlay 背景と reduced-motion guard を含む                  |
+| `styles/all.css`             | 上の navigation 以外の機能シートをこの順で全部                                                                |
 
 `var(--octc-*)` を使う機能シートは、先に `core.css` を読むか、ホスト側で同じ
 トークンを定義してください。フル Tweet の chrome は独自の `--ox-tweet-*` を
 持つので `core.css` は不要です。
+
+`styles/mpa-navigation.css` はブラウザのナビゲーション遷移を有効化するため、
+`styles/all.css` には含めません。独自ホストで MPA View Transitions を使う
+場合だけ import してください。ページ背景が `--octc-color-bg` 由来でない
+場合は `--ox-content-mpa-navigation-bg` を設定してください。
 
 これらのファイルはパッケージビルド時に `crates/ox_content_ssg` からコピー
 されます。組み込み SSG も同じソースを読むので、公式 chrome が独自ホスト向け

--- a/docs/content/ja/theming.md
+++ b/docs/content/ja/theming.md
@@ -23,6 +23,18 @@ defineTheme({
 
 外部リンク、ダウンロード、ハッシュのみのリンクは、普通のブラウザ挙動のままです。
 
+cross-document navigation にオプトインする独自ホストは、生の
+`@view-transition` ルールを書く代わりに共有ナビゲーション CSS を import
+してください。組み込み SSG と同じ overlay background fix を使い、
+`prefers-reduced-motion` の読者には通常のナビゲーションを残します。
+
+```css
+@import "@ox-content/vite-plugin/styles/mpa-navigation.css";
+```
+
+組み込みの `--octc-color-bg` token を使わないホストでは、
+`--ox-content-mpa-navigation-bg` にページ背景色を設定してください。
+
 ## テーマトグルの円形リビール
 
 `viewTransitions` は文書間の遷移の話です。テーマトグルは _同一文書内_ の変更で、既定では即座に切り替わります。読者が操作した位置から広がる円形のリビールにはオプトインします。

--- a/docs/content/theming.md
+++ b/docs/content/theming.md
@@ -33,6 +33,18 @@ defineTheme({
 
 External links, downloads, and hash-only links retain normal browser behavior.
 
+Custom hosts that opt into cross-document navigation should import the shared
+navigation stylesheet instead of writing a bare `@view-transition` rule. It
+uses the same overlay background fix as the built-in SSG and keeps reduced
+motion users on native navigation:
+
+```css
+@import "@ox-content/vite-plugin/styles/mpa-navigation.css";
+```
+
+If your host does not use the built-in `--octc-color-bg` token, set
+`--ox-content-mpa-navigation-bg` to your page background color.
+
 ## Theme Toggle Reveal
 
 `viewTransitions` covers navigation between documents. The theme toggle is a

--- a/npm/vite-plugin-ox-content/package.json
+++ b/npm/vite-plugin-ox-content/package.json
@@ -168,6 +168,7 @@
     "./styles/citations.css": "./dist/styles/citations.css",
     "./styles/not-by-ai.css": "./dist/styles/not-by-ai.css",
     "./styles/reader-chrome.css": "./dist/styles/reader-chrome.css",
+    "./styles/mpa-navigation.css": "./dist/styles/mpa-navigation.css",
     "./styles/theme-transition.css": "./dist/styles/theme-transition.css"
   },
   "publishConfig": {

--- a/npm/vite-plugin-ox-content/scripts/copy-component-styles.mjs
+++ b/npm/vite-plugin-ox-content/scripts/copy-component-styles.mjs
@@ -14,7 +14,7 @@ const packageRoot = dirname(fileURLToPath(new URL("../package.json", import.meta
 const ssgSrc = join(packageRoot, "../../crates/ox_content_ssg/src");
 const outDir = join(packageRoot, "dist/styles");
 
-/** @typedef {{ name: string, sources: string[] }} StyleEntry */
+/** @typedef {{ name: string, sources: string[], includeInAll?: boolean }} StyleEntry */
 
 /** Public feature stylesheets. Filenames are package API. */
 export const STYLE_ENTRIES = /** @type {const} */ ([
@@ -48,6 +48,7 @@ export const STYLE_ENTRIES = /** @type {const} */ ([
   { name: "citations.css", sources: ["plugins/citations.css"] },
   { name: "not-by-ai.css", sources: ["plugins/not-by-ai.css"] },
   { name: "reader-chrome.css", sources: ["html/reader_chrome.css"] },
+  { name: "mpa-navigation.css", sources: ["html/mpa_navigation.css"], includeInAll: false },
   { name: "theme-transition.css", sources: ["html/theme_transition.css"] },
 ]);
 
@@ -70,7 +71,9 @@ export function copyComponentStyles() {
     writeGenerated(entry.name, entry.sources.map(crateCss).join(""));
   }
 
-  const imports = STYLE_ENTRIES.map((entry) => `@import "./${entry.name}";`).join("\n");
+  const imports = STYLE_ENTRIES.filter((entry) => entry.includeInAll !== false)
+    .map((entry) => `@import "./${entry.name}";`)
+    .join("\n");
   writeGenerated(ALL_STYLESHEET, `${imports}\n`);
 
   return {

--- a/npm/vite-plugin-ox-content/src/published-styles.test.ts
+++ b/npm/vite-plugin-ox-content/src/published-styles.test.ts
@@ -24,8 +24,13 @@ const DOCUMENTED_STYLE_IMPORTS = [
   "citations.css",
   "not-by-ai.css",
   "reader-chrome.css",
+  "mpa-navigation.css",
   "all.css",
 ] as const;
+
+const ALL_STYLESHEET_IMPORTS = DOCUMENTED_STYLE_IMPORTS.filter(
+  (name) => name !== "all.css" && name !== "mpa-navigation.css",
+);
 
 const CRATE_SOURCES: Record<
   Exclude<(typeof DOCUMENTED_STYLE_IMPORTS)[number], "all.css">,
@@ -55,6 +60,7 @@ const CRATE_SOURCES: Record<
   "citations.css": ["plugins/citations.css"],
   "not-by-ai.css": ["plugins/not-by-ai.css"],
   "reader-chrome.css": ["html/reader_chrome.css"],
+  "mpa-navigation.css": ["html/mpa_navigation.css"],
 };
 
 function crateCss(relativePath: string): string {
@@ -144,9 +150,10 @@ describe("published component styles", () => {
       );
 
       const allCss = packedCss(tarball, "all.css");
-      for (const name of Object.keys(CRATE_SOURCES)) {
+      for (const name of ALL_STYLESHEET_IMPORTS) {
         expect(allCss).toContain(`@import "./${name}";`);
       }
+      expect(allCss).not.toContain('@import "./mpa-navigation.css";');
     } finally {
       cleanup();
     }


### PR DESCRIPTION
## Summary
- publish the built-in MPA navigation stylesheet as `@ox-content/vite-plugin/styles/mpa-navigation.css` for custom hosts
- keep it out of `styles/all.css` because it enables browser navigation transitions
- add `--ox-content-mpa-navigation-bg` with `--octc-color-bg` and `Canvas` fallbacks for stable transition overlays

## Testing
- `vp test --typecheck npm/vite-plugin-ox-content/src/published-styles.test.ts npm/vite-plugin-ox-content/src/theme-mpa-navigation.test.ts`
- `cargo test -p ox_content_ssg mpa_navigation`
- `cargo test -p ox_content_ssg --lib html::tests`
- `vp run workspace:fmt:check`
- `vp run check:file-lines`
- `vp run -F @ox-content/vite-plugin build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in stylesheet for cross-document View Transition navigation.
  * Added a configurable navigation background color with fallbacks to the standard page background and browser canvas color.
  * Excluded navigation styles from the bundled `all.css` stylesheet so they can be included independently.

* **Documentation**
  * Documented the new navigation stylesheet, opt-in usage, background customization, and reduced-motion behavior in English and Japanese guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->