### PR TITLE
perf(renderer): validate URL schemes without heap allocation

### DIFF
--- a/crates/ox_content_renderer/Cargo.toml
+++ b/crates/ox_content_renderer/Cargo.toml
@@ -44,3 +44,7 @@ harness = false
 [[bench]]
 name = "headings"
 harness = false
+
+[[bench]]
+name = "sanitized_urls"
+harness = false

--- a/crates/ox_content_renderer/benches/sanitized_urls.rs
+++ b/crates/ox_content_renderer/benches/sanitized_urls.rs
@@ -1,0 +1,37 @@
+//! URL sanitization costs, with parsing outside the measured region.
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use ox_content_allocator::Allocator;
+use ox_content_parser::Parser;
+use ox_content_renderer::{HtmlRenderer, HtmlRendererOptions};
+
+fn bench_sanitized_urls(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sanitized_urls");
+    for (name, url) in [
+        ("https", "https://example.com/api/reference?lang=ja#settings"),
+        ("mixed_case", "hTtPs://example.com/api"),
+        ("relative", "./guide/api.md#settings"),
+        ("unsafe", "javascript:alert(1)"),
+    ] {
+        let source = format!("[API reference]({url}) ![Preview]({url})\n\n").repeat(256);
+        let allocator = Allocator::for_source_len(source.len());
+        let document = Parser::new(&allocator, &source).parse().unwrap();
+        for sanitize in [false, true] {
+            group.bench_function(format!("{name}/enabled_{sanitize}"), |b| {
+                b.iter(|| {
+                    let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
+                        sanitize,
+                        ..Default::default()
+                    });
+                    black_box(renderer.render(black_box(&document)));
+                });
+            });
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_sanitized_urls);
+criterion_main!(benches);

--- a/crates/ox_content_renderer/src/html/renderer/write.rs
+++ b/crates/ox_content_renderer/src/html/renderer/write.rs
@@ -143,13 +143,19 @@ impl HtmlRenderer {
             return true;
         }
 
-        let scheme = url[..colon_index]
-            .chars()
-            .filter(|ch| !ch.is_ascii_whitespace())
-            .map(|ch| ch.to_ascii_lowercase())
-            .collect::<String>();
+        // Every allowed scheme is ASCII and at most six bytes. Normalize
+        // into bounded stack storage instead of allocating for each link.
+        let mut scheme = [0; 6];
+        let mut len = 0;
+        for byte in url[..colon_index].bytes().filter(|byte| !byte.is_ascii_whitespace()) {
+            let Some(slot) = scheme.get_mut(len) else {
+                return false;
+            };
+            *slot = byte.to_ascii_lowercase();
+            len += 1;
+        }
 
