### PR TITLE
perf(renderer): stream heading attributes from reusable buffers

### DIFF
--- a/crates/ox_content_renderer/Cargo.toml
+++ b/crates/ox_content_renderer/Cargo.toml
@@ -40,3 +40,7 @@ criterion = { workspace = true }
 [[bench]]
 name = "renderer"
 harness = false
+
+[[bench]]
+name = "headings"
+harness = false

--- a/crates/ox_content_renderer/benches/headings.rs
+++ b/crates/ox_content_renderer/benches/headings.rs
@@ -1,0 +1,42 @@
+//! Heading output workloads, with parsing outside the measured region.
+
+use std::fmt::Write as _;
+use std::hint::black_box;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use ox_content_allocator::Allocator;
+use ox_content_parser::Parser;
+use ox_content_renderer::{HtmlRenderer, HtmlRendererOptions};
+
+fn bench_headings(c: &mut Criterion) {
+    let mut group = c.benchmark_group("headings");
+    for (name, title) in [
+        ("ascii", "API reference"),
+        ("unicode", "日本語の見出しと設定ガイド"),
+        ("long", "An extended API reference heading describing configuration and options"),
+    ] {
+        let mut source = String::new();
+        for index in 0..512 {
+            writeln!(source, "## {title} {index}\n").unwrap();
+        }
+        let allocator = Allocator::for_source_len(source.len());
+        let document = Parser::new(&allocator, &source).parse().unwrap();
+        group.throughput(Throughput::Bytes(source.len() as u64));
+        for permalinks in [false, true] {
+            let case = format!("{name}/permalinks_{permalinks}");
+            group.bench_function(case, |b| {
+                b.iter(|| {
+                    let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
+                        heading_permalinks: permalinks,
+                        ..Default::default()
+                    });
+                    black_box(renderer.render(black_box(&document)));
+                });
+            });
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_headings);
+criterion_main!(benches);

--- a/crates/ox_content_renderer/src/html/escape.rs
+++ b/crates/ox_content_renderer/src/html/escape.rs
@@ -271,5 +271,20 @@ pub(super) fn write_url_escaped_into(out: &mut String, s: &str) {
     escape_into(out, s, url_escape_mask, &URL_ESCAPE_FLAG, &URL_ESCAPE_TABLE, &URL_ESCAPE_NIBBLES);
 }
 
