### PR TITLE
test(perf): add a native Markdown extension matrix

### DIFF
--- a/crates/ox_content_transform/examples/extensions.rs
+++ b/crates/ox_content_transform/examples/extensions.rs
@@ -1,0 +1,76 @@
+//! Reproducible native extension timings: cargo run --release -p ox_content_transform --example extensions
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+#[path = "extensions/cases.rs"]
+mod extensions;
+use ox_content_transform::{
+    features::{TransformFeatureOptions, preprocess_markdown},
+    transformer::MarkdownTransformer,
+};
+use serde_json::json;
+use std::{hint::black_box, time::Instant};
+
+fn samples(mut run: impl FnMut()) -> Vec<f64> {
+    if std::env::var_os("OX_EXTENSION_VERIFY").is_some() {
+        return vec![];
+    }
+    for _ in 0..10 {
+        run();
+    }
+    (0..9)
+        .map(|_| {
+            let start = Instant::now();
+            for _ in 0..10 {
+                run();
+            }
+            start.elapsed().as_secs_f64() * 100.0
+        })
+        .collect()
+}
+
+fn main() {
+    let filter = std::env::args().nth(1).unwrap_or_default();
+    let absent = extensions::PROSE.repeat(32);
+    let mut failed = false;
+    for case in extensions::cases() {
+        if !case.name.contains(&filter) {
+            continue;
+        }
+        let transformer = MarkdownTransformer::from_options(&case.options);
+        let features = TransformFeatureOptions::from_options(&case.options);
+        for (mode, source) in [("present", case.source.as_str()), ("absent", absent.as_str())] {
+            let result = transformer.transform(source);
+            assert!(result.errors.is_empty(), "{}: {:?}", case.name, result.errors);
+            if mode == "present" && !result.html.contains(case.marker) {
+                eprintln!(
+                    "{} missing {}: {}",
+                    case.name,
+                    case.marker,
+                    result.html.chars().take(300).collect::<String>()
+                );
+                failed = true;
+                continue;
+            }
+            let preprocess_ms = samples(|| {
+                black_box(preprocess_markdown(black_box(source), &features));
+            });
+            let transform_ms = samples(|| {
+                black_box(transformer.transform(black_box(source)));
+            });
+            let fresh_ms = samples(|| {
+                black_box(
+                    MarkdownTransformer::from_options(black_box(&case.options))
+                        .transform(black_box(source)),
+                );
+            });
+            println!(
+                "{}",
+                json!({"name":case.name,"mode":mode,"bytes":source.len(),"iterations":10,"preprocess_ms":preprocess_ms,"transform_ms":transform_ms,"fresh_ms":fresh_ms,"html":result.html,"frontmatter":result.frontmatter,"toc":toc_json(&result.toc),"imports":result.imports.len(),"exports":result.exports,"components":result.components})
+            );
+        }
+    }
+    assert!(!failed, "Invalid extension fixtures");
+}
+
+fn toc_json(entries: &[ox_content_transform::TocEntry]) -> serde_json::Value {
+    json!(entries.iter().map(|entry| json!({"depth":entry.depth,"text":entry.text,"slug":entry.slug,"children":toc_json(&entry.children)})).collect::<Vec<_>>())
+}

--- a/crates/ox_content_transform/examples/extensions/assets/data.csv
+++ b/crates/ox_content_transform/examples/extensions/assets/data.csv
@@ -1,0 +1,3 @@
+Name,Value
+alpha,1
+beta,2

--- a/crates/ox_content_transform/examples/extensions/assets/host.md
+++ b/crates/ox_content_transform/examples/extensions/assets/host.md
@@ -1,0 +1,1 @@
+# Benchmark host

--- a/crates/ox_content_transform/examples/extensions/assets/partial.md
+++ b/crates/ox_content_transform/examples/extensions/assets/partial.md
@@ -1,0 +1,1 @@
+Install {{ package }} today.

--- a/crates/ox_content_transform/examples/extensions/assets/snippet.md
+++ b/crates/ox_content_transform/examples/extensions/assets/snippet.md
@@ -1,0 +1,1 @@
+Included **snippet**.

--- a/crates/ox_content_transform/examples/extensions/assets/snippet.rs
+++ b/crates/ox_content_transform/examples/extensions/assets/snippet.rs
@@ -1,0 +1,1 @@
+pub fn example() -> u32 { 42 }

