### PR TITLE
perf(vite-plugin): scan BudouX protected blocks without copying HTML

### DIFF
--- a/npm/vite-plugin-ox-content/src/budoux-protected.test.ts
+++ b/npm/vite-plugin-ox-content/src/budoux-protected.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vite-plus/test";
+import { transformBudouxHtml } from "./budoux";
+
+const tags = ["code", "math", "pre", "script", "style", "svg", "textarea"];
+const options = {
+  enabled: true,
+  language: "ja" as const,
+  separator: "|",
+  parser: { parse: (text: string) => text.split(" ") },
+};
+
+describe("BudouX protected block scanning", () => {
+  it.each(tags)("preserves %s after expanding Unicode lowercase characters", async (tag) => {
+    const html = `İ<p>before text</p><${tag}>protected text</${tag.toUpperCase()}><p>after text</p>`;
+    expect(await transformBudouxHtml(html, options)).toBe(
+      `İ<p>before|text</p><${tag}>protected text</${tag.toUpperCase()}><p>after|text</p>`,
+    );
+  });
+
+  it("keeps adjacent, nested, self-closing, and unclosed protected blocks", async () => {
+    const html =
+      "<code/><p>visible text</p><pre><code>protected text</code></PRE><svg>more text</svg><style>unclosed text";
+    expect(await transformBudouxHtml(html, options)).toBe(
+      html.replace("visible text", "visible|text"),
+    );
+  });
+
+  it("does not retain regex state between documents or concurrent calls", async () => {
+    const html = "<code>protected text</code><p>visible text</p>";
+    const result = await Promise.all(
+      Array.from({ length: 20 }, () => transformBudouxHtml(html, options)),
+    );
+    expect(result).toEqual(Array(20).fill(html.replace("visible text", "visible|text")));
+  });
+
+  it("segments only visible text among 2,100 mixed protected blocks", async () => {
+    const html = tags
+      .map((tag) => `<${tag}>protected text</${tag}><p>visible text</p>`)
+      .join("")
+      .repeat(300);
+    const result = await transformBudouxHtml(html, options);
+    expect(result).toBe(html.replaceAll("visible text", "visible|text"));
+  });
+});

