### PR TITLE
perf(vite-plugin): reuse repeated KaTeX rendering within documents

### DIFF
--- a/npm/vite-plugin-ox-content/src/plugins/math-cache.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/math-cache.test.ts
@@ -1,0 +1,72 @@
+import { createRequire } from "node:module";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { renderKatexMath, type MathRenderFailure } from "./math";
+const katex = createRequire(import.meta.url)("katex");
+function placeholder(tex: string, block = false, span = "1:2") {
+  const tag = block ? "div" : "span";
+  return `<${tag} class="ox-math ox-math-${block ? "block" : "inline"}" data-ox-tex="${tex}" data-source-span="${span}">${tex}</${tag}>`;
+}
+afterEach(() => vi.restoreAllMocks());
+
+describe("per-document formula reuse", () => {
+  it("reuses repeated formulas by display mode while preserving every source span", async () => {
+    const render = vi.spyOn(katex, "renderToString");
+    const source =
+      placeholder("x^2", false, "1:2") +
+      placeholder("x^2", true, "3:4") +
+      placeholder("x^2", false, "5:6") +
+      placeholder("x^2", false, "7:8");
+    const html = await renderKatexMath(source);
+    expect(render).toHaveBeenCalledTimes(2);
+    for (const span of ["1:2", "3:4", "5:6", "7:8"])
+      expect(html).toContain(`data-source-span="${span}"`);
+    expect(html.match(/class="ox-math ox-math-inline"/g)).toHaveLength(3);
+    expect(html).toContain('class="ox-math ox-math-block"');
+  });
+
+  it.each(["literal", "render"] as const)(
+    "reports each failed occurrence in %s mode",
+    async (policy) => {
+      const failures: MathRenderFailure[] = [];
+      const render = vi.spyOn(katex, "renderToString");
+      const html = await renderKatexMath(
+        placeholder("\\notARealCommand").repeat(3),
+        policy,
+        failures,
+      );
+      expect(failures).toHaveLength(3);
+      expect(failures[0]).toEqual(failures[1]);
+      expect(render).toHaveBeenCalledTimes(policy === "literal" ? 1 : 2);
+      expect(html).toContain(policy === "literal" ? "$\\notARealCommand$" : 'class="ox-math');
+    },
+  );
+
+  it("records the first failure before throwing in error mode", async () => {
+    const failures: MathRenderFailure[] = [];
+    await expect(
+      renderKatexMath(placeholder("\\notARealCommand").repeat(2), "error", failures),
+    ).rejects.toThrow("notARealCommand");
+    expect(failures).toHaveLength(1);
+  });
+
+  it("does not retain formula results between documents", async () => {
+    const render = vi.spyOn(katex, "renderToString");
+    await renderKatexMath(placeholder("x").repeat(5));
+    await renderKatexMath(placeholder("x").repeat(5));
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps distinct formulas correct after the cache limit", async () => {
+    const source =
+      placeholder("x").repeat(2) +
+      Array.from({ length: 160 }, (_, index) => placeholder(`x_{${index}}`)).join("");
+    const html = await renderKatexMath(source);
+    expect(html.match(/class="ox-math ox-math-inline"/g)).toHaveLength(162);
+    expect(html).toContain("x_{159}");
+  });
+  it("does not retain renderings larger than the string budget", async () => {
+    const render = vi.spyOn(katex, "renderToString").mockReturnValue("x".repeat(128 * 1024 + 1));
+    await renderKatexMath(placeholder("x").repeat(3));
+    expect(render).toHaveBeenCalledTimes(3);
+  });
+});

--- a/npm/vite-plugin-ox-content/src/plugins/math.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/math.ts
@@ -68,6 +68,7 @@ export async function renderKatexMath(
     return html;
   }
 
