### PR TITLE
perf(vite-plugin): protect static diagrams in one pass

### DIFF
--- a/npm/vite-plugin-ox-content/src/plugins/mermaid-protect.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/mermaid-protect.test.ts
@@ -1,0 +1,84 @@
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vite-plus/test";
+import {
+  protectMermaidSvgs,
+  protectStaticDiagramSvgs,
+  restoreMermaidSvgs,
+  restoreStaticDiagramSvgs,
+} from "./mermaid-protect";
+
+const mermaid =
+  '<div class="ox-mermaid"><svg><foreignObject><div>a<br /></div></foreignObject></svg></div>';
+const graphviz = '<figure class="ox-graphviz"><svg><g>b</g></svg></figure>';
+
+describe("static diagram protection", () => {
+  it("preserves ordered mixed diagrams and all surrounding text", () => {
+    const html = `before${mermaid}between${graphviz}after`;
+    const result = protectStaticDiagramSvgs(html);
+    expect(result.html).toBe(
+      "before<!--ox-static-diagram-0-->between<!--ox-static-diagram-1-->after",
+    );
+    expect([...result.svgs.values()]).toEqual([mermaid, graphviz]);
+    expect(restoreStaticDiagramSvgs(result.html, result.svgs)).toBe(html);
+  });
+
+  it.each(["İ", "日本語🙂", "AΣİZ", "𝔘nicode"])("keeps original offsets after %s", (prefix) => {
+    const html = `${prefix}${mermaid}${prefix}${graphviz}${prefix}`;
+    const result = protectStaticDiagramSvgs(html);
+    expect([...result.svgs.values()]).toEqual([mermaid, graphviz]);
+    expect(restoreStaticDiagramSvgs(result.html, result.svgs)).toBe(html);
+  });
+
+  it("matches marker and nested closing tags case-insensitively", () => {
+    const diagram = '<DIV CLASS="OX-MERMAID"><div>nested</DIV></div>';
+    const result = protectStaticDiagramSvgs(diagram);
+    expect([...result.svgs.values()]).toEqual([diagram]);
+    expect(result.html).toBe("<!--ox-static-diagram-0-->");
+  });
+
+  it("protects an outer diagram together with nested diagrams", () => {
+    const outer = `<div class="ox-mermaid">${graphviz}${mermaid}</div>`;
+    const result = protectStaticDiagramSvgs(outer + graphviz);
+    expect([...result.svgs.values()]).toEqual([outer, graphviz]);
+    expect(restoreStaticDiagramSvgs(result.html, result.svgs)).toBe(outer + graphviz);
+  });
+
+  it("keeps malformed tails and unrelated marker-like classes unchanged", () => {
+    const tail = `<div class="ox-mermaid"><svg>unclosed${graphviz}`;
+    const html = `<div class="other ox-mermaid">other</div>${mermaid}${tail}`;
+    const result = protectStaticDiagramSvgs(html);
+    expect([...result.svgs.values()]).toEqual([mermaid]);
+    expect(result.html.endsWith(tail)).toBe(true);
+    expect(restoreStaticDiagramSvgs(result.html, result.svgs)).toBe(html);
+  });
+
+  it("preserves aliases and unknown placeholders", () => {
+    const html = `<!--ox-static-diagram-999-->${graphviz}`;
+    const result = protectMermaidSvgs(html);
+    expect(restoreMermaidSvgs(result.html, result.svgs)).toBe(html);
+    expect(protectStaticDiagramSvgs("plain text")).toEqual({ html: "plain text", svgs: new Map() });
+  });
+
+  it("protects and restores 2,000 diagrams within a 64 MiB JS heap", () => {
+    const moduleUrl = new URL("./mermaid-protect.ts", import.meta.url).href;
+    const program = `
+      import { protectStaticDiagramSvgs, restoreStaticDiagramSvgs } from ${JSON.stringify(moduleUrl)};
+      const source = (${JSON.stringify("ordinary prose ".repeat(40))} + ${JSON.stringify(mermaid + graphviz)}).repeat(1000);
+      const result = protectStaticDiagramSvgs(source);
+      if (result.svgs.size !== 2000 || restoreStaticDiagramSvgs(result.html, result.svgs) !== source) process.exit(1);
+      process.stdout.write("ok");
+    `;
+    const result = spawnSync(
+      process.execPath,
+      ["--max-old-space-size=64", "--input-type=module", "--eval", program],
+      {
+        encoding: "utf8",
+        timeout: 20_000,
+        maxBuffer: 1024 * 1024,
+      },
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr.slice(-2000)).toBe(0);
+    expect(result.stdout).toBe("ok");
+  });
+});

