### PR TITLE
fix(solid): skip embeds during html host island discovery

### DIFF
--- a/npm/vite-plugin-ox-content-solid/src/html-host-registry.test.ts
+++ b/npm/vite-plugin-ox-content-solid/src/html-host-registry.test.ts
@@ -77,6 +77,47 @@ describe("createSolidHtmlHostIslandRegistry", () => {
     );
   });
 
+  it("discovers islands without rendering built-in embeds", async () => {
+    const root = await createProject("ox-solid-html-discovery-embeds-");
+    const originalFetch = globalThis.fetch;
+    const fetchCalls: Parameters<typeof fetch>[0][] = [];
+    globalThis.fetch = (async (input) => {
+      fetchCalls.push(input);
+      throw new Error("registry discovery should not fetch embeds");
+    }) as typeof fetch;
+
+    try {
+      const result = await resolveSolidHtmlHostIslandRegistry(
+        {
+          root,
+          oxContent: {
+            embeds: { github: false, openGraph: { cache: false } },
+            mdx: true,
+          },
+          documents: [
+            {
+              documentPath: path.join(root, "content", "published.mdx"),
+              source: [
+                "import Probe from './published/Probe.tsx'",
+                "",
+                "<Probe />",
+                '<OgCard url="https://example.com/post" />',
+              ].join("\n"),
+            },
+          ],
+        },
+        { root, mode: "production", command: "build" },
+      );
+
+      expect(result.modules).toEqual([
+        { name: "Probe", moduleId: "/content/published/Probe.tsx", exportName: "default" },
+      ]);
+      expect(fetchCalls).toEqual([]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("builds a browser registry that includes reachable selected chunks only", async () => {
     const root = await createProject("ox-solid-html-build-");
     const registry = createSolidHtmlHostIslandRegistry({

--- a/npm/vite-plugin-ox-content-solid/src/html-host-registry.ts
+++ b/npm/vite-plugin-ox-content-solid/src/html-host-registry.ts
@@ -201,7 +201,7 @@ export async function resolveSolidHtmlHostIslandRegistry(
     if (entry.documentPath) watchFiles.add(resolveWatchFile(entry.documentPath, context.root));
   }
 
-  const oxContent = customHostOxContentOptions(input.oxContent ?? {});
+  const oxContent = customHostOxContentOptions({ ...(input.oxContent ?? {}), embeds: false });
   const srcDir = oxContent.srcDir ?? "content";
   const contentRoot = resolveContentRootPath({ root: context.root, srcDir });
   for (const document of documents) {


### PR DESCRIPTION
## Summary
- disable built-in embed rendering for Solid HTML host island discovery
- keep MDX import-based island discovery intact
- add a regression test that verifies Open Graph embed fetching is not reached

Fixes #1370.

Co-authored-by: ryoppippi <1560508+ryoppippi@users.noreply.github.com>

## Verification
- ./node_modules/.bin/vp test npm/vite-plugin-ox-content-solid/src/html-host-registry.test.ts npm/vite-plugin-ox-content-solid/src/html-host-collection-documents.test.ts
- ./node_modules/.bin/vp test --typecheck npm/vite-plugin-ox-content-solid/src/html-host-registry.test.ts npm/vite-plugin-ox-content-solid/src/html-host-collection-documents.test.ts
- ./node_modules/.bin/vp run --filter @ox-content/vite-plugin-solid typecheck
- ./node_modules/.bin/vp run --filter @ox-content/vite-plugin-solid build
- node tools/scripts/check-file-lines.ts --base origin/main

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791518658&installation_model_id=422833&pr_number=1373&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1373&signature=f4d93d6d3f369b322cfe1806d2803b20b58a1996ba0f699f778c48d5a799368b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Built-in embeds are no longer rendered by the content host, preventing unintended content fetches.
  - MDX-based interactive islands continue to be discovered and supported when configured.
- **Tests**
  - Added coverage to verify that embed fetching remains disabled while eligible islands are detected correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->