+/// Escapes attribute values, including line endings, directly into the output.
+/// Separate field borrows let heading IDs stay in their reusable scratch buffer.
+pub(super) fn write_attribute_escaped_into(out: &mut String, s: &str) {
+    // Attribute escaping differs from text escaping only at CR/LF. Split
+    // at those ASCII boundaries and reuse the vectorized text escaper for
+    // whole runs, preserving UTF-8 without decoding and pushing each char.
+    let mut start = 0;
+    for index in memchr::memchr2_iter(b'\r', b'\n', s.as_bytes()) {
+        write_escaped_into(out, &s[start..index]);
+        out.push_str(if s.as_bytes()[index] == b'\r' { "&#13;" } else { "&#10;" });
+        start = index + 1;
+    }
+    write_escaped_into(out, &s[start..]);
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/ox_content_renderer/src/html/escape/tests.rs
+++ b/crates/ox_content_renderer/src/html/escape/tests.rs
@@ -27,6 +27,23 @@ fn check(s: &str) {
     let mut url = String::new();
     write_url_escaped_into(&mut url, s);
     assert_eq!(url, reference(s, &URL_ESCAPE_FLAG, &URL_ESCAPE_TABLE), "url escape: {s:?}");
+
+    let mut attributes = String::from("prefix:");
+    let mut expected = attributes.clone();
+    for ch in s.chars() {
+        match ch {
+            '&' => expected.push_str("&amp;"),
+            '<' => expected.push_str("&lt;"),
+            '>' => expected.push_str("&gt;"),
+            '"' => expected.push_str("&quot;"),
+            '\'' => expected.push_str("&#39;"),
+            '\r' => expected.push_str("&#13;"),
+            '\n' => expected.push_str("&#10;"),
+            _ => expected.push(ch),
+        }
+    }
+    write_attribute_escaped_into(&mut attributes, s);
+    assert_eq!(attributes, expected, "attribute escape: {s:?}");
 }
 
 #[test]
@@ -48,6 +65,9 @@ fn matches_reference_on_fixtures() {
         // the ones a sloppy fold would leak: 0x21 0x23 0x25 0x3D 0x3F.
         "!#%=?",
         "!#%=? &<>\"' !#%=?",
+        "\r\n",
+        "\n\r\r\n\n",
+        "日本語\r\n<&>\"'\n🙂\r",
     ] {
         check(case);
     }
@@ -117,7 +137,7 @@ fn matches_reference_on_pseudorandom_bytes() {
     // xorshift over the printable-plus-needles range; deterministic so a
     // failure is reproducible.
     let mut state = 0x2545_F491_4F6C_DD1Du64;
-    let alphabet: Vec<u8> = (0x20u8..0x7f).chain(*b"&<>\"' ").collect();
+    let alphabet: Vec<u8> = (0x20u8..0x7f).chain(*b"&<>\"' \r\n").collect();
     for len in 0..200 {
         let mut s = String::with_capacity(len);
         for _ in 0..len {

--- a/crates/ox_content_renderer/src/html/renderer/write.rs
+++ b/crates/ox_content_renderer/src/html/renderer/write.rs
@@ -10,7 +10,9 @@ use compact_str::CompactString;
 use ox_content_ast::{Heading, Node, Span};
 
 use super::super::autolink::find_autolink_match;
-use super::super::escape::{write_escaped_into, write_url_escaped_into};
+use super::super::escape::{
+    write_attribute_escaped_into, write_escaped_into, write_url_escaped_into,
+};
 use super::super::heading::{
     HEADING_PERMALINK_CLASS, collect_heading_text_into, heading_has_permalink_marker,
     slugify_heading_into,
@@ -34,18 +36,7 @@ impl HtmlRenderer {
     }
 
     pub(in crate::html::renderer) fn write_attribute_escaped(&mut self, s: &str) {
-        for ch in s.chars() {
-            match ch {
-                '&' => self.output.push_str("&amp;"),
-                '<' => self.output.push_str("&lt;"),
-                '>' => self.output.push_str("&gt;"),
-                '"' => self.output.push_str("&quot;"),
-                '\'' => self.output.push_str("&#39;"),
-                '\n' => self.output.push_str("&#10;"),
-                '\r' => self.output.push_str("&#13;"),
-                _ => self.output.push(ch),
-            }
-        }
+        write_attribute_escaped_into(&mut self.output, s);
     }
 
     pub(in crate::html::renderer) fn write_source_span_attr(&mut self, span: Span) {
@@ -223,8 +214,7 @@ impl HtmlRenderer {
     pub(in crate::html::renderer) fn write_heading_id(&mut self, heading: &Heading<'_>) {
         crate::profile_span!("renderer::write_heading_id");
         self.prepare_heading_id(heading);
-        let id = self.heading_id_scratch.clone();
-        self.write_attribute_escaped(&id);
+        write_attribute_escaped_into(&mut self.output, &self.heading_id_scratch);
     }
 
     pub(in crate::html::renderer) fn write_heading_permalink_if_needed(
@@ -240,8 +230,7 @@ impl HtmlRenderer {
         self.output.push_str("<a class=\"");
         self.output.push_str(HEADING_PERMALINK_CLASS);
         self.output.push_str("\" href=\"#");
-        let id = self.heading_id_scratch.clone();
-        self.write_attribute_escaped(&id);
+        write_attribute_escaped_into(&mut self.output, &self.heading_id_scratch);
         if self.heading_text_scratch.is_empty() {
             self.output.push_str("\" aria-label=\"Permalink to this section\">#</a>");
             return;

--- a/crates/ox_content_renderer/tests/edge_heading_buffers.rs
+++ b/crates/ox_content_renderer/tests/edge_heading_buffers.rs
@@ -1,0 +1,52 @@
+use ox_content_allocator::Allocator;
+use ox_content_ast::Node;
+use ox_content_parser::Parser;
+use ox_content_renderer::{HtmlRenderer, HtmlRendererOptions};
+
+#[test]
+fn explicit_heading_ids_escape_identically_in_ids_and_permalinks() {
+    let allocator = Allocator::new();
+    let mut document = Parser::new(&allocator, "## Title").parse().unwrap();
+    let Node::Heading(heading) = &mut document.children[0] else {
+        panic!("expected heading");
+    };
+    heading.id = Some("日本語<&>\"'\r\n");
+    let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
+        heading_permalinks: true,
+        ..Default::default()
+    });
+    let expected = concat!(
+        "<h2 id=\"日本語&lt;&amp;&gt;&quot;&#39;&#13;&#10;\">Title",
+        "<a class=\"header-anchor\" href=\"#日本語&lt;&amp;&gt;&quot;&#39;&#13;&#10;\" ",
+        "aria-label=\"Permalink to &quot;Title&quot;\">#</a></h2>\n"
+    );
+    assert_eq!(renderer.render_borrowed(&document), expected);
+    assert_eq!(renderer.render(&document), expected);
+}
+
+#[test]
+fn heading_buffers_do_not_leak_long_ids_or_duplicate_counts_across_renders() {
+    let allocator = Allocator::new();
+    let long_title = "日本語の長い見出し".repeat(64);
+    let long_source = format!("## {long_title}\n\n## {long_title}");
+    let long_document = Parser::new(&allocator, &long_source).parse().unwrap();
+    let short_document = Parser::new(&allocator, "## A\n\n## A").parse().unwrap();
+    let empty_document = Parser::new(&allocator, "").parse().unwrap();
+    let options = HtmlRendererOptions { heading_permalinks: true, ..Default::default() };
+    let mut renderer = HtmlRenderer::with_options(options.clone());
+    let expected = concat!(
+        "<h2 id=\"a\">A<a class=\"header-anchor\" href=\"#a\" ",
+        "aria-label=\"Permalink to &quot;A&quot;\">#</a></h2>\n",
+        "<h2 id=\"a-1\">A<a class=\"header-anchor\" href=\"#a-1\" ",
+        "aria-label=\"Permalink to &quot;A&quot;\">#</a></h2>\n"
+    );
+    for _ in 0..3 {
+        assert_eq!(
+            renderer.render_borrowed(&long_document),
+            HtmlRenderer::with_options(options.clone()).render(&long_document)
+        );
+        assert_eq!(renderer.render_borrowed(&short_document), expected);
+        assert_eq!(renderer.render_borrowed(&empty_document), "");
+        assert_eq!(renderer.render(&short_document), expected);
+    }
+}


### PR DESCRIPTION
## Summary

Render heading IDs and permalinks directly from the reusable ID buffer, removing one allocation per heading (two with permalinks). Attribute output now reuses the existing vectorized HTML escaper between CR/LF boundaries instead of decoding and pushing every character. Output and newline escaping stay unchanged.

Add heading-heavy Criterion workloads and differential attribute coverage over all byte values, vector/copy boundaries, CR/LF, and Unicode. Add explicit-ID and renderer-reuse regressions.

## Measurements

Base: `f3f442e42a26466015d82c63b46b76d7db91ef89`; head: `092e621f492395152db503a04fc7dab04f749298`. Local Apple M5 Pro, arm64, Rust 1.98.0, production-aligned bench profile, identical 512-heading inputs; parsing excluded. Criterion: 1 s warmup, 2 s measurement, 50 samples. Median time in microseconds; these are focused workloads, not whole-site claims.

| Workload | Base µs | Head µs | Time change |
| --- | ---: | ---: | ---: |
| ascii_permalinks_false | 52.32 | 24.37 | -53.4% |
| ascii_permalinks_true | 97.15 | 29.55 | -69.6% |
| long_permalinks_false | 161.61 | 57.69 | -64.3% |
| long_permalinks_true | 245.20 | 68.85 | -71.9% |
| unicode_permalinks_false | 196.06 | 93.40 | -52.4% |
| unicode_permalinks_true | 250.58 | 102.03 | -59.3% |

Reproduce with `cargo bench -p ox_content_renderer --bench headings -- --warm-up-time 1 --measurement-time 2 --sample-size 50 --save-baseline original` on the base with the same benchmark file, then `--baseline original` on this branch.

The API-document counting allocator reports **26 → 17 allocations per pipeline iteration** (100 iterations after 5 warmups); heading-ID spans allocate **9 → 0** times per document. The small mixed-document controls also improve with the final implementation.

## CI measurement follow-up

Attempt 1 on Blacksmith (`34343947377`, base `f3f442e`, head `092e621`, Node 26.8.1, AMD EPYC 32 cores) failed on a single large parse-only NAPI row: **0.218 → 0.363 ms (-39.89% throughput)**. This PR changes renderer output, not parser or NAPI parse-only code. Adjacent parse-only sizes were small 420,221 → 417,068 ops/s (-0.75%), medium 58,161 → 56,099 (-3.55%), and huge 233 → 250 (+7.30%). The unchanged md4x NAPI huge parse row also moved 42 → 32 ops/s (-23.81%). The changed parse+render large row was 0.190 → 0.195 ms (-2.55%), within the gate's noise band; all absolute budgets and bundle gates passed.

These inconsistent size/control deltas justify **one** rerun of the same base/head pair. The failed result is retained here and in the workflow logs; no threshold or override label is changed. Attempt 2 completed successfully on the same pair: large parse-only **0.202 → 0.194 ms (+4.37% throughput)**, parse+render **0.173 → 0.175 ms (-1.26%)**, and async **0.207 → 0.197 ms (+4.94%)**. All relative and absolute gates passed. No further rerun was performed.

## Risk

- Risk level: low. Attribute escaping is checked against the prior character-based implementation, including all seven replacements and append semantics.
- Rollback: revert this commit. No API, dependency, or configuration changes.

## Validation

- [x] Focused release-profile heading benchmarks completed.
- [x] Differential regression coverage added for attribute escapes and reusable heading buffers.
- [x] `cargo test -p ox_content_parser -p ox_content_renderer`: 596 passed, zero failures (including doctests).
- [x] Targeted all-targets Clippy with `-D warnings`, formatting, panic-construct gate, and file-line gate passed.
- [x] Exact-head CI and Linux runtime/bundle comparison completed successfully ([run 34343947377, attempt 2](https://github.com/ubugeeei-prod/ox-content/actions/runs/34343947377/attempts/2)); merged-main CI also passed.

- [x] 220 individual documents × 4 GFM/permalink configurations: 880 HTML outputs byte-identical between the original base and combined head; fresh and reused renderers also match.

## Release and docs checklist

- [x] Internal comments and reproducible benchmarks updated; public behavior and documentation unchanged.
- [x] No configuration, migration, observability, privacy, or dependency changes.