+  const renderer = hasRepeatedFormula(html) ? cacheKatex(katex) : katex;
   return html.replace(MATH_TAG, (match, tag: string) => {
     const openTag = match.slice(0, match.indexOf(">"));
     const className = CLASS_ATTR.exec(openTag)?.[1] ?? "";
@@ -92,7 +93,7 @@ export async function renderKatexMath(
 
     let rendered: string;
     try {
-      rendered = katex.renderToString(tex, { ...options, throwOnError: true });
+      rendered = renderer.renderToString(tex, { ...options, throwOnError: true });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       failures?.push({ tex, block, message });
@@ -104,10 +105,58 @@ export async function renderKatexMath(
         // the sentence reads the way its author wrote it.
         return escapeHtmlText(block ? `$$${tex}$$` : `$${tex}$`);
       }
-      rendered = katex.renderToString(tex, { ...options, throwOnError: false });
+      rendered = renderer.renderToString(tex, { ...options, throwOnError: false });
     }
     return `<${tag} class="ox-math ox-math-${kind}"${sourceSpan}>${rendered}</${tag}>`;
   });
+}
+
+// Sampling bounds the decision even on very large pages. A missed later
+// repetition only means rendering it normally, with no per-formula cache work.
+function hasRepeatedFormula(html: string): boolean {
+  const seen = new Set<string>();
+  for (const match of html.matchAll(MATH_TAG)) {
+    const encoded = TEX_ATTR.exec(match[0].slice(0, match[0].indexOf(">")))?.[1];
+    if (encoded === undefined) continue;
+    if (seen.has(encoded)) return true;
+    seen.add(encoded);
+    if (seen.size >= 32) return false;
+  }
+  return false;
+}
+
+function cacheKatex(katex: KatexModule): KatexModule {
+  type Result = { html: string } | { error: unknown };
+  const cache = new Map<string, Result>();
+  let characters = 0;
+  return {
+    renderToString(tex, options) {
+      // Other render options are fixed by renderKatexMath. Throwing and literal
+      // rendering remain separate, as do inline and display-mode output.
+      const key = `${options?.displayMode ? "b" : "i"}${options?.throwOnError ? "t" : "f"}${tex}`;
+      const cached = cache.get(key);
+      if (cached) {
+        if ("error" in cached) throw cached.error;
+        return cached.html;
+      }
+      let result: Result;
+      let size = key.length;
+      try {
+        const html = katex.renderToString(tex, options);
+        result = { html };
+        size += html.length;
+      } catch (error) {
+        result = { error };
+        size += error instanceof Error ? error.message.length : String(error).length;
+      }
+      if (cache.size < 128 && characters + size <= 128 * 1024) {
+        cache.set(key, result);
+        characters += size;
+      }
+      if ("error" in result) throw result.error;
+      return result.html;
+    },
+  };
 }
 
 function escapeHtmlText(value: string): string {

--- a/tools/benchmarks/katex-formulas.mjs
+++ b/tools/benchmarks/katex-formulas.mjs
@@ -1,0 +1,34 @@
+// Run with node tools/benchmarks/katex-formulas.mjs [source-module.ts].
+import { performance } from "node:perf_hooks";
+import { pathToFileURL } from "node:url";
+const moduleUrl = process.argv[2]
+  ? pathToFileURL(process.argv[2])
+  : new URL("../../npm/vite-plugin-ox-content/src/plugins/math.ts", import.meta.url);
+const { renderKatexMath } = await import(moduleUrl);
+for (const kind of ["absent", "repeated", "distinct", "mixed", "invalid"]) {
+  const html =
+    kind === "absent"
+      ? "<p>Ordinary prose and code.</p>".repeat(128)
+      : Array.from({ length: 128 }, (_, i) => {
+          const tex =
+            kind === "invalid"
+              ? "\\notARealCommand"
+              : `x_{${kind === "repeated" ? 0 : kind === "mixed" ? i % 8 : i}}^2 + \\frac{1}{2}`;
+          return `<span class="ox-math ox-math-inline" data-ox-tex="${tex}" data-source-span="${i}:1">${tex}</span>`;
+        }).join("");
+  const expected = await renderKatexMath(html);
+  if (["repeated", "distinct", "mixed"].includes(kind) && !expected.includes('class="katex"')) {
+    throw new Error("KaTeX did not render the fixture");
+  }
+  const runs = [];
+  for (let sample = -2; sample < 9; sample++) {
+    const start = performance.now();
+    for (let i = 0; i < 5; i++) {
+      if ((await renderKatexMath(html)) !== expected) throw new Error("Output changed");
+    }
+    if (sample >= 0) runs.push((performance.now() - start) / 5);
+  }
+  console.log(
+    JSON.stringify({ kind, bytes: Buffer.byteLength(html), samples_ms: runs, html: expected }),
+  );
+}


### PR DESCRIPTION
Repeated TeX currently calls KaTeX again for every occurrence. On pages where a bounded prefix scan finds repetition, reuse KaTeX results within that document. Cache keys distinguish display mode and throw-on-error rendering; successful strings and errors have a 128-entry / 128 Ki-character retention budget. Pages with no repetition in the first 32 formulas keep the ordinary rendering path.

The existing placeholder loop still handles each occurrence, preserving source spans, wrappers, literal/error/render policies, and one failure-array entry per occurrence. Cache lifetime ends with the document. Tests cover repeated inline/block formulas, diagnostic multiplicity, throwing policy, document isolation, limits and oversized rendering results.

Apple M5 Pro / Node 26.8.1 / installed KaTeX 0.16.47, base `574591e2`, ABBA order, nine measured samples after two warmup samples, five iterations per sample. Timings include `renderKatexMath` plus output equality verification; repeated/distinct/mixed inputs contain 128 formulas:

| Input | Base A1 / A2 median ms | Head B1 / B2 median ms |
| --- | ---: | ---: |
| No math | 0.00140 / 0.00133 | 0.00138 / 0.00138 |
| One repeated formula | 4.07165 / 3.45388 | 0.77418 / 0.79035 |
| 128 distinct formulas | 3.42727 / 3.16292 | 3.53696 / 3.30635 |
| Eight repeated formulas | 3.35102 / 3.20315 | 0.95617 / 0.89292 |
| Repeated invalid formula, literal policy | 0.89637 / 0.86614 | 0.18413 / 0.17799 |

The repeated and mixed cases improve 4.81x and 3.54x by paired means. **The distinct-formula control took 3.8% more time in this run**; its base/head ranges overlap, but no improvement is claimed there. The bounded prefix check limits that tradeoff. All five fixture outputs match byte-for-byte. This is a math-rendering result, not a whole-site speedup.

Reproduce with `node tools/benchmarks/katex-formulas.mjs [source-module.ts]`; keep the module in a checkout that resolves the same KaTeX peer. The driver rejects missing-KaTeX fallbacks. Validation: all 28 math unit, error-policy, option, asset and integration tests pass with the CI-built base native binding; changed-file `vp check` and source length checks pass. Full remote CI must pass before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Repeated mathematical formulas now render more efficiently through bounded caching.
  - Cached results preserve display modes, source spans, and error behavior.
  - Cache contents are isolated between documents and avoid retaining oversized results.

- **Reliability**
  - Rendering failures are consistently reported according to the selected error policy.

- **Testing**
  - Added coverage for repeated, distinct, invalid, and oversized formulas.

- **Benchmarking**
  - Added performance measurements for representative mathematical rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->