--- a/npm/vite-plugin-ox-content/src/plugins/mermaid-protect.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/mermaid-protect.ts
@@ -20,20 +20,28 @@ export interface MermaidSvgProtection {
  */
 export function protectStaticDiagramSvgs(html: string): MermaidSvgProtection {
   const svgs = new Map<string, string>();
-  let result = html;
-  let idx = 0;
+  const chunks: string[] = [];
+  const markers = /<div class="ox-mermaid"|<figure class="ox-graphviz"/gi;
+  let cursor = 0;
+  let match: RegExpExecArray | null;
 
-  while (true) {
-    const block = findNextStaticDiagramBlock(result, idx);
-    if (!block) break;
+  while ((match = markers.exec(html)) !== null) {
+    const tag = match[0].slice(1, 4).toLowerCase() === "div" ? "div" : "figure";
+    const end = findMatchingElementEnd(html, match.index, tag);
+    if (end === -1) break;
 
     const placeholder = `<!--ox-static-diagram-${svgs.size}-->`;
-    svgs.set(placeholder, result.substring(block.start, block.end));
-    result = result.substring(0, block.start) + placeholder + result.substring(block.end);
-    idx = block.start + placeholder.length;
+    // Retain slices of one source string, not one whole intermediate document
+    // for every diagram. Offsets stay in the original UTF-16 string as well.
+    svgs.set(placeholder, html.slice(match.index, end));
+    chunks.push(html.slice(cursor, match.index), placeholder);
+    cursor = end;
+    markers.lastIndex = end;
   }
 
-  return { html: result, svgs };
+  if (svgs.size === 0) return { html, svgs };
+  chunks.push(html.slice(cursor));
+  return { html: chunks.join(""), svgs };
 }
 
 /**
@@ -64,45 +72,14 @@ export function restoreMermaidSvgs(html: string, svgs: Map<string, string>): str
   return restoreStaticDiagramSvgs(html, svgs);
 }
 
-function findNextStaticDiagramBlock(
-  html: string,
-  startAt: number,
-): { start: number; end: number } | null {
-  const lower = html.toLowerCase();
-  const markers = [
-    { marker: '<div class="ox-mermaid"', tag: "div" },
-    { marker: '<figure class="ox-graphviz"', tag: "figure" },
-  ];
-  const next = markers
-    .map((candidate) => ({ ...candidate, start: lower.indexOf(candidate.marker, startAt) }))
-    .filter((candidate) => candidate.start !== -1)
-    .sort((a, b) => a.start - b.start)[0];
-  if (!next) return null;
-
-  const end = findMatchingElementEnd(lower, next.start, next.tag);
-  return end === -1 ? null : { start: next.start, end };
-}
-
-function findMatchingElementEnd(html: string, start: number, tag: string): number {
+function findMatchingElementEnd(html: string, start: number, tag: "div" | "figure"): number {
+  const tags = tag === "div" ? /<div|<\/div>/gi : /<figure|<\/figure>/gi;
+  tags.lastIndex = start;
   let depth = 0;
-  let pos = start;
-  const open = `<${tag}`;
-  const close = `</${tag}>`;
-
-  while (pos < html.length) {
-    const openIdx = html.indexOf(open, pos);
-    const closeIdx = html.indexOf(close, pos);
-    if (closeIdx === -1) return -1;
-
-    if (openIdx !== -1 && openIdx < closeIdx) {
-      depth++;
-      pos = openIdx + open.length;
-    } else {
-      depth--;
-      if (depth === 0) return closeIdx + close.length;
-      pos = closeIdx + close.length;
-    }
+  let match: RegExpExecArray | null;
+  while ((match = tags.exec(html)) !== null) {
+    depth += match[0][1] === "/" ? -1 : 1;
+    if (depth === 0) return tags.lastIndex;
   }
-
   return -1;
 }

--- a/tools/benchmarks/static-diagrams.mjs
+++ b/tools/benchmarks/static-diagrams.mjs
@@ -1,0 +1,37 @@
+// Run with node --expose-gc tools/benchmarks/static-diagrams.mjs [source-module.ts].
+// Use the same source module path and Node version for before/after comparisons.
+import { performance } from "node:perf_hooks";
+import { pathToFileURL } from "node:url";
+const moduleUrl = process.argv[2]
+  ? pathToFileURL(process.argv[2])
+  : new URL("../../npm/vite-plugin-ox-content/src/plugins/mermaid-protect.ts", import.meta.url);
+const { protectStaticDiagramSvgs } = await import(moduleUrl);
+const results = [];
+for (const count of [0, 10, 100, 300]) {
+  const source = (
+    "<p>日本語の通常の段落: API documentation and configuration.</p>".repeat(10) +
+    '<div class="ox-mermaid"><svg><foreignObject><div>diagram<br /></div></foreignObject></svg></div><figure class="ox-graphviz"><svg><g>graph</g></svg></figure>'
+  ).repeat(count || 100);
+  const html = count
+    ? source
+    : source.replaceAll("ox-mermaid", "unrelated").replaceAll("ox-graphviz", "unrelated");
+  const runs = [];
+  const iterations = count >= 100 ? 20 : 100;
+  for (let sample = -2; sample < 9; sample++) {
+    global.gc?.();
+    const start = performance.now();
+    for (let i = 0; i < iterations; i++) {
+      const result = protectStaticDiagramSvgs(html);
+      if (result.svgs.size !== count * 2) throw new Error("wrong diagram count");
+    }
+    if (sample >= 0) runs.push((performance.now() - start) / iterations);
+  }
+  results.push({
+    diagrams: count * 2,
+    bytes: Buffer.byteLength(html),
+    iterations,
+    samples_ms: runs,
+    median_ms: [...runs].sort((a, b) => a - b)[4],
+  });
+}
+console.log(JSON.stringify(results, null, 2));


### PR DESCRIPTION
Pages containing many Mermaid or Graphviz SVGs repeatedly lowercased and rebuilt the entire HTML document for every diagram. Slices retained each intermediate document, causing 2,000 diagrams to exhaust the JS heap. Scan the original string and join its unchanged spans once; this also preserves UTF-16 offsets after characters such as `İ`.

The existing aliases, case-insensitive marker matching, nested blocks, malformed-tail behavior, and restoration remain covered. A child-process regression protects and restores 2,000 diagrams with a 64 MiB heap. The old source fails that regression and two Unicode cases; the new source passes all 10 protection cases.

Measured against `574591e278f48b0a2288e549b7eb91fe901c5287` on Apple M5 Pro / Node 26.8.1, using identical bounded inputs, two warmups, nine samples, and explicit GC before each sample:

| Diagram count | HTML bytes | Base median ms | Head median ms |
| --- | ---: | ---: | ---: |
| 0 (control) | 87,300 | 0.049685 | 0.019295 |
| 20 | 8,760 | 0.087047 | 0.006448 |
| 200 | 87,600 | 7.901879 | 0.056356 |
| 600 | 262,800 | 77.465456 | 0.165027 |

These are protection-only timings, not end-to-end page build timings. Reproduce with `node --expose-gc tools/benchmarks/static-diagrams.mjs [source-module.ts]`. The 2,000-diagram case is a memory regression, excluded from timing because the baseline runs out of memory.

Validation: all 39 diagram, Graphviz, block-structure, and embed tests pass from the package directory, matching CI invocation; changed-file `vp check` and source length gate pass. The optional package `tsgo --noEmit` command reports byte-identical existing diagnostics on base and head; CI uses `vp run check:ts`. Full remote CI must pass before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791550323&installation_model_id=422833&pr_number=1385&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1385&signature=880f439e87a4cf0f5a77f24fb3d32e73e3f62762e757ee4d2e003621b641e5a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->