### PR TITLE
perf(vite-plugin): share repeated SpeakerDeck metadata requests

### DIFF
--- a/npm/vite-plugin-ox-content/src/plugins/speaker-deck-dedup.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/speaker-deck-dedup.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vite-plus/test";
+import { enrichSpeakerDeckEmbeds } from "./speaker-deck";
+
+const URL = "https://speakerdeck.com/docs/talk";
+const tag = (attrs = `url="${URL}"`) => `<SpeakerDeck ${attrs}>İ本文</SpeakerDeck>`;
+const response = () =>
+  new Response(
+    JSON.stringify({
+      title: "Fetched title",
+      author_name: "Fetched author",
+      html: '<iframe src="https://speakerdeck.com/player/0123456789abcdef"></iframe>',
+    }),
+  );
+
+describe("SpeakerDeck document request sharing", () => {
+  it("shares in-flight and completed requests while preserving each tag's attributes", async () => {
+    let calls = 0;
+    let resolve!: (value: Response) => void;
+    const input =
+      tag() + tag(`href="${URL}" title="Authored"`) + tag(`src="${URL}" author="Local"`).repeat(98);
+    const pending = enrichSpeakerDeckEmbeds(input, () => {
+      calls++;
+      return new Promise<Response>((done) => {
+        resolve = done;
+      });
+    });
+    expect(calls).toBe(1);
+    resolve(response());
+    const html = await pending;
+    expect(calls).toBe(1);
+    expect(html.match(/player="0123456789abcdef"/g)).toHaveLength(100);
+    expect(html.match(/İ本文/g)).toHaveLength(100);
+    expect(html).toContain('title="Authored"');
+    expect(html.match(/author="Local"/g)).toHaveLength(98);
+    expect(html.indexOf('title="Fetched title"')).toBeLessThan(html.indexOf('title="Authored"'));
+  });
+
+  it("keeps distinct URL requests independent and bounded to four concurrent requests", async () => {
+    let active = 0;
+    let maximum = 0;
+    const calls: string[] = [];
+    const input = Array.from({ length: 12 }, (_, i) => tag(`url="${URL}-${i}"`)).join("");
+    await enrichSpeakerDeckEmbeds(input, async (url) => {
+      calls.push(url);
+      maximum = Math.max(maximum, ++active);
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      active--;
+      return response();
+    });
+    expect(new Set(calls).size).toBe(12);
+    expect(maximum).toBe(4);
+  });
+
+  it("does not request metadata for player IDs or invalid URLs", async () => {
+    const input =
+      tag(`url="${URL}" player="01234567"`) +
+      tag(`url="${URL}" id="01234567"`) +
+      tag('url="https://example.com/docs/talk"');
+    let calls = 0;
+    expect(
+      await enrichSpeakerDeckEmbeds(input, async () => {
+        calls++;
+        return response();
+      }),
+    ).toBe(input);
+    expect(calls).toBe(0);
+  });
+
+  it("shares failure within one document but retries on the next document", async () => {
+    let calls = 0;
+    const input = tag().repeat(12);
+    const fetcher = async () => {
+      calls++;
+      return new Response("{}", { status: 503 });
+    };
+    expect(await enrichSpeakerDeckEmbeds(input, fetcher)).toBe(input);
+    expect(calls).toBe(1);
+    expect(await enrichSpeakerDeckEmbeds(input, fetcher)).toBe(input);
+    expect(calls).toBe(2);
+  });
+
+  it("does not retain successful metadata across documents", async () => {
+    let calls = 0;
+    const fetcher = async () => {
+      calls++;
+      return response();
+    };
+    await enrichSpeakerDeckEmbeds(tag().repeat(8), fetcher);
+    await enrichSpeakerDeckEmbeds(tag().repeat(8), fetcher);
+    expect(calls).toBe(2);
+  });
+});

--- a/npm/vite-plugin-ox-content/src/plugins/speaker-deck.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/speaker-deck.ts
@@ -29,8 +29,17 @@ export async function enrichSpeakerDeckEmbeds(
     full: match[0],
     index: match.index ?? 0,
   }));
+  const requests = new Map<string, Promise<SpeakerDeckMeta | null>>();
+  const loadMeta = (url: string): Promise<SpeakerDeckMeta | null> => {
+    let pending = requests.get(url);
+    if (!pending) {
+      pending = fetchOembed(url, fetchImpl);
+      requests.set(url, pending);
+    }
+    return pending;
+  };
   const enriched = await mapWithConcurrency(matches, OEMBED_CONCURRENCY, (match) =>
-    enrichTag(match.full, match.attrs, fetchImpl),
+    enrichTag(match.full, match.attrs, loadMeta),
   );
 
   let output = "";