--- a/crates/ox_content_transform/examples/extensions/blocks.rs
+++ b/crates/ox_content_transform/examples/extensions/blocks.rs
@@ -1,0 +1,64 @@
+use super::{Case, case};
+use ox_content_transform::*;
+
+pub fn cases() -> Vec<Case> {
+    let mut cases = vec![];
+    macro_rules! feature {
+        ($field:ident, $source:expr, $marker:expr) => {
+            cases.push(case(
+                stringify!($field),
+                $source,
+                $marker,
+                TransformOptions { $field: Some(Default::default()), ..Default::default() },
+            ));
+        };
+    }
+    feature!(containers, "::: tip Tip title\nBody with **emphasis**.\n:::\n\n", "tip");
+    feature!(cards, "::: card\n### Install\nCopy the package.\n:::\n\n", "ox-card");
+    feature!(
+        steps,
+        "::: steps\n### Install\nRun the command.\n### Build\nBuild the site.\n:::\n\n",
+        "ox-steps"
+    );
+    feature!(
+        code_groups,
+        "::: code-group\n```js [a.js]\nlet a = 1;\n```\n```ts [a.ts]\nlet a: number = 1;\n```\n:::\n\n",
+        "<tabs>"
+    );
+    feature!(
+        image_galleries,
+        "::: gallery\n![Alt](/a.png \"Caption\")\n![Other](/b.png)\n:::\n\n",
+        "ox-image-gallery"
+    );
+    feature!(
+        timelines,
+        "::: timeline\n- 2026-08-26 Release\n- 2026-09-01 Updated\n:::\n\n",
+        "ox-timeline"
+    );
+    feature!(conditional_blocks, "::: if true\nVisible\n::: else\nHidden\n:::\n\n", "Visible");
+    feature!(
+        file_tree,
+        "```file-tree\nsrc/\n  index.ts\n  utils/\n    format.ts\n```\n\n",
+        "ox-file-tree"
+    );
+    feature!(data_tables, "```csv-table\nName,Value\nalpha,1\nbeta,2\n```\n\n", "<table");
+    cases.push(case("json_tables", "```json-table\n[{\"name\":\"alpha\",\"value\":1},{\"name\":\"beta\",\"value\":2}]\n```\n\n", "<table", TransformOptions { data_tables: Some(DataTableOptions::default()), ..Default::default() }));
+    let all_blocks = TransformOptions {
+        containers: Some(ContainerOptions::default()),
+        cards: Some(CardOptions::default()),
+        steps: Some(StepsOptions::default()),
+        code_groups: Some(CodeGroupOptions::default()),
+        image_galleries: Some(ImageGalleryOptions::default()),
+        timelines: Some(TimelineOptions::default()),
+        conditional_blocks: Some(ConditionalBlockOptions::default()),
+        data_tables: Some(DataTableOptions::default()),
+        ..Default::default()
+    };
+    cases.push(case(
+        "all_blocks_tip",
+        "::: tip\nOrdinary **content**.\n:::\n\n",
+        "tip",
+        all_blocks,
+    ));
+    cases
+}

--- a/crates/ox_content_transform/examples/extensions/cases.rs
+++ b/crates/ox_content_transform/examples/extensions/cases.rs
@@ -1,0 +1,28 @@
+use ox_content_transform::*;
+#[path = "blocks.rs"]
+mod blocks;
+#[path = "files.rs"]
+mod files;
+#[path = "syntax.rs"]
+mod syntax;
+pub const PROSE: &str = "# Ordinary documentation\n\nPlain prose and **emphasis**, a [link](https://example.com), and `code`.\n\n日本語の文章です。\n";
+pub struct Case {
+    pub name: &'static str,
+    pub source: String,
+    pub options: TransformOptions,
+    pub marker: &'static str,
+}
+pub fn case(
+    name: &'static str,
+    source: &str,
+    marker: &'static str,
+    options: TransformOptions,
+) -> Case {
+    Case { name, source: source.repeat(32), marker, options }
+}
+pub fn cases() -> Vec<Case> {
+    let mut cases = syntax::cases();
+    cases.extend(blocks::cases());
+    cases.extend(files::cases());
+    cases
+}

