### PR TITLE
perf(transform): prepare abbreviation candidates once

### DIFF
--- a/crates/ox_content_transform/src/features/abbreviations.rs
+++ b/crates/ox_content_transform/src/features/abbreviations.rs
@@ -12,7 +12,11 @@ use std::borrow::Cow;
 use crate::AbbreviationsOptions;
 
 mod protect;
+mod terms;
+use terms::Terms;
 
+#[cfg(test)]
+mod matching_tests;
 #[cfg(test)]
 mod tests;
 
@@ -20,7 +24,7 @@ use protect::next_protected;
 
 #[derive(Clone)]
 pub(super) struct ResolvedAbbreviations {
-    terms: Vec<(String, String)>,
+    terms: Terms,
     first_use_only: bool,
 }
 
@@ -47,38 +51,48 @@ pub(super) fn resolve(options: Option<&AbbreviationsOptions>) -> Option<Resolved
             terms.push((term.to_string(), title.to_string()));
         }
     }
-    Some(ResolvedAbbreviations { terms, first_use_only: options.first_use_only.unwrap_or(false) })
+    Some(ResolvedAbbreviations {
+        terms: Terms::new(terms),
+        first_use_only: options.first_use_only.unwrap_or(false),
+    })
 }
 
 pub(super) fn apply(current: &mut Cow<'_, str>, options: Option<&ResolvedAbbreviations>) {
     let Some(options) = options else {
         return;
     };
-    let mut terms = options.terms.clone();
+    let mut definitions = None;
     if current.contains("*[")
         && let Some(stripped) =
             super::segments::transform_markdown_text_segments(current, |segment, out| {
-                strip_or_copy_definition(segment, &mut terms, out);
+                strip_or_copy_definition(segment, &options.terms, &mut definitions, out);
             })
     {
         *current = Cow::Owned(stripped);
     }
+    let local_terms = definitions.map(Terms::new);
+    let terms = local_terms.as_ref().unwrap_or(&options.terms);
     if terms.is_empty() {
         return;
     }
-    terms.sort_by(|a, b| b.0.len().cmp(&a.0.len()).then_with(|| a.0.cmp(&b.0)));
     let mut used = FxHashSet::default();
     if let Some(replaced) =
         super::segments::transform_markdown_text_segments(current, |segment, out| {
-            replace(segment, &terms, options.first_use_only, &mut used, out);
+            replace(segment, terms, options.first_use_only, &mut used, out);
         })
     {
         *current = Cow::Owned(replaced);
     }
 }
 