-        matches!(scheme.as_str(), "http" | "https" | "mailto" | "tel")
+        matches!(&scheme[..len], b"http" | b"https" | b"mailto" | b"tel")
     }
 
     pub(in crate::html::renderer) fn write_html_value(&mut self, value: &str) {
@@ -270,3 +276,6 @@ impl HtmlRenderer {
         self.heading_id_counts.insert(key, 1);
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/ox_content_renderer/src/html/renderer/write/tests.rs
+++ b/crates/ox_content_renderer/src/html/renderer/write/tests.rs
@@ -1,0 +1,92 @@
+//! Preserve the existing URL policy while removing temporary scheme strings.
+
+use super::HtmlRenderer;
+
+fn previous_url_policy(url: &str) -> bool {
+    if url.bytes().any(|byte| byte.is_ascii_control()) {
+        return false;
+    }
+    let Some(colon_index) = url.find(':') else {
+        return true;
+    };
+    let first_path_marker = url.find(&['/', '?', '#'][..]).unwrap_or(usize::MAX);
+    if first_path_marker < colon_index {
+        return true;
+    }
+    let scheme = url[..colon_index]
+        .chars()
+        .filter(|ch| !ch.is_ascii_whitespace())
+        .map(|ch| ch.to_ascii_lowercase())
+        .collect::<String>();
+    matches!(scheme.as_str(), "http" | "https" | "mailto" | "tel")
+}
+
+fn assert_previous_policy(url: &str) {
+    assert_eq!(HtmlRenderer::is_safe_url(url), previous_url_policy(url), "{url:?}");
+}
+
+#[test]
+fn allowed_schemes_preserve_all_case_and_space_combinations() {
+    for scheme in ["http", "https", "mailto", "tel"] {
+        for case_mask in 0..(1 << scheme.len()) {
+            for space_mask in 0..(1 << (scheme.len() + 1)) {
+                let mut candidate = String::new();
+                for (index, byte) in scheme.bytes().enumerate() {
+                    if space_mask & (1 << index) != 0 {
+                        candidate.push(' ');
+                    }
+                    let byte = if case_mask & (1 << index) != 0 {
+                        byte.to_ascii_uppercase()
+                    } else {
+                        byte
+                    };
+                    candidate.push(char::from(byte));
+                }
+                if space_mask & (1 << scheme.len()) != 0 {
+                    candidate.push(' ');
+                }
+                candidate.push_str(":example");
+                assert!(HtmlRenderer::is_safe_url(&candidate), "{candidate:?}");
+            }
+        }
+    }
+}
+
+#[test]
+fn scheme_mutations_match_the_previous_policy() {
+    for scheme in
+        ["http", "https", "mailto", "tel", "javascript", "data", "vbscript", "file", "ftp", ""]
+    {
+        for index in 0..=scheme.len() {
+            for inserted in (0u8..=255).map(char::from).chain(['日', '🙂', '\u{200b}', '\u{3000}'])
+            {
+                let mut candidate = scheme.to_string();
+                candidate.insert(index, inserted);
+                candidate.push_str(":example");
+                assert_previous_policy(&candidate);
+            }
+        }
+        for prefix in ["", "./", "/", "//", "?", "#"] {
+            for suffix in
+                ["", ":payload", "://example.com", "/path:part", "?query:value", "#part:value"]
+            {
+                assert_previous_policy(&format!("{prefix}{scheme}{suffix}"));
+            }
+        }
+    }
+    assert_previous_policy(&format!("{}:payload", "x".repeat(8192)));
+    assert_previous_policy(&format!("{}https{}:example", " ".repeat(128), " ".repeat(128)));
+}
+
+#[test]
+fn controls_remain_rejected_anywhere_in_the_url() {
+    for byte in (0u8..=31).chain([127]) {
+        for url in ["https://example.com/api", "./relative/path", "mailto:hi@example.com"] {
+            for index in 0..=url.len() {
+                let mut candidate = url.to_string();
+                candidate.insert(index, char::from(byte));
+                assert!(!HtmlRenderer::is_safe_url(&candidate), "{candidate:?}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

With `sanitize: true`, rendering each absolute link or image URL allocated a temporary normalized scheme string. Normalize the same ASCII case/whitespace policy into six stack bytes, the maximum length of an allowed scheme. The control-character rejection, relative-path precedence, allowed schemes, URL output, and public APIs keep their current behavior.

Add renderer benchmarks with 256 links and 256 images per document, with sanitization both enabled and disabled. Differential tests cover every ASCII/Latin-1 insertion position, Unicode, all allowed-scheme case/space combinations, controls throughout URLs, path/query/fragment precedence, and long scheme inputs against the previous policy.

## Measurements

Base: `50c9227c2eaefd616d46e8761bb4e1725b5fd393`. Apple M5 Pro arm64, Rust 1.98.0, production-aligned bench profile. Identical pre-parsed documents, fresh renderers, and compiler options. Values below are per-run median microseconds from retained executables in base/head/head/base order (0.5 s warmup, 1 s measurement, 30 samples per case).

| Workload | Base 1 | Head 1 | Head 2 | Base 2 | Time change |
| --- | ---: | ---: | ---: | ---: | ---: |
| HTTPS / sanitize on | 42.476 | 33.403 | 39.170 | 53.646 | -24.5% |
| Rejected scheme / sanitize on | 41.048 | 31.495 | 40.238 | 59.879 | -28.9% |
| HTTPS / sanitize off, control | 10.779 | 11.726 | 15.237 | 13.043 | +13.2% |
| Relative / sanitize off, control | 9.306 | 13.890 | 14.200 | 15.568 | +12.9% |
| Relative / sanitize on, control | 15.734 | 20.420 | 23.204 | 23.641 | +10.8% |
| Rejected scheme / sanitize off, control | 11.573 | 13.540 | 13.723 | 13.050 | +10.7% |

The shared host had substantial drift. The initial sequential run also sped up unchanged controls by 20–35%, so it is not used as the headline result. The interleaved figures retain the slower controls rather than hiding them; they support a targeted gain, not a default-renderer or whole-site speedup claim. The exact-head Linux runtime/bundle gate passed, as recorded below.

A counting-allocator probe running the old/new policy functions 1,000 times recorded HTTPS and mailto temporary allocations 1,000 → 0, rejected `javascript` scheme allocations 2,000 → 0, and relative URL allocations 0 → 0. This allocation result is independent of timing noise.

Reproduce the full matrix with `cargo bench -p ox_content_renderer --bench sanitized_urls -- --warm-up-time 1 --measurement-time 2 --sample-size 50 --save-baseline url-original` on base with this benchmark file, then `--baseline url-original` on head.

## Risk

- The sanitizer policy is sensitive: byte normalization must preserve the previous character-based decision. Dedicated differential tests retain the old policy as the oracle, alongside existing unsafe-link/image snapshots.
- Rollback is a single revert. No new dependencies, APIs, options, or output changes.

## Validation

- [x] Parser/renderer suites: 599 tests passed with zero failures; all-targets Clippy, formatting, panic-construct and source-line gates passed.
- [x] Targeted benchmark, unchanged controls and counting-allocator probe.
- [x] Combined changes: 220 real documents × 4 GFM/permalink settings with sanitization enabled produce 880 byte-identical HTML outputs against the pre-wave base; fresh/reused renderer outputs also match.
- [x] Exact-head CI and Linux runtime/bundle comparison passed for `d7accbd5` ([run 34348219795](https://github.com/ubugeeei-prod/ox-content/actions/runs/34348219795)): large parse-only 0.196 → 0.188 ms (+4.33% throughput), parse+render 0.167 → 0.172 ms (-3.14%), async 0.184 → 0.183 ms (+0.71%). These default-option deltas are within the documented noise band; no threshold regressions or budget violations.
- [x] Final combined wave: 601 parser/renderer tests passed; 1,760 HTML outputs match the pre-wave base. The later Svelte merge has no Rust/Cargo changes, and the merged Rust tree matches the tested tree.

- [x] Merged-main CI passed on `936e1e4d` ([run 34350853481](https://github.com/ubugeeei-prod/ox-content/actions/runs/34350853481)), including Windows, macOS and Linux NAPI smoke tests.

## Release and docs checklist

- [x] Internal rationale and reproducible benchmarks added.
- [x] No public API or configuration changes; no release or changelog changes.