--- a/crates/ox_content_transform/examples/extensions/files.rs
+++ b/crates/ox_content_transform/examples/extensions/files.rs
@@ -1,0 +1,98 @@
+use super::{Case, case};
+use ox_content_transform::*;
+
+pub fn cases() -> Vec<Case> {
+    let root = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/extensions/assets");
+    let host = format!("{root}/host.md");
+    vec![
+        case(
+            "includes",
+            "<!-- @include: ./snippet.md -->\n\n",
+            "Included <strong>snippet</strong>",
+            TransformOptions {
+                source_path: Some(host.clone()),
+                includes: Some(IncludeOptions {
+                    root_dir: Some(root.into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        ),
+        case(
+            "partials",
+            "<!-- @partial: ./partial.md package=\"ox-content\" -->\n\n",
+            "Install ox-content today",
+            TransformOptions {
+                source_path: Some(host.clone()),
+                partials: Some(PartialsOptions {
+                    root_dir: Some(root.into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        ),
+        case(
+            "code_imports",
+            "<<< ./snippet.rs\n\n",
+            "pub fn example",
+            TransformOptions {
+                source_path: Some(host.clone()),
+                code_imports: Some(CodeImportOptions {
+                    root_dir: Some(root.into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        ),
+        case(
+            "external_data_tables",
+            "```csv-table src=\"./data.csv\"\n```\n\n",
+            "<table",
+            TransformOptions {
+                source_path: Some(host.clone()),
+                data_tables: Some(DataTableOptions {
+                    root_dir: Some(root.into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        ),
+        case(
+            "edit_this_page",
+            "# Guide\n\nProse.\n\n",
+            "Edit this page",
+            TransformOptions {
+                source_path: Some(host),
+                edit_this_page: Some(EditThisPageOptions {
+                    repo_url: Some("https://github.com/example/docs".into()),
+                    root_dir: Some(root.into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        ),
+        Case {
+            name: "frontmatter",
+            source: "---\ntitle: Extension benchmark\nlabels: [one, two]\n---\n\n# Visible\n"
+                .into(),
+            marker: "Visible",
+            options: TransformOptions { frontmatter: Some(true), ..Default::default() },
+        },
+        case(
+            "semantic_footnotes",
+            "Sentence[^note].\n\n[^note]: Note text.\n\n",
+            "aria-label=\"Footnotes\"",
+            TransformOptions {
+                footnotes: Some(true),
+                semantic_footnotes: Some(true),
+                ..Default::default()
+            },
+        ),
+        case(
+            "autolink_urls",
+            "Visit https://example.com/docs now.\n\n",
+            "href=",
+            TransformOptions { autolink_urls: Some(true), ..Default::default() },
+        ),
+    ]
+}

--- a/crates/ox_content_transform/examples/extensions/syntax.rs
+++ b/crates/ox_content_transform/examples/extensions/syntax.rs
@@ -1,0 +1,98 @@
+#![allow(clippy::literal_string_with_formatting_args)]
+use super::{Case, case};
+use ox_content_transform::*;
+
+pub fn cases() -> Vec<Case> {
+    let mut cases = vec![];
+    macro_rules! flag {
+        ($field:ident, $source:expr, $marker:expr) => {
+            cases.push(case(
+                stringify!($field),
+                $source,
+                $marker,
+                TransformOptions { $field: Some(true), ..Default::default() },
+            ));
+        };
+    }
+    macro_rules! feature {
+        ($field:ident, $source:expr, $marker:expr) => {
+            cases.push(case(
+                stringify!($field),
+                $source,
+                $marker,
+                TransformOptions { $field: Some(Default::default()), ..Default::default() },
+            ));
+        };
+    }
+    flag!(
+        gfm,
+        "~~deleted~~ https://example.com\n\n- [x] Task\n\n| A | B |\n|---|---|\n|1|2|\n\n",
+        "<table>"
+    );
+    flag!(mdx, "<Demo label=\"hello\" />\n\n", "Demo");
+    flag!(footnotes, "Sentence[^note].\n\n[^note]: Note text.\n\n", "footnote");
+    flag!(task_lists, "- [x] Done\n- [ ] Pending\n\n", "checkbox");
+    flag!(tables, "| A | B |\n|---|---|\n|1|2|\n\n", "<table>");
+    flag!(strikethrough, "~~removed~~ unchanged\n\n", "<del>");
+    flag!(autolinks, "https://example.com/docs\n\n", "href=");
+    flag!(superscript, "x^2^ + y^3^\n\n", "<sup>");
+    flag!(subscript, "H~2~O\n\n", "<sub>");
+    flag!(smart_punctuation, "\"quoted\" -- --- ...\n\n", "…");
+    flag!(heading_attributes, "## Heading {#custom .wide}\n\n", "custom");
+    flag!(cjk_emphasis, "日本語**強調**です。\n\n", "<strong>");
+    flag!(source_spans, "## Heading\n\nParagraph.\n\n", "data-source");
+    flag!(heading_permalinks, "## Heading\n\n", "header-anchor");
+    flag!(
+        code_annotations,
+        "```ts annotate=highlight:1\nconst a = 1;\nconst b = 2;\n```\n\n",
+        "highlighted"
+    );
+    feature!(wiki_links, "[[Guide]] and [[API|Reference]]\n\n", "href=");
+    feature!(emoji_shortcodes, ":rocket: :smile: :unknown: :heart:\n\n", "🚀");
+    feature!(math, "$x^2$\n\n$$\ny = x + 1\n$$\n\n", "math");
+    feature!(attributes, "A [link](/guide){.wide target=_blank}\n\n", "wide");
+    feature!(badges, "Status {badge:tip}Stable{/badge}\n\n", "ox-badge");
+    feature!(not_by_ai, "Authored <NotByAI />.\n\n", "ox-not-by-ai");
+    feature!(keyboard_keys, "Press {kbd:Ctrl+K} then {kbd:Enter}.\n\n", "<kbd");
+    feature!(definition_lists, "Term\n: Definition with **emphasis**.\n\n", "<dl");
+    feature!(magic_links, "{link:https://example.com}\n\n", "ox-magic-link");
+    feature!(images, "![A caption](/image.png \"Caption\")\n\n", "<figure");
+    feature!(
+        sanitize,
+        "<p>Safe <a href=\"https://example.com\">link</a><script>bad()</script></p>\n\n",
+        "Safe"
+    );
+    for (name, count, first_use_only) in [
+        ("abbreviations_8", 8, false),
+        ("abbreviations_256", 256, false),
+        ("abbreviations_first_use", 256, true),
+    ] {
+        let mut terms = (0..count)
+            .map(|i| (format!("TERM{i}"), format!("Term number {i}")))
+            .collect::<rustc_hash::FxHashMap<_, _>>();
+        terms.insert("API".into(), "Application programming interface".into());
+        cases.push(case(
+            name,
+            "The API uses TERM0 and TERM7. API and unknown prose continue.\n\n",
+            "<abbr",
+            TransformOptions {
+                abbreviations: Some(AbbreviationsOptions {
+                    enabled: Some(true),
+                    terms: Some(terms),
+                    first_use_only: Some(first_use_only),
+                }),
+                ..Default::default()
+            },
+        ));
+    }
+    cases.push(case(
+        "abbreviations_inline",
+        "*[API]: Application programming interface\n\nThe API is used.\n\n",
+        "<abbr",
+        TransformOptions {
+            abbreviations: Some(AbbreviationsOptions::default()),
+            ..Default::default()
+        },
+    ));
+    cases
+}

--- a/crates/ox_content_transform/tests/extension_fixtures.rs
+++ b/crates/ox_content_transform/tests/extension_fixtures.rs
@@ -1,0 +1,20 @@
+//! Ensure performance workloads exercise their named extensions.
+#[path = "../examples/extensions/cases.rs"]
+mod extensions;
+use ox_content_transform::transformer::MarkdownTransformer;
+
+#[test]
+fn native_extension_matrix_exercises_valid_output_and_absent_controls() {
+    for case in extensions::cases() {
+        let transformer = MarkdownTransformer::from_options(&case.options);
+        let result = transformer.transform(&case.source);
+        assert!(result.errors.is_empty(), "{}: {:?}", case.name, result.errors);
+        assert!(result.html.contains(case.marker), "{} missing {}", case.name, case.marker);
+        if case.name == "frontmatter" {
+            assert!(result.frontmatter.contains("Extension benchmark"));
+        }
+        let absent = transformer.transform(extensions::PROSE);
+        assert!(absent.errors.is_empty(), "{}: {:?}", case.name, absent.errors);
+        assert!(absent.html.contains("Ordinary documentation"), "{}", case.name);
+    }
+}

--- a/tools/benchmarks/native-extensions.md
+++ b/tools/benchmarks/native-extensions.md
@@ -1,0 +1,19 @@
+# Native Markdown extension matrix
+
+Run `cargo run --release -p ox_content_transform --example extensions` from the repository root. Pass a case-name substring after `--` to select a subset, such as `-- abbreviations`. Set `OX_EXTENSION_VERIFY=1` to validate the fixtures without timing.
+
+The runner emits one JSON object per case and mode. All 49 cases have a syntax-present input and a fixed enabled-but-absent prose control. Every present fixture checks an extension-specific output marker, and all outputs must have no diagnostics. The same fixture validation is included in `cargo test -p ox_content_transform`.
+
+Each row records input bytes, iterations, nine raw samples after ten warmup iterations, rendered HTML, frontmatter, table of contents, and component metadata. Times are milliseconds per operation:
+
+- `preprocess_ms`: preprocessing with resolved feature options.
+- `transform_ms`: full native transform with a reused transformer.
+- `fresh_ms`: option resolution plus full native transform, as for one-shot callers.
+
+Most present inputs repeat a small representative fixture 32 times. Frontmatter uses one document header. File includes, partials, code imports, and external data tables use the tracked assets next to the example; repeated reads measure a warm local filesystem. They do not measure network fetches.
+
+The matrix covers GFM options, MDX, footnotes, superscript/subscript, punctuation, heading attributes/permalinks, source spans, code annotations, wiki links, emoji, math placeholders, attributes, badges, NotByAI, keyboard keys, definition lists, magic links, figures, sanitization, four abbreviation workloads, containers, cards, steps, code groups, galleries, timelines, conditionals, file trees, inline CSV/JSON, combined block options, includes, partials, code imports, external CSV, edit links, frontmatter, semantic footnotes, and renderer autolinks.
+
+KaTeX rendering, syntax highlighters, diagram processes, citations, BudouX, media/provider enrichment, and framework generation run after or outside this native pipeline and need their own measurements. Native math and code-group rows end at their placeholders; they do not include KaTeX or the tab widget renderer.
+
+For comparisons, use identical example/asset files and `Cargo.lock` in isolated base/head checkouts. Build both release executables before measuring, record the exact source SHAs, Rust/Node versions, CPU and OS, and run the saved binaries in ABBA order without concurrent builds or tests. Compare output fields exactly before interpreting medians. Keep raw samples and unchanged controls; these microbenchmarks do not establish whole-site build speedups.


### PR DESCRIPTION
The standard Markdown benchmarks do not cover most opt-in extensions, so optimizations can miss their setup costs or accidentally benchmark a disabled feature. Add 49 native workloads, each paired with an enabled-but-absent control, and verify that every positive fixture produces its intended extension output without diagnostics.

The standalone release runner records nine raw timing samples for preprocessing, full transformation with reused options, and option resolution plus transformation. JSON rows include exact HTML, frontmatter, TOC and component metadata for base/head compatibility comparisons. File-oriented extensions use tracked local fixtures. The same fixture checks run in the normal Rust integration suite.

Covers the native syntax and transform extensions, including wiki links, emoji, math placeholders, badges, keyboard keys, abbreviations, figures/galleries, containers/cards/steps/code groups, timelines, conditionals, file trees, CSV/JSON tables, includes/partials/code imports, sanitizer, and renderer options. The documentation distinguishes downstream KaTeX/highlighting/media/diagram/JS processing from native timings and describes isolated ABBA comparisons.

Validation: all 98 present/control fixture outputs succeed; the integration fixture test, `cargo clippy -p ox_content_transform --all-targets -- -D warnings`, Rustfmt and changed-source limits pass. Production transform code is unchanged. Run `cargo run --release -p ox_content_transform --example extensions` or set `OX_EXTENSION_VERIFY=1` for fixture-only verification. Full remote CI must pass before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791551739&installation_model_id=422833&pr_number=1387&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1387&signature=163dbf7f80b0a16848e9bcc4aa7c266d1a28b6232416404e4ce3597683fa2633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a native Markdown extension benchmark covering syntax, block, and file-based extension scenarios.
  - Added representative fixtures for includes, partials, code imports, tables, and other extension behaviors.
  - Added optional case filtering and validation-only execution for benchmark runs.

- **Tests**
  - Added coverage validating extension output markers, frontmatter, diagnostics, and standard prose behavior.

- **Documentation**
  - Added instructions for running benchmarks, interpreting timing results, and comparing performance consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->