### PR TITLE
fix(vite-plugin): serve published assets during failed replans

### DIFF
--- a/npm/vite-plugin-ox-content/src/custom-host-collection-assets.test.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-collection-assets.test.ts
@@ -1,0 +1,98 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import type { ViteDevServer } from "vite";
+import type { CollectionAssetManifest } from "./collection-assets";
+import { createCustomHostCollectionAssetsDevController } from "./custom-host-collection-assets";
+import type { OxContentCustomHostBaseContext } from "./custom-host-types";
+
+afterEach(() => vi.restoreAllMocks());
+
+function setup(load: () => Promise<CollectionAssetManifest>) {
+  const root = process.cwd();
+  const onReplanned = vi.fn();
+  const controller = createCustomHostCollectionAssetsDevController({
+    server: { watcher: { add: vi.fn(), unwatch: vi.fn() } } as unknown as ViteDevServer,
+    context: { root, base: "/" } as OxContentCustomHostBaseContext,
+    options: {
+      manifest: load,
+      watch: [{ path: "content", kind: "directory" }],
+      ownedPrefixes: ["/assets/content"],
+    },
+    beforeReplan: vi.fn(),
+    onReplanned,
+  })!;
+  return { controller, onReplanned, changed: path.join(root, "content", "asset.txt") };
+}
+
+describe("custom host collection asset snapshot reads", () => {
+  it("serves the published manifest immediately while a refresh is pending", async () => {
+    const first: CollectionAssetManifest = { assets: [] };
+    const second: CollectionAssetManifest = { assets: [] };
+    const refresh = Promise.withResolvers<CollectionAssetManifest>();
+    const load = vi.fn().mockResolvedValueOnce(first).mockReturnValueOnce(refresh.promise);
+    const { controller, changed, onReplanned } = setup(load);
+    await expect(controller.manifest()).resolves.toBe(first);
+    controller.invalidate(changed);
+
+    const received: CollectionAssetManifest[] = [];
+    const read = controller.manifest().then((value) => received.push(value!));
+    try {
+      await Promise.resolve();
+      expect(received).toEqual([first]);
+    } finally {
+      refresh.resolve(second);
+      await read;
+      await vi.waitFor(() => expect(onReplanned).toHaveBeenCalledOnce());
+      controller.close();
+    }
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("retains a failed refresh for manifest and middleware reads without retrying per request", async () => {
+    const first: CollectionAssetManifest = { assets: [] };
+    const recovered: CollectionAssetManifest = { assets: [] };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const load = vi
+      .fn()
+      .mockResolvedValueOnce(first)
+      .mockRejectedValueOnce(new Error("refresh failed"))
+      .mockResolvedValueOnce(recovered);
+    const { controller, changed, onReplanned } = setup(load);
+    await controller.manifest();
+    controller.invalidate(changed);
+    await vi.waitFor(() => expect(warn).toHaveBeenCalledOnce());
+
+    for (let request = 0; request < 3; request += 1) {
+      await expect(controller.manifest()).resolves.toBe(first);
+      const next = vi.fn();
+      await controller.middleware(
+        { method: "GET", url: "/page" } as IncomingMessage,
+        {} as ServerResponse,
+        next,
+      );
+      expect(next).toHaveBeenCalledExactlyOnceWith();
+    }
+    expect(load).toHaveBeenCalledTimes(2);
+    expect(onReplanned).not.toHaveBeenCalled();
+
+    controller.invalidate(changed);
+    await vi.waitFor(() => expect(onReplanned).toHaveBeenCalledOnce());
+    await expect(controller.manifest()).resolves.toBe(recovered);
+    expect(load).toHaveBeenCalledTimes(3);
+    controller.close();
+  });
+
+  it("propagates cold-load failures and retries when no successful snapshot exists", async () => {
+    const recovered: CollectionAssetManifest = { assets: [] };
+    const load = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("cold failure"))
+      .mockResolvedValue(recovered);
+    const { controller } = setup(load);
+    await expect(controller.manifest()).rejects.toThrow("cold failure");
+    await expect(controller.manifest()).resolves.toBe(recovered);
+    expect(load).toHaveBeenCalledTimes(2);
+    controller.close();
+  });
+});

--- a/npm/vite-plugin-ox-content/src/custom-host-collection-assets.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-collection-assets.ts
@@ -97,7 +97,9 @@ export function createCustomHostCollectionAssetsDevController(input: {
 
   return {
     async manifest() {
-      return (await loadSnapshot()).manifest;
+      // A watcher-triggered refresh publishes atomically through `apply`.
+      // Keep serving the last successful generation while it runs or fails.
+      return snapshot?.manifest ?? (await loadSnapshot()).manifest;
     },
     middleware: async (req, res, next) => {
       if (req.method !== "GET" && req.method !== "HEAD") {
@@ -111,7 +113,7 @@ export function createCustomHostCollectionAssetsDevController(input: {
       }
 
       try {
-        const current = await loadSnapshot();
+        const current = snapshot ?? (await loadSnapshot());
         await serveCollectionAsset(current, publicPath, req, res, next);
       } catch (error) {
         next(error);


### PR DESCRIPTION
## Summary

After a custom host has published an asset manifest, a slow or failed watcher replan must keep serving that successful generation. Previously both route manifest reads and the asset middleware awaited the pending plan; after a failure, each request could retry it and return HTTP 500. This caused the existing collection-assets integration test to fail in #1378 CI.

Read the last published snapshot directly while the watcher refreshes in the background. A successful generation still replaces it atomically and invalidates routes; initial-load failures still propagate and retry normally.

## Risk

- Low: requests may use the last successful manifest while the next one is being planned, matching the existing failure/recovery contract.
- Rollback: revert this commit. No API or configuration changes.

## Validation

- [x] Two deterministic controller regressions fail on current main and pass with the fix: a read completes while a controlled refresh promise is still pending, and repeated reads after a failed refresh do not invoke the loader again.
- [x] Cold-load error/retry and later successful watcher recovery covered.
- [x] Controller, collection-manifest integration, and dev-lifecycle suites: 8 tests passed across 3 files.
- [x] Formatting, source-line limit, and diff whitespace checks passed.
- [x] Exact-head CI and bundle benchmark passed before merge ([CI 34344948859](https://github.com/ubugeeei-prod/ox-content/actions/runs/34344948859), [benchmark 34344948822](https://github.com/ubugeeei-prod/ox-content/actions/runs/34344948822)); merged-main CI also passed.

## Release and docs checklist

- [x] Internal comment documents the published-generation read rule.
- [x] No public API, configuration, dependency, privacy, or observability changes.
