### PR TITLE
test(perf): cover every media provider and downstream extension stage

### DIFF
--- a/npm/vite-plugin-ox-content/src/extension-media-fixtures.test.ts
+++ b/npm/vite-plugin-ox-content/src/extension-media-fixtures.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vite-plus/test";
+import { importNapiModuleSync } from "./napi";
+
+const media = JSON.parse(
+  readFileSync(new URL("../../../tools/benchmarks/extension-media.json", import.meta.url), "utf8"),
+);
+
+describe("extension benchmark media fixtures", () => {
+  it("covers every native provider exactly once with an active, diagnostic-free fixture", () => {
+    const napi = importNapiModuleSync();
+    expect(media.fixtures.map((fixture: { name: string }) => fixture.name).sort()).toEqual(
+      napi
+        .mediaEmbedTags()
+        .map((tag) => tag.name)
+        .sort(),
+    );
+    for (const fixture of media.fixtures) {
+      const output = napi.transformMediaEmbedsWithDiagnostics(fixture.html, media.options);
+      expect(output.diagnostics, fixture.name).toEqual([]);
+      expect(output.html, fixture.name).not.toBe(fixture.html);
+    }
+  });
+});

--- a/tools/benchmarks/build-pipeline-extensions.mjs
+++ b/tools/benchmarks/build-pipeline-extensions.mjs
@@ -1,0 +1,19 @@
+import { createRequire } from "node:module";
+import { isAbsolute } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+const require = createRequire(
+  new URL("../../npm/vite-plugin-ox-content/package.json", import.meta.url),
+);
+const { rolldown } = await import(pathToFileURL(require.resolve("rolldown")).href);
+const bundle = await rolldown({
+  input: fileURLToPath(new URL("./pipeline-extensions.ts", import.meta.url)),
+  platform: "node",
+  external: (id) => !id.startsWith(".") && !isAbsolute(id),
+});
+await bundle.write({
+  file: fileURLToPath(
+    new URL("../../npm/vite-plugin-ox-content/.pipeline-extensions.mjs", import.meta.url),
+  ),
+  format: "esm",
+});
+await bundle.close();

--- a/tools/benchmarks/extension-bibliography.json
+++ b/tools/benchmarks/extension-bibliography.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "example",
+    "type": "article-journal",
+    "title": "Example",
+    "author": [{ "given": "Ada", "family": "Example" }],
+    "issued": { "date-parts": [[2026]] }
+  }
+]

