### PR TITLE
perf(vite-plugin): reuse asynchronous native module normalization

### DIFF
--- a/npm/vite-plugin-ox-content/src/napi-loader.test.ts
+++ b/npm/vite-plugin-ox-content/src/napi-loader.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+afterEach(() => {
+  vi.doUnmock("@ox-content/napi");
+  vi.doUnmock("node:module");
+  vi.resetModules();
+});
+
+describe("shared asynchronous native binding", () => {
+  it("loads concurrent extension callers once and preserves named/default export precedence", async () => {
+    vi.resetModules();
+    let defaultReads = 0;
+    const parse = () => "named";
+    vi.doMock("@ox-content/napi", () => ({
+      default: {
+        parse: () => "default",
+        get transform() {
+          defaultReads++;
+          return () => "transformed";
+        },
+      },
+      parse,
+    }));
+    const { importNapiModule } = await import("./napi");
+    const callers = await Promise.all(Array.from({ length: 100 }, () => importNapiModule()));
+    for (const binding of callers) {
+      expect(binding.parse).toBe(parse);
+      expect(binding.transform("source")).toBe("transformed");
+    }
+    await importNapiModule();
+    expect(defaultReads).toBe(1);
+  });
+
+  it("shares successful require fallback without retrying the failed import for each caller", async () => {
+    vi.resetModules();
+    const requireBinding = vi.fn(() => ({ transform: () => "fallback" }));
+    vi.doMock("@ox-content/napi", () => {
+      throw new Error("ESM unavailable");
+    });
+    vi.doMock("node:module", () => ({ createRequire: () => requireBinding }));
+    const { importNapiModule } = await import("./napi");
+    for (const binding of await Promise.all([importNapiModule(), importNapiModule()])) {
+      expect(binding.transform("source")).toBe("fallback");
+    }
+    await importNapiModule();
+    expect(requireBinding).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains both failure causes and retries a failed load", async () => {
+    vi.resetModules();
+    const importError = new Error("ESM unavailable");
+    const requireError = new Error("binding not built yet");
+    const requireBinding = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw requireError;
+      })
+      .mockReturnValue({ transform: () => "recovered" });
+    vi.doMock("@ox-content/napi", () => {
+      throw importError;
+    });
+    vi.doMock("node:module", () => ({ createRequire: () => requireBinding }));
+    const { importNapiModule } = await import("./napi");
+    const failed = await Promise.allSettled([importNapiModule(), importNapiModule()]);
+    for (const result of failed) {
+      expect(result.status).toBe("rejected");
+      if (result.status === "rejected") {
+        expect(result.reason).toBeInstanceOf(AggregateError);
+        expect(result.reason.errors).toHaveLength(2);
+        expect(result.reason.errors[1]).toBe(requireError);
+      }
+    }
+    expect((await importNapiModule()).transform("source")).toBe("recovered");
+    expect(requireBinding).toHaveBeenCalledTimes(2);
+  });
+});

--- a/npm/vite-plugin-ox-content/src/napi.ts
+++ b/npm/vite-plugin-ox-content/src/napi.ts
@@ -22,7 +22,21 @@ function normalizeNapiModule(mod: NapiModule): NapiModule {
     : mod;
 }
 
-export async function importNapiModule(): Promise<NapiModule> {
+let asyncNapiModule: Promise<NapiModule> | undefined;
+
+export function importNapiModule(): Promise<NapiModule> {
+  if (!asyncNapiModule) {
+    asyncNapiModule = loadNapiModule().catch((error: unknown) => {
+      // Failed loads remain retryable, as before. Share successful imports and
+      // normalization across all extension stages and concurrent documents.
+      asyncNapiModule = undefined;
+      throw error;
+    });
+  }
+  return asyncNapiModule;
+}
+
+async function loadNapiModule(): Promise<NapiModule> {
   try {
     return normalizeNapiModule((await import("@ox-content/napi")) as NapiModule);
   } catch (importError) {


### PR DESCRIPTION
Every asynchronous native-module load currently recreates a wrapper containing all native exports. Share the successful load and normalization across extension stages and concurrent documents. Keep require fallback and AggregateError diagnostics, and evict failed promises so a later load can retry.

The downstream extension matrix measured 144 rows in A/B/B/A order with the same CI-built arm64 NAPI binding, Node 26.8.1 and Apple M5 Pro. All 144 output hashes match. Raw medians below are milliseconds per stage (two base runs / two head runs):

| Workload | Base | Head |
| --- | --- | --- |
| One tabs group | .03348 / .03272 | .00158 / .00120 |
| One package-manager group | .03596 / .03510 | .00353 / .00293 |
| One YouTube embed | .03352 / .03338 | .00106 / .00096 |
| One code-lint block | .03689 / .03658 | .00147 / .00160 |
| One docs-test extraction | .03787 / .03663 | .00110 / .00111 |
| Code lint absent, 16896-byte HTML | .04684 / .04549 | .01413 / .01427 |
| Cross references absent, unchanged sync path | .12139 / .12478 | .12128 / .12079 |

The fixed overhead drops by roughly 32 microseconds per async load. Whole-build speedups do not follow directly from these stage timings. Some unchanged highlighting/citation controls were 10–20% slower in the first head run, so no performance claim is made for those paths. Reproduction uses the pipeline benchmark from #1394; this PR contains only the loader and focused tests.

Validation: 51 tests passed across loader failure/recovery/concurrency, Markdown transforms, embeds, code blocks, highlighting and frameworks. The new tests fail on the base implementation and pass with this change. Changed-file formatting/lint and source-size checks pass. Base 3a311bed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791554262&installation_model_id=422833&pr_number=1395&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1395&signature=c39cc4dbfcc60541d46473ae243961df8c489045bcd259114bd9fb844b86e841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->