-fn strip_or_copy_definition(segment: &str, terms: &mut Vec<(String, String)>, out: &mut String) {
+fn strip_or_copy_definition(
+    segment: &str,
+    configured: &Terms,
+    definitions: &mut Option<Vec<(String, String)>>,
+    out: &mut String,
+) {
     if let Some((term, title)) = parse_standalone_definition(segment) {
+        let terms = definitions.get_or_insert_with(|| configured.entries().to_vec());
         if let Some(existing) = terms.iter_mut().find(|entry| entry.0 == term) {
             existing.1 = title;
         } else {
@@ -101,18 +115,18 @@ fn parse_standalone_definition(segment: &str) -> Option<(String, String)> {
     Some((term.to_string(), title.to_string()))
 }
 
-fn replace(
+fn replace<'a>(
     segment: &str,
-    terms: &[(String, String)],
+    terms: &'a Terms,
     first_use_only: bool,
-    used: &mut FxHashSet<String>,
+    used: &mut FxHashSet<&'a str>,
     out: &mut String,
 ) {
     let mut cursor = 0usize;
+    let mut protected = next_protected(segment, cursor);
     while cursor < segment.len() {
-        let protected = next_protected(segment, cursor);
         let found = next_term(segment, cursor, terms, protected.as_ref().map(|span| span.start));
-        match (found, protected) {
+        match (found, protected.as_ref()) {
             (None, None) => {
                 out.push_str(&segment[cursor..]);
                 return;
@@ -120,10 +134,12 @@ fn replace(
             (None, Some(span)) => {
                 out.push_str(&segment[cursor..span.end]);
                 cursor = span.end;
+                protected = next_protected(segment, cursor);
             }
             (Some(found), Some(span)) if span.start <= found.start => {
                 out.push_str(&segment[cursor..span.end]);
                 cursor = span.end;
+                protected = next_protected(segment, cursor);
             }
             (Some(found), _) => {
                 out.push_str(&segment[cursor..found.start]);
@@ -134,13 +150,13 @@ fn replace(
     }
 }
 
-fn emit_or_copy(
-    found: TermMatch<'_>,
+fn emit_or_copy<'a>(
+    found: TermMatch<'a>,
     first_use_only: bool,
-    used: &mut FxHashSet<String>,
+    used: &mut FxHashSet<&'a str>,
     out: &mut String,
 ) {
-    if first_use_only && !used.insert(found.term.to_string()) {
+    if first_use_only && !used.insert(found.term) {
         out.push_str(found.term);
         return;
     }
@@ -152,9 +168,9 @@ fn emit_or_copy(
 }
 
 fn next_term<'a>(
-    segment: &'a str,
+    segment: &str,
     from: usize,
-    terms: &'a [(String, String)],
+    terms: &'a Terms,
     limit: Option<usize>,
 ) -> Option<TermMatch<'a>> {
     let limit = limit.unwrap_or(segment.len());
@@ -164,8 +180,9 @@ fn next_term<'a>(
             cursor += 1;
             continue;
         }
-        if left_boundary(segment, cursor) {
-            for (term, title) in terms {
+        let candidates = terms.starting_with(segment.as_bytes()[cursor]);
+        if !candidates.is_empty() && left_boundary(segment, cursor) {
+            for (term, title) in candidates {
                 let end = cursor + term.len();
                 if end <= limit
                     && segment.is_char_boundary(end)

--- a/crates/ox_content_transform/src/features/abbreviations/matching_tests.rs
+++ b/crates/ox_content_transform/src/features/abbreviations/matching_tests.rs
@@ -1,0 +1,96 @@
+use crate::{AbbreviationsOptions, TransformOptions, transformer::MarkdownTransformer};
+use rustc_hash::FxHashMap;
+
+fn options(first: bool) -> TransformOptions {
+    TransformOptions {
+        abbreviations: Some(AbbreviationsOptions {
+            enabled: Some(true),
+            first_use_only: Some(first),
+            terms: Some(FxHashMap::from_iter([
+                ("API".into(), "short".into()),
+                ("API Gateway".into(), "long".into()),
+                ("TERM".into(), "term".into()),
+                ("café".into(), "coffee".into()),
+                ("総務".into(), "general affairs".into()),
+            ])),
+        }),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn longest_matching_term_keeps_unicode_boundaries() {
+    let result = MarkdownTransformer::from_options(&options(false))
+        .transform("API Gateway API xAPI café caféé 総務 総務省 日本語APIです。");
+    assert!(result.errors.is_empty());
+    assert!(result.html.contains("title=\"long\">API Gateway</abbr>"));
+    assert_eq!(result.html.matches("title=\"short\"").count(), 2);
+    assert_eq!(result.html.matches("title=\"coffee\"").count(), 1);
+    assert_eq!(result.html.matches("title=\"general affairs\"").count(), 1);
+    assert!(result.html.contains("xAPI"));
+    assert!(result.html.contains("caféé"));
+    assert!(result.html.contains("総務省"));
+}
+
+#[test]
+fn protected_ranges_remain_valid_across_many_adjacent_matches() {
+    let source = "API TERM API [API](url) TERM API <abbr title=\"x\">API</abbr> TERM API <a href=\"url\">TERM</a> API TERM";
+    let result = MarkdownTransformer::from_options(&options(false)).transform(source);
+    assert_eq!(result.html.matches("class=\"ox-abbr\"").count(), 9);
+    assert!(result.html.contains("<abbr title=\"x\">API</abbr>"));
+    assert!(result.html.contains("<a href=\"url\">TERM</a>"));
+}
+
+#[test]
+fn inline_overrides_and_first_use_state_do_not_leak_between_documents() {
+    let transformer = MarkdownTransformer::from_options(&options(true));
+    for _ in 0..3 {
+        let local = transformer.transform("*[API]: local\n*[NEW]: added\n\nAPI NEW API NEW");
+        assert_eq!(local.html.matches("class=\"ox-abbr\"").count(), 2);
+        assert!(local.html.contains("title=\"local\">API"));
+        assert!(local.html.contains("title=\"added\">NEW"));
+        let configured = transformer.transform("API NEW API\n\nTERM TERM");
+        assert_eq!(configured.html.matches("class=\"ox-abbr\"").count(), 2);
+        assert!(configured.html.contains("title=\"short\">API"));
+        assert!(!configured.html.contains("local"));
+        assert!(!configured.html.contains("added"));
+    }
+}
+
+#[test]
+fn indexed_candidates_match_exhaustive_longest_match_reference() {
+    let entries = ["A", "API", "API Gateway", "A-B", "B", "café", "総務", "🙂", "🙂🙂"]
+        .into_iter()
+        .map(|term| (term.to_string(), term.to_string()))
+        .collect::<Vec<_>>();
+    let mut reference = entries.clone();
+    reference.sort_by(|a, b| b.0.len().cmp(&a.0.len()).then_with(|| a.0.cmp(&b.0)));
+    let terms = super::terms::Terms::new(entries);
+    let parts = ["A", "API Gateway", "A-B", "B", "café", "総務", "🙂🙂", "x", " ", "-", "。"];
+    for left in parts {
+        for middle in parts {
+            for right in parts {
+                let source = format!("{left}{middle}{right}");
+                for from in source.char_indices().map(|(index, _)| index) {
+                    let expected = source
+                        .char_indices()
+                        .filter(|(index, _)| *index >= from)
+                        .find_map(|(start, _)| {
+                            if !super::left_boundary(&source, start) {
+                                return None;
+                            }
+                            reference.iter().find_map(|(term, _)| {
+                                let end = start + term.len();
+                                (source[start..].starts_with(term)
+                                    && super::right_boundary(&source, end))
+                                .then_some((start, end, term.as_str()))
+                            })
+                        });
+                    let actual = super::next_term(&source, from, &terms, None)
+                        .map(|found| (found.start, found.end, found.term));
+                    assert_eq!(actual, expected, "{source} at {from}");
+                }
+            }
+        }
+    }
+}

--- a/crates/ox_content_transform/src/features/abbreviations/terms.rs
+++ b/crates/ox_content_transform/src/features/abbreviations/terms.rs
@@ -1,0 +1,42 @@
+//! Prepared exact-match candidates, preserving longest-match precedence.
+#[derive(Clone)]
+pub(super) struct Terms {
+    entries: Vec<(String, String)>,
+    starts: Option<Box<[usize; 257]>>,
+}
+
+impl Terms {
+    pub(super) fn new(mut entries: Vec<(String, String)>) -> Self {
+        entries.sort_by(|a, b| {
+            a.0.as_bytes()[0]
+                .cmp(&b.0.as_bytes()[0])
+                .then_with(|| b.0.len().cmp(&a.0.len()))
+                .then_with(|| a.0.cmp(&b.0))
+        });
+        if entries.len() <= 8 {
+            return Self { entries, starts: None };
+        }
+        let mut starts = Box::new([0; 257]);
+        for (term, _) in &entries {
+            starts[usize::from(term.as_bytes()[0]) + 1] += 1;
+        }
+        for i in 1..starts.len() {
+            starts[i] += starts[i - 1];
+        }
+        Self { entries, starts: Some(starts) }
+    }
+
+    pub(super) fn entries(&self) -> &[(String, String)] {
+        &self.entries
+    }
+    pub(super) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+    pub(super) fn starting_with(&self, byte: u8) -> &[(String, String)] {
+        let Some(starts) = &self.starts else {
+            return &self.entries;
+        };
+        let bucket = usize::from(byte);
+        &self.entries[starts[bucket]..starts[bucket + 1]]
+    }
+}


### PR DESCRIPTION
Configured glossaries cloned and sorted the entire dictionary for every document, then tested every term at each word boundary. Prepare longest-first candidates grouped by their first byte, borrow the configured dictionary until a valid page-local definition overrides it, reuse the next protected span while emitting adjacent matches, and borrow term keys for first-use tracking. Dictionaries of eight terms or fewer keep a direct scan; larger indexes are boxed so disabled abbreviations do not enlarge the whole transformer by 2 KiB.

Preserves longest matches, existing Unicode boundary semantics, escaped titles, inline definitions, protected code/links/comments, and per-document first-use state. Four additional regressions cover overlap and Unicode, multiple matches around protected regions, reused transformers with local definitions, and indexed matching against an exhaustive reference over 1,331 combinations and every character boundary.

Apple M5 Pro / Rust 1.98.0 / release profile, base `574591e2`, identical fixtures and lockfile, saved binaries in ABBA order. Nine samples, ten iterations per sample; each value below is a median in milliseconds for **option resolution plus native transformation**:

| Workload | Bytes | Base A1 / A2 | Head B1 / B2 | Paired mean speedup |
| --- | ---: | ---: | ---: | ---: |
| 9 configured terms, present | 2,016 | 0.04016 / 0.03992 | 0.02431 / 0.02582 | 1.60x |
| 257 configured terms, present | 2,016 | 0.41795 / 0.37757 | 0.09333 / 0.09795 | 4.16x |
| 257 terms, first-use mode | 2,016 | 0.35566 / 0.39376 | 0.07778 / 0.07678 | 4.85x |
| 257 terms, absent | 4,096 | 0.49443 / 0.31253 | 0.04330 / 0.04383 | 9.26x |
| Inline-only definitions, absent | 4,096 | 0.01579 / 0.01650 | 0.01630 / 0.01630 | 0.99x |

The larger absent-input baseline varies substantially; raw paired values are retained above. The median head/base ratio across the 90 unaffected fixture/control rows is 1.019. All 98 HTML, frontmatter, TOC, import-count, export and component outputs match exactly. The reusable matrix is in #1387; its numbered abbreviation cases contain that many generated terms plus `API`. These are native-transform timings, not whole-site build timings.

Validation: 29 abbreviation tests and the full transform crate suite pass; Clippy with warnings denied, Rustfmt, panic-construct and source-length gates pass. Full remote CI must pass before merge.

CI measurement audit: the first Benchmark run (34356480548) compared base 18c46f3067727b6b29d8ffe5330471b568d0d82b with head 776b2de582d9516aabbb3b4fe4d4254dbadbda66 on the same Blacksmith 32-vCPU Intel runner label. The large parse+render row fell from 0.172 ms to 0.194 ms (-11.33% throughput), crossing the -10% gate. This API uses render_scratch and does not invoke abbreviation preprocessing. Unchanged controls in the same large render sample also slowed: marked 368→321 ops/s (-12.8%), md4x NAPI 3248→2966 (-8.7%), markdown-it 246→237 (-3.7%). Parse-only improved 5.62%. Raw workflow logs are retained. One same-head rerun is being used to distinguish runner variation; no gate or threshold is overridden.

Same-head rerun completed successfully: Benchmark run 34356480548 attempt 2 passed the unchanged regression and absolute-budget gates. All checks passed before merge.