--- a/tools/benchmarks/extension-media.json
+++ b/tools/benchmarks/extension-media.json
@@ -1,0 +1,180 @@
+{
+  "options": {
+    "spotify": true,
+    "appleMusic": true,
+    "speakerDeck": true,
+    "audio": true,
+    "video": true,
+    "stackBlitz": true,
+    "twitter": true,
+    "bluesky": true,
+    "googleMaps": true,
+    "qiita": true,
+    "zenn": true,
+    "packageRegistry": true,
+    "playgrounds": true,
+    "vimeo": true,
+    "twitch": true,
+    "discord": true,
+    "fediverse": true,
+    "facebook": true,
+    "threads": true,
+    "instagram": true,
+    "webContainer": true,
+    "loom": true,
+    "asciinema": true,
+    "figma": true,
+    "note": true,
+    "googleSlides": true
+  },
+  "fixtures": [
+    {
+      "name": "loom",
+      "html": "<loom url=\"https://www.loom.com/share/abc123def\"></loom>"
+    },
+    {
+      "name": "asciinema",
+      "html": "<asciinema url=\"https://asciinema.org/a/569727\"></asciinema>"
+    },
+    {
+      "name": "figma",
+      "html": "<figma url=\"https://www.figma.com/file/AbC123/My-Design\"></figma>"
+    },
+    {
+      "name": "note",
+      "html": "<note url=\"https://note.com/someone/n/nabc123\"></note>"
+    },
+    {
+      "name": "replit",
+      "html": "<replit url=\"https://replit.com/@someone/my-repl\"></replit>"
+    },
+    {
+      "name": "spotify",
+      "html": "<Spotify url=\"https://open.spotify.com/track/abc123\"></Spotify>"
+    },
+    {
+      "name": "applemusic",
+      "html": "<AppleMusic url=\"https://music.apple.com/gb/album/1989-taylors-version/1708308989\"></AppleMusic>"
+    },
+    {
+      "name": "speakerdeck",
+      "html": "<SpeakerDeck url=\"https://speakerdeck.com/jane/my-cool-talk\"></SpeakerDeck>"
+    },
+    {
+      "name": "Audio",
+      "html": "<Audio src=\"https://cdn.example.com/intro.mp3\"></Audio>"
+    },
+    {
+      "name": "Video",
+      "html": "<Video src=\"/talk.mp4\" poster=\"/talk.jpg\" captions=\"/talk.en.vtt\" srclang=\"en\" label=\"English\" width=\"1280\" height=\"720\" title=\"Talk\"></Video>"
+    },
+    {
+      "name": "stackblitz",
+      "html": "<StackBlitz url=\"https://stackblitz.com/edit/vitejs-vite\"></StackBlitz>"
+    },
+    {
+      "name": "tweet",
+      "html": "<Tweet url=\"https://x.com/jack/status/20\" displayName=\"jack\" handle=\"jack\" avatar=\"https://pbs.twimg.com/profile_images/avatar.jpg\" datetime=\"2006-03-21T20:50:14Z\" dateLabel=\"Mar 21, 2006\" replies=\"120\" retweets=\"520\" quotes=\"8\" likes=\"2.4M\" views=\"10M\">just setting up my twttr</Tweet>"
+    },
+    {
+      "name": "bluesky",
+      "html": "<Bluesky url=\"https://bsky.app/profile/bsky.app/post/3l6oveex3ii2l\" displayName=\"Bluesky\" handle=\"bsky.app\" avatar=\"https://bsky.app/static/apple-touch-icon.png\" datetime=\"2024-02-06T12:34:56Z\" dateLabel=\"Feb 6, 2024\" replies=\"10\" reposts=\"20\" likes=\"30\" quotes=\"4\">hello sky</Bluesky>"
+    },
+    {
+      "name": "googlemaps",
+      "html": "<GoogleMaps url=\"https://www.google.com/maps/place/Tokyo+Station/\" place=\"Tokyo Station\" address=\"1 Chome Marunouchi, Chiyoda City\" embed=\"https://www.google.com/maps/embed?pb=!1m18\"></GoogleMaps>"
+    },
+    {
+      "name": "qiita",
+      "html": "<Qiita url=\"https://qiita.com/ubugeeei/items/abcdef123456\"></Qiita>"
+    },
+    {
+      "name": "zenn",
+      "html": "<Zenn url=\"https://zenn.dev/ubugeeei/articles/ox-content\" title=\"Ox Content notes\" author=\"ubugeeei\" date=\"2026-08-26\" likes=\"12\"></Zenn>"
+    },
+    {
+      "name": "npmpackage",
+      "html": "<NpmPackage url=\"https://www.npmjs.com/package/@vitejs/plugin-vue/v/6.0.0\" title=\"@vitejs/plugin-vue\" license=\"MIT\" repository=\"https://github.com/vitejs/vite-plugin-vue\" dateTime=\"2026-08-26T00:00:00Z\" dateLabel=\"2026-08-26\">Vue support for Vite.</NpmPackage>"
+    },
+    {
+      "name": "cratesio",
+      "html": "<CratesIo url=\"https://crates.io/crates/serde/1.0.0\" description=\"Serialization framework\" license=\"MIT OR Apache-2.0\" downloads=\"123456\"></CratesIo>"
+    },
+    {
+      "name": "pypi",
+      "html": "<PyPI url=\"https://pypi.org/project/requests/2.32.0\" repository=\"https://github.com/psf/requests\">Python HTTP for Humans.</PyPI>"
+    },
+    {
+      "name": "dockerhub",
+      "html": "<DockerHub url=\"https://hub.docker.com/_/nginx/tags?name=mainline\" downloads=\"987654\" stars=\"321\" dateLabel=\"2026-08-23\"></DockerHub>"
+    },
+    {
+      "name": "codepen",
+      "html": "<CodePen url=\"https://codepen.io/ubugeeei/pen/abc123\" title=\"Card demo\" author=\"ubugeeei\" image=\"https://shots.codepen.io/card.png\">Static preview.</CodePen>"
+    },
+    {
+      "name": "jsfiddle",
+      "html": "<JSFiddle url=\"https://jsfiddle.net/ubugeeei/abc123/2/\" title=\"Fiddle demo\" embed=\"https://jsfiddle.net/ubugeeei/abc123/2/embedded/result/\"></JSFiddle>"
+    },
+    {
+      "name": "observable",
+      "html": "<Observable url=\"https://observablehq.com/@d3/bar-chart\" author=\"@d3\" runtime=\"Observable Runtime\"></Observable>"
+    },
+    {
+      "name": "codesandbox",
+      "html": "<CodeSandbox url=\"https://codesandbox.io/s/demo\" embed=\"https://codesandbox.io/embed/demo\"></CodeSandbox>"
+    },
+    {
+      "name": "vimeo",
+      "html": "<Vimeo url=\"https://vimeo.com/123456789\" title=\"Vimeo demo\" author=\"Vimeo Staff\" duration=\"1:30\" image=\"https://i.vimeocdn.com/video/123.jpg\" embed=\"https://player.vimeo.com/video/123456789?dnt=1\">A video fallback.</Vimeo>"
+    },
+    {
+      "name": "twitch",
+      "html": "<Twitch url=\"https://www.twitch.tv/videos/40464143\" title=\"Twitch VOD\" channel=\"twitchdev\" duration=\"2:00:00\" embed=\"https://player.twitch.tv/?video=v40464143&parent=docs.example.com&autoplay=false\"></Twitch>"
+    },
+    {
+      "name": "discord",
+      "html": "<Discord url=\"https://discord.gg/abc123\" server=\"Ox Content\" channel=\"announcements\">Join the release channel.</Discord>"
+    },
+    {
+      "name": "mastodon",
+      "html": "<Mastodon url=\"https://mastodon.social/@docs/111\" author=\"@docs@mastodon.social\" replies=\"3\" reposts=\"5\" likes=\"8\">Fediverse release note.</Mastodon>"
+    },
+    {
+      "name": "facebook",
+      "html": "<Facebook url=\"https://www.facebook.com/example/posts/123\" title=\"Launch note\" author=\"Example\"></Facebook>"
+    },
+    {
+      "name": "threads",
+      "html": "<Threads url=\"https://www.threads.net/@example/post/abc\" author=\"@example\">Thread copy.</Threads>"
+    },
+    {
+      "name": "instagram",
+      "html": "<Instagram url=\"https://www.instagram.com/p/abc123/\" author=\"@example\" image=\"https://cdn.example.com/photo.jpg\">Caption text.</Instagram>"
+    },
+    {
+      "name": "webcontainer",
+      "html": "<WebContainer entry=\"src/main.ts\" title=\"Demo & Tools\">\nnpm install\nnpm run dev\n</WebContainer>"
+    },
+    {
+      "name": "googleslides",
+      "html": "<googleslides url=\"https://docs.google.com/presentation/d/1AbC_123/edit\"></googleslides>"
+    },
+    {
+      "name": "fediverse",
+      "html": "<fediverse url=\"https://social.example/@author/123\"></fediverse>"
+    },
+    {
+      "name": "misskey",
+      "html": "<misskey url=\"https://social.example/notes/123\"></misskey>"
+    },
+    {
+      "name": "mixi2",
+      "html": "<mixi2 url=\"https://mixi.social/@author/posts/123\"></mixi2>"
+    },
+    {
+      "name": "xpost",
+      "html": "<XPost url=\"https://x.com/jack/status/20\" displayName=\"jack\" handle=\"jack\" avatar=\"https://pbs.twimg.com/profile_images/avatar.jpg\" datetime=\"2006-03-21T20:50:14Z\" dateLabel=\"Mar 21, 2006\" replies=\"120\" retweets=\"520\" quotes=\"8\" likes=\"2.4M\" views=\"10M\">just setting up my twttr</XPost>"
+    }
+  ]
+}

