### PR TITLE
perf(vite-plugin): cache repeated HTML minifier callbacks

### DIFF
--- a/npm/vite-plugin-ox-content/src/custom-host-build.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-build.ts
@@ -39,7 +39,7 @@ import {
   shouldTransformHtml,
   ssgUrlPath,
 } from "./custom-host-utils";
-import { minifyHtmlOutput } from "./html-minify";
+import { createHtmlMinifyContext, minifyHtmlOutput } from "./html-minify";
 import { writeRedirectOutputs } from "./redirect-outputs";
 import {
   planSsgOutputs,
@@ -201,6 +201,7 @@ async function writeCoordinatedOutputs(
   const rewrittenHtml = new Map(
     resources.pages.map((page) => [path.resolve(page.outputPath), page.html]),
   );
+  const htmlMinifyContext = createHtmlMinifyContext();
 
   await Promise.all(
     routes.map(async (entry) => {
@@ -208,7 +209,7 @@ async function writeCoordinatedOutputs(
         rewrittenHtml.get(path.resolve(entry.outputPath)) ?? entry.body;
       if (minifyHtml && isHtmlContentType(entry.contentType)) {
         const html = typeof body === "string" ? body : new TextDecoder().decode(body);
-        body = await minifyHtmlOutput(html);
+        body = await minifyHtmlOutput(html, htmlMinifyContext);
       }
       await fs.mkdir(path.dirname(entry.outputPath), { recursive: true });
       await fs.writeFile(entry.outputPath, body);

--- a/npm/vite-plugin-ox-content/src/html-minify.test.ts
+++ b/npm/vite-plugin-ox-content/src/html-minify.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { minifyHtmlOutput } from "./html-minify";
+import { createHtmlMinifyContext, minifyHtmlOutput } from "./html-minify";
 
 describe("minifyHtmlOutput", () => {
   it("minifies final HTML while preserving whitespace-sensitive content", async () => {
@@ -60,5 +60,25 @@ describe("minifyHtmlOutput", () => {
     await expect(
       minifyHtmlOutput("<!doctype html><script>function () {</script>"),
     ).rejects.toThrow();
+  });
+
+  it("reuses identical inline script and style minification within a build context", async () => {
+    const context = createHtmlMinifyContext();
+    const script = "const answer = 1 + 2; window.__answer = answer;";
+    const style = ".badge { color: red; margin: 0px; }";
+
+    const [first, second] = await Promise.all([
+      minifyHtmlOutput(`<style>${style}</style><script>${script}</script>`, context),
+      minifyHtmlOutput(`<main><style>${style}</style><script>${script}</script></main>`, context),
+    ]);
+
+    expect(first).toBe(
+      "<style>.badge{color:red;margin:0}</style><script>const answer=3;window.__answer=3</script>",
+    );
+    expect(second).toBe(
+      "<main><style>.badge{color:red;margin:0}</style><script>const answer=3;window.__answer=3</script></main>",
+    );
+    expect(context.scripts.size).toBe(1);
+    expect(context.styles.size).toBe(1);
   });
 });

--- a/npm/vite-plugin-ox-content/src/html-minify.ts
+++ b/npm/vite-plugin-ox-content/src/html-minify.ts
@@ -1,6 +1,8 @@
+import type { Options as HtmlMinifierOptions } from "html-minifier-terser";
+
 const HYDRATION_COMMENT = /^\s*[!/$#]/u;
 
-const HTML_MINIFY_OPTIONS = {
+const HTML_MINIFY_OPTIONS: HtmlMinifierOptions = {
   caseSensitive: true,
   collapseWhitespace: true,
   conservativeCollapse: true,
@@ -10,15 +12,64 @@ const HTML_MINIFY_OPTIONS = {
   removeComments: true,
   removeRedundantAttributes: true,
   useShortDoctype: true,
-} as const;
+};
+
+export interface HtmlMinifyContext {
+  scripts: Map<string, Promise<string>>;
+  styles: Map<string, Promise<string>>;
+}
 
 let cleanCssModule: Promise<typeof import("clean-css")> | undefined;
 let htmlMinifierModule: Promise<typeof import("html-minifier-terser")> | undefined;
 let terserModule: Promise<typeof import("terser")> | undefined;
 
-export async function minifyHtmlOutput(html: string): Promise<string> {
+export function createHtmlMinifyContext(): HtmlMinifyContext {
+  return {
+    scripts: new Map(),
+    styles: new Map(),
+  };
+}
+
+export async function minifyHtmlOutput(
+  html: string,
+  context: HtmlMinifyContext = createHtmlMinifyContext(),
+): Promise<string> {
   const { minify } = await loadHtmlMinifier();
-  return minify(html, HTML_MINIFY_OPTIONS);
+  return minify(html, optionsForContext(context));
+}
+
+function optionsForContext(context: HtmlMinifyContext): HtmlMinifierOptions {
+  return {
+    ...HTML_MINIFY_OPTIONS,
+    minifyCSS: (text, type) =>
+      cachedMinify(context.styles, cacheKey(type ?? "style", text), () => minifyCss(text, type)),
+    minifyJS: (text, inline) =>
+      cachedMinify(context.scripts, cacheKey(inline === true ? "inline" : "script", text), () =>
+        minifyJs(text, inline),
+      ),
+  };
+}
+
+function cachedMinify(
+  cache: Map<string, Promise<string>>,
+  key: string,
+  minify: () => Promise<string>,
+): Promise<string> {
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  const next = minify().catch((error: unknown) => {
+    if (cache.get(key) === next) {
+      cache.delete(key);
+    }
+    throw error;
+  });
+  cache.set(key, next);
+  return next;
+}
+
+function cacheKey(kind: string, text: string): string {
+  return `${kind}\0${text}`;
 }
 
 async function minifyJs(text: string, inline?: boolean): Promise<string> {

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -105,7 +105,7 @@ import {
   writeSnapshotSearchIndex,
 } from "./versions";
 import { PageResourceError, createResourceDedupeStore, processPageResources } from "./resources";
-import { minifyHtmlOutput } from "./html-minify";
+import { createHtmlMinifyContext, minifyHtmlOutput } from "./html-minify";
 import {
   createVersionNavigationContext,
   rewriteVersionedHeaderNavItems,
@@ -2317,9 +2317,13 @@ async function writeGeneratedPages(
     }
   }
 
+  const htmlMinifyContext = createHtmlMinifyContext();
+
   await Promise.all(
     optimizedOutput.pages.map(async (page) => {
-      const html = context.ssgOptions.minifyHtml ? await minifyHtmlOutput(page.html) : page.html;
+      const html = context.ssgOptions.minifyHtml
+        ? await minifyHtmlOutput(page.html, htmlMinifyContext)
+        : page.html;
       await fs.mkdir(path.dirname(page.outputPath), { recursive: true });
       await fs.writeFile(page.outputPath, html, "utf-8");
     }),


### PR DESCRIPTION
## Summary
- add a per-build HTML minification context for inline script/style callback results
- share that context across custom-host and SSG page writes
- cover repeated inline script/style reuse while preserving minified output

Fixes #1371.

Co-authored-by: ryoppippi <1560508+ryoppippi@users.noreply.github.com>

## Verification
- ./node_modules/.bin/vp test npm/vite-plugin-ox-content/src/html-minify.test.ts npm/vite-plugin-ox-content/src/ssg-html-minify.test.ts
- ./node_modules/.bin/vp test --typecheck npm/vite-plugin-ox-content/src/html-minify.test.ts npm/vite-plugin-ox-content/src/ssg-html-minify.test.ts
- ./node_modules/.bin/vp run --filter @ox-content/vite-plugin build
- node tools/scripts/check-file-lines.ts --base origin/main

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791518655&installation_model_id=422833&pr_number=1372&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1372&signature=ca372c20ac6ba9d61f851498c5b8201d8f3a71bc61a8d2530b1321585138b9eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved HTML generation efficiency by reusing cached minification results for identical inline scripts and styles during parallel page builds.
  * Reduced repeated CSS and JavaScript minification work when generating multiple pages.
* **Bug Fixes**
  * Improved consistency of HTML minification across concurrently generated routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->