### PR TITLE
perf(parser): skip long table cell runs with memchr

### DIFF
--- a/crates/ox_content_parser/Cargo.toml
+++ b/crates/ox_content_parser/Cargo.toml
@@ -52,7 +52,7 @@ harness = false
 
 [[bench]]
 name = "tables"
- harness = false
+harness = false
 
 [[bench]]
 name = "table_pipes"

--- a/crates/ox_content_parser/Cargo.toml
+++ b/crates/ox_content_parser/Cargo.toml
@@ -52,4 +52,8 @@ harness = false
 
 [[bench]]
 name = "tables"
+ harness = false
+
+[[bench]]
+name = "table_pipes"
 harness = false

--- a/crates/ox_content_parser/benches/table_pipes.rs
+++ b/crates/ox_content_parser/benches/table_pipes.rs
@@ -1,0 +1,44 @@
+//! Long table cells with and without escaped pipes.
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use ox_content_allocator::Allocator;
+use ox_content_parser::{Parser, ParserOptions};
+
+fn bench_table_pipes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parse_table_pipes");
+    for size in [8, 32, 128, 512] {
+        for escaped in [false, true] {
+            let mut cell = "x".repeat(size);
+            if escaped {
+                cell.push_str(" \\| 日本語");
+            }
+            let mut source = String::from("| A | B | C | D |\n| --- | --- | --- | --- |\n");
+            for _ in 0..128 {
+                for _ in 0..4 {
+                    source.push_str("| ");
+                    source.push_str(&cell);
+                    source.push(' ');
+                }
+                source.push_str("|\n");
+            }
+            let kind = if escaped { "escaped" } else { "plain" };
+            group.throughput(Throughput::Bytes(source.len() as u64));
+            group.bench_with_input(BenchmarkId::new(kind, size), &source, |b, source| {
+                b.iter(|| {
+                    let allocator = Allocator::for_source_len(source.len());
+                    black_box(
+                        Parser::with_options(&allocator, black_box(source), ParserOptions::gfm())
+                            .parse()
+                            .unwrap(),
+                    );
+                });
+            });
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_table_pipes);
+criterion_main!(benches);

--- a/crates/ox_content_parser/src/parser/table_cell_source.rs
+++ b/crates/ox_content_parser/src/parser/table_cell_source.rs
@@ -20,9 +20,7 @@ pub(super) fn unescape_table_pipes<'a>(
     // Most cells contain no pipe at all. Search only actual pipe positions
     // instead of examining every byte, then reuse the first escaped match
     // when constructing the remapped source below.
-    let Some(first_pipe) =
-        memchr::memchr_iter(b'|', bytes).find(|&index| is_escaped_table_pipe(bytes, index))
-    else {
+    let Some(first_pipe) = escaped_pipe_scan_start(bytes) else {
         return TableCellContent { content, source_offsets: None };
     };
 
@@ -55,6 +53,20 @@ pub(super) fn unescape_table_pipes<'a>(
         &mut source_offsets,
     );
     TableCellContent { content: unescaped.into_bump_str(), source_offsets: Some(source_offsets) }
+}
+
+#[inline]
+fn escaped_pipe_scan_start(bytes: &[u8]) -> Option<usize> {
+    // Vector dispatch costs more than the scan for short labels. Keep the
+    // scalar path there; long prose cells benefit from skipping whole runs.
+    if bytes.len() < 64 {
+        return bytes
+            .iter()
+            .enumerate()
+            .any(|(index, &byte)| byte == b'|' && is_escaped_table_pipe(bytes, index))
+            .then_some(0);
+    }
+    memchr::memchr_iter(b'|', bytes).find(|&index| is_escaped_table_pipe(bytes, index))
 }
 
 fn push_mapped_table_cell_slice(
@@ -196,3 +208,6 @@ fn table_cell_boundary_offset(index: usize, offsets: &[u32]) -> u32 {
 pub(super) fn is_escaped_table_pipe(bytes: &[u8], pipe: usize) -> bool {
     bytes[..pipe].iter().rev().take_while(|&&byte| byte == b'\\').count() % 2 == 1
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/ox_content_parser/src/parser/table_cell_source.rs
+++ b/crates/ox_content_parser/src/parser/table_cell_source.rs
@@ -17,19 +17,20 @@ pub(super) fn unescape_table_pipes<'a>(
     content: &'a str,
 ) -> TableCellContent<'a> {
     let bytes = content.as_bytes();
-    if !bytes
-        .iter()
-        .enumerate()
-        .any(|(index, &byte)| byte == b'|' && is_escaped_table_pipe(bytes, index))
-    {
+    // Most cells contain no pipe at all. Search only actual pipe positions
+    // instead of examining every byte, then reuse the first escaped match
+    // when constructing the remapped source below.
+    let Some(first_pipe) =
+        memchr::memchr_iter(b'|', bytes).find(|&index| is_escaped_table_pipe(bytes, index))
+    else {
         return TableCellContent { content, source_offsets: None };
-    }
+    };
 
     let mut unescaped =
         ox_content_allocator::String::with_capacity_in(content.len(), allocator.bump());
     let mut source_offsets: Vec<'a, u32> = allocator.new_vec();
     let mut copied_through = 0;
-    let mut search_start = 0;
+    let mut search_start = first_pipe;
     while let Some(relative) = memchr(b'|', &bytes[search_start..]) {
         let pipe = search_start + relative;
         if is_escaped_table_pipe(bytes, pipe) {

--- a/crates/ox_content_parser/src/parser/table_cell_source/tests.rs
+++ b/crates/ox_content_parser/src/parser/table_cell_source/tests.rs
@@ -1,0 +1,44 @@
+// Test fixtures deliberately use owned formatting outside parser hot paths.
+#![allow(clippy::disallowed_macros)]
+
+use super::{escaped_pipe_scan_start, is_escaped_table_pipe, unescape_table_pipes};
+use ox_content_allocator::Allocator;
+
+#[test]
+fn pipe_candidates_match_scalar_scan_across_length_and_escape_boundaries() {
+    for prefix_len in 0..=128 {
+        for backslashes in 0..=5 {
+            for suffix in ["", "|", " \\| end", " 日本語 \\| 🙂"] {
+                let source =
+                    format!("{}{}|{suffix}", "x".repeat(prefix_len), "\\".repeat(backslashes));
+                let bytes = source.as_bytes();
+                let expected = bytes.iter().enumerate().find_map(|(index, &byte)| {
+                    (byte == b'|' && is_escaped_table_pipe(bytes, index)).then_some(index)
+                });
+                let scan_start = escaped_pipe_scan_start(bytes);
+                assert_eq!(scan_start.is_some(), expected.is_some(), "{source:?}");
+                if let (Some(start), Some(first)) = (scan_start, expected) {
+                    assert!(start <= first, "must not skip the first escaped pipe: {source:?}");
+                }
+            }
+        }
+        assert_eq!(escaped_pipe_scan_start("x".repeat(prefix_len).as_bytes()), None);
+    }
+}
+
+#[test]
+fn skipped_unescaped_pipes_keep_content_and_source_offsets() {
+    for prefix_len in [0, 8, 31, 63, 64, 65, 128] {
+        let prefix = "x".repeat(prefix_len);
+        let source = format!("{prefix}|日本語\\|end");
+        let allocator = Allocator::new();
+        let result = unescape_table_pipes(&allocator, &source);
+        assert_eq!(result.content, format!("{prefix}|日本語|end"));
+        let offsets = result.source_offsets.unwrap();
+        assert_eq!(offsets.len(), result.content.len() + 1);
+        let removed_at = prefix_len + "|日本語".len();
+        for (index, offset) in offsets.iter().enumerate() {
+            assert_eq!(*offset as usize, index + usize::from(index > removed_at));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Skip directly to escaped-pipe candidates in long GFM table cells instead of examining every byte. Reuse the first candidate when constructing the existing unescape/source-offset mapping. Keep the previous scalar probe below 64 bytes, where vector setup can cost more than the skipped work.

Add full-parser Criterion workloads for 8/32/128/512-character cells with and without escaped pipes, plus differential candidate and source-offset tests across the short/long boundary, slash parity, earlier unescaped pipes, and Unicode.

## Measurements

Base production tree: `50c9227c2eaefd616d46e8761bb4e1725b5fd393` (including #1378–#1380). Head: `70e5b8d6` (also verified against the byte-identical combined validation tree). Apple M5 Pro arm64, Rust 1.98.0, production-aligned bench profile. Each document has 128 rows × 4 cells and uses GFM with a fresh allocator. Same benchmark file on both trees; 1 s warmup, 2 s measurement, 50 samples. Median microseconds measure the complete parse.

| Cell workload | Base µs | Head µs | Time change |
| --- | ---: | ---: | ---: |
| escaped/128 | 150.10 | 121.10 | -19.3% |
| escaped/32 | 72.79 | 79.05 | +8.6% |
| escaped/512 | 411.96 | 319.69 | -22.4% |
| escaped/8 | 50.15 | 45.47 | -9.3% |
| plain/128 | 62.14 | 35.72 | -42.5% |
| plain/32 | 25.48 | 26.65 | +4.6% |
| plain/512 | 168.07 | 86.04 | -48.8% |
| plain/8 | 23.56 | 18.63 | -20.9% |

These are local workload results on a shared host, not a whole-parser speedup claim. Background browser-test activity affected earlier runs; short-cell rows remain noisy (including the +4.6%/+8.6% 32-character rows above). The retained short-cell scalar probe is unchanged apart from the length guard. The Linux runtime/bundle comparison passed for the exact head, as recorded below.

Reproduce by adding this benchmark file to base, then running `cargo bench -p ox_content_parser --bench table_pipes -- --warm-up-time 1 --measurement-time 2 --sample-size 50 --save-baseline merged-base`; run with `--baseline merged-base` on head. The combined tree was also measured over the repository's 220-document Markdown corpus.

## Risk

- Low semantic risk: candidate selection skips only bytes that cannot match the unchanged escaped-pipe predicate. The existing unescape and source-span remapping paths remain intact.
- Rollback: revert the commit. No API, dependency, or option changes.

## Validation

- [x] Focused parser/renderer regression suites, targeted Clippy with warnings denied, formatting, panic-construct and source-line gates passed before rebasing onto merged main.
- [x] All eight full-parser cell workloads remeasured against the merged main production tree.
- [x] Combined parser/renderer suite: 598 tests passed, zero failures; all-targets Clippy passed.
- [x] Combined 220-document corpus validated with retained base/head binaries in base/head/head/base order: parse medians 2.234/2.263/2.265/2.263 ms (+0.7%); parse+render 3.616/3.366/3.418/3.576 ms (-5.7%). This measures the combined optimization wave, not this PR alone.
- [x] Exact-head CI and Linux runtime/bundle comparison passed for `70e5b8d6` ([run 34346552035](https://github.com/ubugeeei-prod/ox-content/actions/runs/34346552035)). Large-input parse-only 0.215 → 0.191 ms (+12.29% throughput), parse+render 0.193 → 0.175 ms (+10.07% throughput). Async throughput -9.02% remains informational; no relative gate or absolute budget violations.
- [x] Final combined wave: 601 parser/renderer tests passed; 1,760 individual-document HTML outputs match the pre-wave base across GFM, permalink and sanitizer settings, including fresh/reused renderer equivalence.

- [x] 220 individual documents × 4 GFM/permalink configurations: 880 HTML outputs byte-identical between the original base and combined head; fresh and reused renderers also match.

## Release and docs checklist

- [x] Internal rationale and reproducible benchmarks added.
- [x] No public API, configuration, dependency, privacy, or observability changes.