--- a/tools/benchmarks/pipeline-extensions.md
+++ b/tools/benchmarks/pipeline-extensions.md
@@ -1,0 +1,19 @@
+# Downstream extension benchmarks
+
+The native Markdown matrix lives in `native-extensions.md`. This companion covers the post-render pipeline: every native media provider, tabs, package-manager tabs, YouTube, syntax highlighting, cross references, citations (including local bibliography reads), code lint, and docs-test extraction. It tests 1, 32 and 256 occurrences plus enabled-but-absent controls: 144 rows. A registry assertion prevents silently omitting new providers. Each fixture must exercise its transform and retain stable output.
+
+From the repository root, with workspace dependencies and the matching NAPI binding built:
+
+```sh
+node tools/benchmarks/build-pipeline-extensions.mjs
+cd npm/vite-plugin-ox-content
+OX_MEDIA_FIXTURES=../../tools/benchmarks/extension-media.json \
+OX_BIBLIOGRAPHY=../../tools/benchmarks/extension-bibliography.json \
+node ../../tools/benchmarks/pipeline-extensions.mjs .pipeline-extensions.mjs > results.jsonl
+```
+
+`OX_EXTENSION_FILTER` restricts workload names. Keep the generated bundle local. Use the same Node, dependency versions and NAPI build profile for comparisons. Each row records input bytes, nine samples after two warmups, median milliseconds and an output SHA-256. Five calls form each sample; output verification happens outside the timed interval. Save both revisions and runner metadata alongside results. Run A/B/B/A without competing builds, and retain unchanged controls. Timing is observational, not a wall-clock unit-test threshold.
+
+Media measurements are native HTML transformations with supplied metadata; they perform no HTTP requests. Live GitHub/OpenGraph/Reddit/provider latency, cold Mermaid/Graphviz renderer execution, TypeScript compiler startup and docs-test execution are separate costs. Existing provider request caches and renderer caches must be measured explicitly as cold or warm. Do not treat an unavailable optional renderer as a successful fast render. `speakerdeck-oembed.mjs` separately measures request deduplication against a controlled local HTTP server.
+
+KaTeX, BudouX and static-diagram protection have their own focused drivers (`katex-formulas.mjs`, `budoux-protected.mjs`, `static-diagrams.mjs`). End-to-end build speed cannot be inferred by multiplying these isolated speedups.