@@ -67,7 +76,7 @@ async function mapWithConcurrency<T, U>(
 async function enrichTag(
   full: string,
   attrs: string,
-  fetchImpl: SpeakerDeckFetch,
+  loadMeta: (url: string) => Promise<SpeakerDeckMeta | null>,
 ): Promise<string> {
   if (readAttr(attrs, "player") || readAttr(attrs, "id")) {
     return full;
@@ -77,7 +86,7 @@ async function enrichTag(
     return full;
   }
 
-  const meta = await fetchOembed(url, fetchImpl);
+  const meta = await loadMeta(url);
   if (!meta) {
     return full;
   }

--- a/tools/benchmarks/speakerdeck-oembed.mjs
+++ b/tools/benchmarks/speakerdeck-oembed.mjs
@@ -1,0 +1,66 @@
+// Bundle src/plugins/speaker-deck.ts with Rolldown, then pass the bundle path.
+// Uses local HTTP with a controlled delay; does not contact SpeakerDeck.
+import { createServer } from "node:http";
+import { performance } from "node:perf_hooks";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createHash } from "node:crypto";
+
+const { enrichSpeakerDeckEmbeds } = await import(pathToFileURL(resolve(process.argv[2])).href);
+let requests = 0;
+const server = createServer((_request, response) => {
+  requests++;
+  setTimeout(() => {
+    response.setHeader("content-type", "application/json");
+    response.end(
+      JSON.stringify({
+        title: "Local benchmark",
+        author_name: "Example",
+        html: '<iframe src="https://speakerdeck.com/player/0123456789abcdef"></iframe>',
+      }),
+    );
+  }, 5);
+});
+await new Promise((done) => server.listen(0, "127.0.0.1", done));
+try {
+  const endpoint = `http://127.0.0.1:${server.address().port}/`;
+  const fetcher = (url, init) => fetch(endpoint + new URL(url).search, init);
+  for (const [name, count, unique] of [
+    ["absent", 0, 0],
+    ["repeated", 100, 1],
+    ["mixed", 100, 10],
+    ["distinct", 100, 100],
+  ]) {
+    const html =
+      "<p>İ本文</p>" +
+      Array.from(
+        { length: count },
+        (_, i) =>
+          `<SpeakerDeck url="https://speakerdeck.com/docs/talk-${i % unique}"></SpeakerDeck>`,
+      ).join("");
+    const expected = await enrichSpeakerDeckEmbeds(html, fetcher);
+    const samples = [];
+    const counts = [];
+    for (let i = 0; i < 7; i++) {
+      requests = 0;
+      const start = performance.now();
+      const output = await enrichSpeakerDeckEmbeds(html, fetcher);
+      samples.push(performance.now() - start);
+      counts.push(requests);
+      if (output !== expected) throw new Error("Output changed between samples");
+    }
+    console.log(
+      JSON.stringify({
+        name,
+        bytes: Buffer.byteLength(html),
+        samples_ms: samples,
+        median_ms: [...samples].sort((a, b) => a - b)[3],
+        requests: counts,
+        sha256: createHash("sha256").update(expected).digest("hex"),
+      }),
+    );
+  }
+} finally {
+  server.closeAllConnections();
+  await new Promise((done) => server.close(done));
+}


### PR DESCRIPTION
Repeated SpeakerDeck share URLs currently issue a separate oEmbed HTTP request for every element. Share in-flight and completed requests by exact URL within one document, while keeping each element’s authored metadata, output order, and the four-request concurrency limit. Successful and failed results expire when that document finishes.

A controlled local HTTP server (5 ms response delay, 100 elements, Node 26.8.1, Apple M5 Pro) measured A/B/B/A runs with seven samples each:

| Workload | Base median ms, two runs | Head median ms, two runs | Requests per document |
| --- | --- | --- | --- |
| One repeated URL | 198.562 / 198.871 | 9.227 / 7.903 | 100 → 1 |
| Ten repeated URLs | 200.257 / 197.009 | 24.276 / 24.333 | 100 → 10 |
| 100 distinct URLs | 196.565 / 198.123 | 199.427 / 200.796 | 100 → 100 |

The repeated fixture is 23.2× faster; this is controlled local enrichment latency, not a claim about production network speed or whole-site build time. Distinct URLs retain the same request count and measured approximately 1.4% slower. HTML hashes match on all workloads. The benchmark does not contact SpeakerDeck.

Validation: 14 tests passed across SpeakerDeck enrichment, rendering and offline builds. New regressions cover in-flight sharing, authored per-element attributes, order, exact distinct URL handling, four-request concurrency, skipped explicit players, failures, and isolation between documents. Changed-file formatting/lint and source-size checks passed. Reproduce with `tools/benchmarks/speakerdeck-oembed.mjs` and a Rolldown bundle of the module at each revision. Base: 574591e2.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791553535&installation_model_id=422833&pr_number=1392&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1392&signature=bf9de3efc6e8a51bcc4995cc2560f5985825026441ec7b4ca39e569d4c9be238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->