--- a/npm/vite-plugin-ox-content/src/budoux.ts
+++ b/npm/vite-plugin-ox-content/src/budoux.ts
@@ -12,6 +12,9 @@ const DEFAULT_LANGUAGE: BudouxLanguage = "ja";
 const DEFAULT_SEPARATOR = "\u200b";
 const ENTITY = /&(?:#[0-9]+|#x[0-9A-Fa-f]+|[A-Za-z][A-Za-z0-9]+);/g;
 const PROTECTED_TAGS = new Set(["code", "math", "pre", "script", "style", "svg", "textarea"]);
+const PROTECTED_CLOSE_PATTERNS = new Map(
+  [...PROTECTED_TAGS].map((name) => [name, new RegExp(`</${name}`, "gi")]),
+);
 const VOID_TAGS = new Set([
   "area",
   "base",
@@ -78,7 +81,6 @@ function transformHtmlText(html: string, replacer: (text: string) => string): st
       if (closeStart > cursor) {
         output += html.slice(cursor, closeStart);
         cursor = closeStart;
-        continue;
       }
     }
 
@@ -165,7 +167,10 @@ function tagName(tag: string): string | undefined {
 }
 
 function findClosingTag(html: string, from: number, tagName: string): number {
-  return html.toLowerCase().indexOf(`</${tagName}`, from);
+  const pattern = PROTECTED_CLOSE_PATTERNS.get(tagName);
+  if (!pattern) return -1;
+  pattern.lastIndex = from;
+  return pattern.exec(html)?.index ?? -1;
 }
 
 async function loadDefaultParser(language: BudouxLanguage): Promise<BudouxParser> {

--- a/tools/benchmarks/budoux-protected.mjs
+++ b/tools/benchmarks/budoux-protected.mjs
@@ -1,0 +1,33 @@
+// Run with node tools/benchmarks/budoux-protected.mjs [source-module.ts].
+import { performance } from "node:perf_hooks";
+import { pathToFileURL } from "node:url";
+const moduleUrl = process.argv[2]
+  ? pathToFileURL(process.argv[2])
+  : new URL("../../npm/vite-plugin-ox-content/src/budoux.ts", import.meta.url);
+const { transformBudouxHtml } = await import(moduleUrl);
+const parser = { parse: (text) => text.split(" ") };
+const options = { enabled: true, language: "ja", separator: "|", parser };
+for (const count of [0, 10, 100, 1000]) {
+  const html = count
+    ? "<p>visible prose</p><code>protected text</code><svg><text>diagram text</text></svg>".repeat(
+        count,
+      )
+    : "<p>visible prose</p>".repeat(1000);
+  const expected = html.replaceAll("visible prose", "visible|prose");
+  const runs = [];
+  for (let sample = -2; sample < 9; sample++) {
+    const start = performance.now();
+    for (let i = 0; i < 10; i++) {
+      if ((await transformBudouxHtml(html, options)) !== expected)
+        throw new Error("Output changed");
+    }
+    if (sample >= 0) runs.push((performance.now() - start) / 10);
+  }
+  console.log(
+    JSON.stringify({
+      protected_blocks: count * 2,
+      bytes: Buffer.byteLength(html),
+      samples_ms: runs,
+    }),
+  );
+}


### PR DESCRIPTION
BudouX lowercased the entire document for each protected code/math/SVG block, and searched each closing tag twice. Reuse bounded case-insensitive searches on the original string and process a found closing tag immediately. This also fixes incorrect UTF-16 offsets after `İ`, which previously caused following visible text to remain unsegmented.

All seven protected tag types, mixed-case closers, nested/adjacent/self-closing/unclosed blocks, concurrent calls, and 2,100 mixed blocks are covered. The seven Unicode regressions fail against the base source. All 14 new and existing BudouX tests pass, including actual Japanese model and Markdown/MDX integration cases.

Protection-walk benchmark on Apple M5 Pro / Node 26.8.1, base `574591e2`, ABBA order, two warmups and nine samples per process:

| Protected blocks | Bytes | Base A1 / A2 ms | Head B1 / B2 ms | Ratio of paired means |
| --- | ---: | ---: | ---: | ---: |
| 0 | 20,000 | 0.28497 / 0.28215 | 0.29315 / 0.28628 | 0.98x |
| 20 | 830 | 0.01078 / 0.00973 | 0.00805 / 0.00777 | 1.30x |
| 200 | 8,300 | 0.26837 / 0.25600 | 0.07465 / 0.07634 | 3.47x |
| 2,000 | 83,000 | 16.10858 / 16.42580 | 0.70736 / 0.74950 | 22.33x |

`node tools/benchmarks/budoux-protected.mjs [source-module.ts]` uses a deterministic custom segmenter to isolate the HTML walk, and asserts output equality on every iteration. These are not default-model segmentation or whole-site build timings. The unchanged prose-only control varies about 2%.

Validation: 14 tests, changed-file `vp check`, and source length gate pass. Full remote CI must pass before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791550736&installation_model_id=422833&pr_number=1386&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1386&signature=f61ba023fc3c68797ab317d94094af7f75cbbacbaab92cb5f07b874bdd27e965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Protected HTML content such as code, math, scripts, styles, SVG, and text areas now remains unchanged during text segmentation.
  - Improved handling of adjacent, nested, self-closing, and unclosed protected blocks.
  - Ensured segmentation state is isolated across documents and concurrent processing.

- **Tests**
  - Added coverage for mixed protected content and large documents.

- **Chores**
  - Added performance benchmarking for protected HTML block processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->