--- a/tools/benchmarks/pipeline-extensions.mjs
+++ b/tools/benchmarks/pipeline-extensions.mjs
@@ -1,0 +1,31 @@
+// Run from npm/vite-plugin-ox-content; see pipeline-extensions.md.
+import { createHash } from "node:crypto";
+import { performance } from "node:perf_hooks";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+const { cases } = await import(pathToFileURL(resolve(process.argv[2])).href);
+for (const workload of cases) {
+  if (process.env.OX_EXTENSION_FILTER && !workload.name.includes(process.env.OX_EXTENSION_FILTER))
+    continue;
+  const output = await workload.run(workload.input);
+  if (workload.validate && !workload.validate(output))
+    throw new Error(`Inactive fixture: ${workload.name}`);
+  const expected = JSON.stringify(output);
+  const samples = [];
+  for (let sample = -2; sample < 9; sample++) {
+    const start = performance.now();
+    for (let i = 0; i < 5; i++) await workload.run(workload.input);
+    if (sample >= 0) samples.push((performance.now() - start) / 5);
+  }
+  if (JSON.stringify(await workload.run(workload.input)) !== expected)
+    throw new Error(`Unstable output: ${workload.name}`);
+  console.log(
+    JSON.stringify({
+      name: workload.name,
+      bytes: Buffer.byteLength(workload.input),
+      samples_ms: samples,
+      median_ms: [...samples].sort((a, b) => a - b)[4],
+      sha256: createHash("sha256").update(expected).digest("hex"),
+    }),
+  );
+}

