### PR TITLE
perf(parser): reserve table cells to the exact column count

### DIFF
--- a/crates/ox_content_parser/Cargo.toml
+++ b/crates/ox_content_parser/Cargo.toml
@@ -49,3 +49,7 @@ harness = false
 [[bench]]
 name = "prepass"
 harness = false
+
+[[bench]]
+name = "tables"
+harness = false

--- a/crates/ox_content_parser/benches/tables.rs
+++ b/crates/ox_content_parser/benches/tables.rs
@@ -1,0 +1,42 @@
+//! GFM table allocation workloads. Header width determines every row's size.
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use ox_content_allocator::Allocator;
+use ox_content_parser::{Parser, ParserOptions};
+
+fn bench_tables(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parse_tables");
+    for columns in [1, 2, 4, 8, 16, 32] {
+        for (name, cell) in [("plain", "value"), ("inline", "**value** with `code`")] {
+            let mut source = "| heading ".repeat(columns);
+            source.push_str("|\n");
+            source.push_str(&"| --- ".repeat(columns));
+            source.push_str("|\n");
+            for _ in 0..128 {
+                for _ in 0..columns {
+                    source.push_str("| ");
+                    source.push_str(cell);
+                    source.push(' ');
+                }
+                source.push_str("|\n");
+            }
+            group.throughput(Throughput::Bytes(source.len() as u64));
+            group.bench_with_input(BenchmarkId::new(name, columns), &source, |b, source| {
+                b.iter(|| {
+                    let allocator = Allocator::for_source_len(source.len());
+                    black_box(
+                        Parser::with_options(&allocator, black_box(source), ParserOptions::gfm())
+                            .parse()
+                            .unwrap(),
+                    );
+                });
+            });
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_tables);
+criterion_main!(benches);

--- a/crates/ox_content_parser/src/parser/table.rs
+++ b/crates/ox_content_parser/src/parser/table.rs
@@ -118,7 +118,11 @@ impl<'a> Parser<'a> {
         column_count: usize,
     ) -> ParseResult<TableRow<'a>> {
         profile_span_detail!("parser::table_row");
-        let mut cells: Vec<'a, TableCell<'a>> = self.allocator.new_vec();
+        // Every row is truncated or padded to the delimiter's exact width.
+        // Reserve it before parsing inline children: those arena allocations
+        // otherwise prevent the cell vector from growing in place, leaving
+        // each discarded backing buffer live until the arena is dropped.
+        let mut cells: Vec<'a, TableCell<'a>> = self.allocator.new_vec_with_capacity(column_count);
         let line_end = line_start + line.len();
         for (cell_content, cell_start, cell_end) in
             Self::table_row_cells_with_offsets(line).take(column_count)


### PR DESCRIPTION
## Summary

Reserve each GFM table row to the delimiter row's known column count before parsing inline children. Rows already pad/truncate to exactly this width. Growing a row between inline arena allocations previously copied cells into new backing buffers and kept the discarded buffers alive until arena teardown.

Add a Criterion matrix covering 1/2/4/8/16/32 columns and plain/inline-rich cells (128 body rows).

## Measurements

Base: `f3f442e42a26466015d82c63b46b76d7db91ef89`. Apple M5 Pro, arm64, Rust 1.98.0, production-aligned bench profile. Inputs and compiler settings are identical; parsing includes a fresh allocator.

The first 50-sample run showed mixed deltas, including an inline/16 slowdown. Unchanged list controls also moved by 6–9%, so this host is noisy. Retained base/head executables were then run in **base → head → head → base** order, without concurrent builds. Below are per-run medians (µs) and the change between the average base/head medians. These are local workload measurements, not a whole-parser speedup claim; the Linux CI gate remains required.

| Workload | Base 1 | Head 1 | Head 2 | Base 2 | Time change |
| --- | ---: | ---: | ---: | ---: | ---: |
| parse_tables/inline/16 | 209.56 | 188.45 | 211.06 | 232.06 | -9.5% |
| parse_tables/inline/32 | 385.10 | 395.75 | 497.92 | 526.27 | -1.9% |
| parse_tables/inline/8 | 103.80 | 90.43 | 113.56 | 130.10 | -12.8% |
| parse_tables/plain/16 | 62.75 | 58.80 | 76.72 | 76.04 | -2.4% |
| parse_tables/plain/32 | 123.17 | 122.39 | 121.94 | 152.04 | -11.2% |
| parse_tables/plain/8 | 30.58 | 31.42 | 32.91 | 37.35 | -5.3% |

Reproduce: `cargo bench -p ox_content_parser --bench tables -- --warm-up-time 1 --measurement-time 2 --sample-size 50 --save-baseline tables-original` on base with this benchmark file, then `--baseline tables-original` on head. The interleaved check used 0.5 s warmup, 1 s measurement and 30 samples per retained executable.

## Risk

- Low: only initial arena-vector capacity changes. Cell count, padding, truncation, escaping, and source spans use the existing paths.
- Rollback: revert the commit. No API, dependency, or option changes.

## Validation

- [x] Parser and renderer suites: 594 tests passed, zero failures (including doctests).
- [x] All-targets Clippy with warnings denied, formatting, panic-construct and source-line gates passed.
- [x] Table matrix and unchanged simple-document/list controls measured.
- [x] Exact-head CI and Linux runtime/bundle comparison passed for `4ec2223` ([run 34344803148](https://github.com/ubugeeei-prod/ox-content/actions/runs/34344803148)); merged main CI `50c9227c` also passed. Linux large-input throughput changed by -4.12% parse-only and -4.79% parse+render, within the documented noise band; no runtime or size budget violations.

## Release and docs checklist

- [x] Internal allocation rationale and reproducible benchmarks documented.
- [x] No public API, configuration, dependency, observability, or security changes.
