### PR TITLE
perf(transform): skip inactive extension passes

### DIFF
--- a/crates/ox_content_transform/src/features.rs
+++ b/crates/ox_content_transform/src/features.rs
@@ -273,8 +273,10 @@ pub fn preprocess_markdown_with_frontmatter<'a, S: BuildHasher>(
     {
         current = Cow::Owned(file_tree::transform(&current, file_tree));
     }
-    if let Some(tables) = &options.data_tables {
-        current = Cow::Owned(data_tables::transform(&current, tables, &mut errors));
+    if let Some(tables) = &options.data_tables
+        && let Some(transformed) = data_tables::preprocess(&current, tables, &mut errors)
+    {
+        current = Cow::Owned(transformed);
     }
     if options.badges && current.contains("{badge:") {
         let replaced = transform_markdown_text_segments(&current, |segment, out| {

--- a/crates/ox_content_transform/src/features/block_preprocess.rs
+++ b/crates/ox_content_transform/src/features/block_preprocess.rs
@@ -11,7 +11,9 @@ pub(super) fn apply<'a, S: BuildHasher>(
     frontmatter: &HashMap<String, Value, S>,
     errors: &mut Vec<String>,
 ) -> Cow<'a, str> {
-    if let Some(conditionals) = &options.conditional_blocks {
+    if let Some(conditionals) = &options.conditional_blocks
+        && current.contains("if")
+    {
         current = Cow::Owned(super::conditional_blocks::transform(
             &current,
             conditionals,
@@ -19,23 +21,34 @@ pub(super) fn apply<'a, S: BuildHasher>(
             errors,
         ));
     }
-    if let Some(galleries) = &options.image_galleries {
+    if let Some(galleries) = &options.image_galleries
+        && current.contains("gallery")
+    {
         current = Cow::Owned(super::image_galleries::transform(&current, galleries, errors));
     }
-    if let Some(timelines) = &options.timelines {
+    if let Some(timelines) = &options.timelines
+        && current.contains("timeline")
+    {
         current = Cow::Owned(super::timelines::transform(&current, timelines, errors));
     }
-    if options.cards.is_some() {
+    if options.cards.is_some() && crate::html_scan::find_ci(&current, 0, "card").is_some() {
         current = Cow::Owned(super::cards::transform(&current));
     }
-    if options.steps.is_some() {
+    if options.steps.is_some() && crate::html_scan::find_ci(&current, 0, "steps").is_some() {
         current = Cow::Owned(super::steps::transform(&current));
     }
-    if options.code_groups.is_some() {
+    if options.code_groups.is_some()
+        && crate::html_scan::find_ci(&current, 0, "code-group").is_some()
+    {
         current = Cow::Owned(super::code_groups::transform(&current, errors));
     }
-    if let Some(containers) = &options.containers {
+    if let Some(containers) = &options.containers
+        && current.contains(":::")
+    {
         current = Cow::Owned(super::containers::transform(&current, containers));
     }
     current
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/ox_content_transform/src/features/block_preprocess/tests.rs
+++ b/crates/ox_content_transform/src/features/block_preprocess/tests.rs
@@ -1,0 +1,106 @@
+use serde_json::Value;
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::hash::BuildHasher;
+
+use crate::features;
+use crate::features::TransformFeatureOptions;
+
+fn legacy<'a, S: BuildHasher>(
+    mut current: Cow<'a, str>,
+    options: &TransformFeatureOptions,
+    frontmatter: &HashMap<String, Value, S>,
+    errors: &mut Vec<String>,
+) -> Cow<'a, str> {
+    if let Some(conditionals) = &options.conditional_blocks {
+        current = Cow::Owned(features::conditional_blocks::transform(
+            &current,
+            conditionals,
+            frontmatter,
+            errors,
+        ));
+    }
+    if let Some(galleries) = &options.image_galleries {
+        current = Cow::Owned(features::image_galleries::transform(&current, galleries, errors));
+    }
+    if let Some(timelines) = &options.timelines {
+        current = Cow::Owned(features::timelines::transform(&current, timelines, errors));
+    }
+    if options.cards.is_some() {
+        current = Cow::Owned(features::cards::transform(&current));
+    }
+    if options.steps.is_some() {
+        current = Cow::Owned(features::steps::transform(&current));
+    }
+    if options.code_groups.is_some() {
+        current = Cow::Owned(features::code_groups::transform(&current, errors));
+    }
+    if let Some(containers) = &options.containers {
+        current = Cow::Owned(features::containers::transform(&current, containers));
+    }
+    current
+}
+
+#[test]
+fn guarded_passes_match_unconditional_pipeline_for_every_option_combination() {
+    let sources = [
+        "Ordinary prose, no block markers.",
+        "::: unknown\nBody\n:::\n",
+        "::: TIP\nBody\n:::\n",
+        "::: CARD\n### Title\nBody\n:::\n",
+        "::: STEPS\n### One\nBody\n:::\n",
+        "::: CODE-GROUP\n```js [a.js]\nx\n```\n:::\n",
+        "::: gallery\n![Alt](/a.png)\n:::\n",
+        "::: timeline\n- 2026-09-01 Release\n:::\n",
+        "::: if true\n::: card\n### Title\nBody\n:::\n:::\n",
+        "```md\n::: card\nHidden\n:::\n```\n",
+        "::: tip\n::: steps\n### One\nText\n:::\n:::\n",
+        "::: code-group\nNot a fence.\n:::\n",
+        "İ 日本語 :: card steps code-group if gallery timeline",
+    ];
+    let frontmatter = HashMap::<String, Value>::new();
+    for mask in 0u8..128 {
+        let mut options = crate::TransformOptions::default();
+        macro_rules! flag {
+            ($bit:expr, $field:ident) => {
+                if mask & (1 << $bit) != 0 {
+                    options.$field = Some(Default::default());
+                }
+            };
+        }
+        flag!(0, conditional_blocks);
+        flag!(1, image_galleries);
+        flag!(2, timelines);
+        flag!(3, cards);
+        flag!(4, steps);
+        flag!(5, code_groups);
+        flag!(6, containers);
+        let options = TransformFeatureOptions::from_options(&options);
+        for source in sources {
+            let mut actual_errors = Vec::new();
+            let mut expected_errors = Vec::new();
+            let actual =
+                super::apply(Cow::Borrowed(source), &options, &frontmatter, &mut actual_errors);
+            let expected =
+                legacy(Cow::Borrowed(source), &options, &frontmatter, &mut expected_errors);
+            assert_eq!(actual, expected, "options {mask} on {source}");
+            assert_eq!(actual_errors, expected_errors, "options {mask} on {source}");
+        }
+    }
+}
+
+#[test]
+fn enabled_data_tables_borrow_documents_without_table_fences() {
+    let options = TransformFeatureOptions::from_options(&crate::TransformOptions {
+        data_tables: Some(crate::DataTableOptions::default()),
+        ..Default::default()
+    });
+    for source in
+        ["# Prose\n\nOrdinary content.", "```rust\nlet a = 1;\n```\n", "日本語の文章です。"]
+    {
+        let result = features::preprocess_markdown(source, &options);
+        assert!(matches!(result.source, Cow::Borrowed(_)));
+        assert_eq!(result.source, source);
+        assert!(result.errors.is_empty());
+    }
+}

--- a/crates/ox_content_transform/src/features/data_tables.rs
+++ b/crates/ox_content_transform/src/features/data_tables.rs
@@ -81,15 +81,24 @@ pub(super) fn resolve(
     })
 }
 
+#[cfg(test)]
 pub(super) fn transform(
     source: &str,
     options: &ResolvedDataTableOptions,
     errors: &mut Vec<String>,
 ) -> String {
+    preprocess(source, options, errors).unwrap_or_else(|| source.to_string())
+}
+
+pub(super) fn preprocess(
+    source: &str,
+    options: &ResolvedDataTableOptions,
+    errors: &mut Vec<String>,
+) -> Option<String> {
     if !source.contains(CSV_LANGUAGE) && !source.contains(JSON_LANGUAGE) {
-        return source.to_string();
+        return None;
     }
-    rewrite(source, options, errors)
+    Some(rewrite(source, options, errors))
 }
 
 fn rewrite(source: &str, options: &ResolvedDataTableOptions, errors: &mut Vec<String>) -> String {


### PR DESCRIPTION
Enabling several block extensions made every `:::` document run every block pass, including passes whose syntax was absent. Those no-op passes repeatedly scanned, collected lines, and copied the document. Skip them with conservative marker checks on the current output at each stage, preserving the established transformation order and case-insensitive card/step/code-group syntax. Skip the final container pass when earlier passes consumed every delimiter.

Data-table preprocessing now returns no replacement when neither CSV nor JSON table syntax is present, retaining the borrowed source instead of copying it. Its existing test-facing transform still returns the same string output.

A differential regression compares all 128 block-option combinations over 13 inputs against the original unconditional sequence (1,664 comparisons), including uppercase markers, nested blocks, fenced examples, malformed code groups and diagnostics. Another regression pins the borrowed data-table no-op path. All 98 native matrix outputs and metadata remain identical.

Apple M5 Pro / Rust 1.98.0 / release profile, base `574591e2`, saved binaries in ABBA order, nine samples of ten iterations. For a 1,120-byte document with 32 tip containers and all seven block extensions plus data tables enabled:

| Operation | Base A1 / A2 median ms | Head B1 / B2 median ms |
| --- | ---: | ---: |
| Preprocessing, resolved options | 0.01080 / 0.01047 | 0.00400 / 0.00389 |
| Option resolution + native transform | 0.02545 / 0.02385 | 0.01762 / 0.01872 |

This is 2.70x faster preprocessing and 26.3% less time for the full native operation in that workload. Individual-extension/control rows are noisy and are not claimed as improvements. The data-table no-op allocation removal is also verified structurally by its borrowed result. Reproduce with the #1387 native extension matrix, filtering `all_blocks_tip`; raw base/head outputs were compared before interpreting timings.

Validation: the full transform crate suite (603 tests), Clippy with warnings denied, Rustfmt, panic-construct and source-length gates pass. Full remote CI must pass before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791552768&installation_model_id=422833&pr_number=1390&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1390&signature=e63e9b6097cc08a51a590e7e5163d05325b61868dc5ac220bf230c3969526034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->