--- a/tools/benchmarks/pipeline-extensions.ts
+++ b/tools/benchmarks/pipeline-extensions.ts
@@ -1,0 +1,140 @@
+import { dirname, resolve } from "node:path";
+import { createRequire } from "node:module";
+import { readFile } from "node:fs/promises";
+import {
+  resolveCitationsOptions,
+  transformCitations,
+} from "../../npm/vite-plugin-ox-content/src/citations";
+import {
+  resolveCrossReferencesOptions,
+  transformCrossReferences,
+} from "../../npm/vite-plugin-ox-content/src/cross-references";
+import { highlightCode } from "../../npm/vite-plugin-ox-content/src/highlight";
+import {
+  resetTabGroupCounter,
+  transformTabs,
+} from "../../npm/vite-plugin-ox-content/src/plugins/tabs";
+import { transformPm } from "../../npm/vite-plugin-ox-content/src/plugins/pm";
+import { transformYouTube } from "../../npm/vite-plugin-ox-content/src/plugins/youtube";
+import { lintCodeBlocks, extractDocsTests } from "../../npm/vite-plugin-ox-content/src/code-blocks";
+
+const napi = createRequire(import.meta.url)("@ox-content/napi");
+const media = JSON.parse(await readFile(process.env.OX_MEDIA_FIXTURES!, "utf8"));
+const registered = napi
+  .mediaEmbedTags()
+  .map((tag: { name: string }) => tag.name)
+  .sort();
+const covered = media.fixtures.map((fixture: { name: string }) => fixture.name).sort();
+if (JSON.stringify(registered) !== JSON.stringify(covered))
+  throw new Error("Media registry coverage mismatch");
+const bibliographyFile = resolve(process.env.OX_BIBLIOGRAPHY!);
+const citationOptions = resolveCitationsOptions({
+  bibliography: bibliographyFile,
+  rootDir: dirname(bibliographyFile),
+});
+const prose = "<p>Plain prose with <strong>formatting</strong> and 日本語.</p>";
+export interface Workload {
+  name: string;
+  input: string;
+  run: (input: string) => unknown;
+  validate?: (output: any) => boolean;
+}
+export const cases: Workload[] = [];
+for (const fixture of media.fixtures) {
+  for (const count of [1, 32, 256]) {
+    cases.push({
+      name: `media/${fixture.name}/${count}`,
+      input: fixture.html.repeat(count),
+      run: (input) => napi.transformMediaEmbedsWithDiagnostics(input, media.options),
+      validate: (output) =>
+        output.diagnostics.length === 0 && output.html !== fixture.html.repeat(count),
+    });
+  }
+}
+cases.push({
+  name: "media/absent",
+  input: prose.repeat(256),
+  run: (input) => napi.transformMediaEmbedsWithDiagnostics(input, media.options),
+  validate: (output) => output.diagnostics.length === 0,
+});
+for (const count of [1, 32, 256]) {
+  for (const [name, input, run] of [
+    [
+      "tabs",
+      '<tabs><tab label="One"><p>One</p></tab><tab label="Two"><p>Two</p></tab></tabs>',
+      async (input: string) => {
+        resetTabGroupCounter();
+        return transformTabs(input);
+      },
+    ],
+    [
+      "pm",
+      "<pm>npm install ox-content</pm>",
+      async (input: string) => {
+        resetTabGroupCounter();
+        return transformPm(input);
+      },
+    ],
+    ["youtube", '<YouTube id="dQw4w9WgXcQ"></YouTube>', transformYouTube],
+    [
+      "highlight",
+      '<pre><code class="language-ts">export const answer: number = 42;</code></pre>',
+      highlightCode,
+    ],
+  ] as const) {
+    cases.push({
+      name: `${name}/${count}`,
+      input: input.repeat(count),
+      run,
+      validate: (output) => output !== input.repeat(count),
+    });
+    if (count === 1) cases.push({ name: `${name}/absent`, input: prose.repeat(256), run });
+  }
+  cases.push({
+    name: `cross_references/${count}`,
+    input: Array.from(
+      { length: count },
+      (_, i) => `<h2 id="sec-${i}">Section ${i}</h2><p>See [@sec-${i}].</p>`,
+    ).join(""),
+    run: (input) => transformCrossReferences(input, resolveCrossReferencesOptions(true)),
+    validate: (output) => output.references.length === count,
+  });
+  cases.push({
+    name: `citations/${count}`,
+    input: "<p>Citation [@example].</p>".repeat(count),
+    run: (input) => transformCitations(input, citationOptions),
+    validate: (output) => output.citations.length === count,
+  });
+  cases.push({
+    name: `code_lint/${count}`,
+    input: "```ts\nconst value = 1;  \n```\n".repeat(count),
+    run: (input) => lintCodeBlocks(input),
+    validate: (output) => output.length === count,
+  });
+  cases.push({
+    name: `docs_test_extract/${count}`,
+    input: "```js test\nconsole.assert(1 + 1 === 2);\n```\n".repeat(count),
+    run: (input) => extractDocsTests(input),
+    validate: (output) => output.length === count,
+  });
+}
+cases.push({
+  name: "cross_references/absent",
+  input: prose.repeat(256),
+  run: (input) => transformCrossReferences(input, resolveCrossReferencesOptions(true)),
+});
+cases.push({
+  name: "citations/absent",
+  input: prose.repeat(256),
+  run: (input) => transformCitations(input, citationOptions),
+});
+cases.push({
+  name: "code_lint/absent",
+  input: prose.repeat(256),
+  run: (input) => lintCodeBlocks(input),
+});
+cases.push({
+  name: "docs_test_extract/absent",
+  input: prose.repeat(256),
+  run: (input) => extractDocsTests(input),
+});


### PR DESCRIPTION
Add a reproducible 144-row downstream extension benchmark alongside the native Markdown matrix. Every one of the 37 media registry tags has an active fixture; a test and runner assertion fail if the registry and fixtures diverge. Measure 1/32/256 occurrences for media, tabs, package-manager tabs, YouTube, highlighting, cross references, citations, code lint and docs-test extraction, with absent controls. Each row retains raw samples and an output hash.

The documented driver bundles source modules with Rolldown and requires the matching NAPI binding. Output validation is outside timing; provider network I/O and external renderer/compiler/test-process costs are explicitly separate. No production behavior changes.

Validation: all 144 rows executed with active-fixture and stable-output checks; 35 related tests passed across five files, including complete media registry coverage. Formatting/lint and source-size guards passed. Baseline: 3a311bed, Node 26.8.1, Apple M5 Pro, CI-built arm64 base NAPI from run 34353537430. Observed native media transforms for 256 instances range roughly 0.2–1.9 ms; these are stage timings, not whole builds.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791554023&installation_model_id=422833&pr_number=1394&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1394&signature=6f837a18c73ca292c9ad035786da14422df034c4bac1a68c84b39463520ad161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->