### PR TITLE
perf(mermaid): render repeated diagram sources once per document

### DIFF
--- a/crates/ox_content_mermaid/examples/render.rs
+++ b/crates/ox_content_mermaid/examples/render.rs
@@ -1,0 +1,34 @@
+use ox_content_mermaid::transform_mermaid;
+use std::fmt::Write as _;
+use std::io::Write as _;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().collect();
+    let command = args.get(1).ok_or("Usage: render /path/to/mmdc [count] [distinct]")?;
+    let count = args.get(2).and_then(|v| v.parse::<usize>().ok()).unwrap_or(1);
+    let distinct = args.get(3).is_some_and(|v| v == "distinct");
+    let mut input = String::new();
+    for i in 0..count {
+        write!(
+            input,
+            "<pre><code class=\"language-mermaid\">graph TD; A--&gt;B{};</code></pre>",
+            if distinct { i } else { 0 }
+        )?;
+    }
+    let start = std::time::Instant::now();
+    let result = transform_mermaid(input, command);
+    writeln!(
+        std::io::stdout().lock(),
+        "{{\"count\":{count},\"distinct\":{distinct},\"ms\":{},\"errors\":{},\"svg_count\":{}}}",
+        start.elapsed().as_secs_f64() * 1000.0,
+        result.errors.len(),
+        result.html.matches("<svg").count()
+    )?;
+    if let Ok(output) = std::env::var("OX_MERMAID_OUTPUT") {
+        std::fs::write(output, &result.html)?;
+    }
+    if !result.errors.is_empty() {
+        return Err(result.errors.join("\n").into());
+    }
+    Ok(())
+}

--- a/crates/ox_content_mermaid/src/lib.rs
+++ b/crates/ox_content_mermaid/src/lib.rs
@@ -12,48 +12,61 @@ pub struct MermaidTransformResult {
 /// renders each in parallel using the mmdc CLI, and replaces them with
 /// `<div class="ox-mermaid">...</div>`.
 pub fn transform_mermaid(html: String, mmdc_path: &str) -> MermaidTransformResult {
-    let blocks = extract_mermaid_blocks_from_html(&html);
+    transform_with_renderer(html, &|source| render_mermaid_with_mmdc(source, mmdc_path))
+}
 
+fn transform_with_renderer(
+    html: String,
+    renderer: &(impl Fn(&str) -> Result<String, String> + Sync),
+) -> MermaidTransformResult {
+    let blocks = extract_mermaid_blocks_from_html(&html);
     if blocks.is_empty() {
         return MermaidTransformResult { html, errors: vec![] };
     }
 
-    // Render all diagrams in parallel using scoped threads.
-    // The intermediate collect() is intentional: we must spawn ALL threads before
-    // joining any, otherwise they would run sequentially instead of in parallel.
+    // Deduplicate decoded sources only within this document. Render raw SVGs;
+    // each occurrence receives fresh IDs when inserted into the document.
+    let mut sources: Vec<&str> = blocks.iter().map(|block| block.source.as_str()).collect();
+    sources.sort_unstable();
+    sources.dedup();
     #[allow(clippy::needless_collect)]
-    let render_results: Vec<std::result::Result<String, String>> = std::thread::scope(|s| {
-        let handles: Vec<_> = blocks
-            .iter()
-            .map(|block| {
-                let source = &block.source;
-                s.spawn(move || render_mermaid_with_mmdc(source, mmdc_path))
-            })
-            .collect();
-
+    let rendered: Vec<Result<String, String>> = std::thread::scope(|scope| {
+        let handles: Vec<_> =
+            sources.iter().map(|source| scope.spawn(move || renderer(source))).collect();
         handles
             .into_iter()
-            .map(|h| h.join().unwrap_or_else(|_| Err("Thread panicked".to_string())))
+            .map(|handle| handle.join().unwrap_or_else(|_| Err("Thread panicked".to_string())))
             .collect()
     });
 
-    // Replace blocks in reverse order to preserve positions
-    let mut result_html = html;
+    let mut output = String::with_capacity(html.len());
+    let mut cursor = 0;
     let mut errors = Vec::new();
-
-    for (i, block) in blocks.iter().enumerate().rev() {
-        match &render_results[i] {
-            Ok(svg) => {
-                let replacement = format!(r#"<div class="ox-mermaid">{svg}</div>"#);
-                result_html.replace_range(block.start..block.end, &replacement);
+    for block in &blocks {
+        output.push_str(&html[cursor..block.start]);
+        let result = sources
+            .binary_search(&block.source.as_str())
+            .ok()
+            .and_then(|index| rendered.get(index));
+        match result {
+            Some(Ok(svg)) => {
+                let id = MERMAID_FILE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                output.push_str(r#"<div class="ox-mermaid">"#);
+                output.push_str(&postprocess_mermaid_svg(svg, id));
+                output.push_str("</div>");
             }
-            Err(e) => {
-                errors.push(e.clone());
+            Some(Err(error)) => {
+                errors.push(error.clone());
+                output.push_str(&html[block.start..block.end]);
             }
+            None => output.push_str(&html[block.start..block.end]),
         }
+        cursor = block.end;
     }
-
-    MermaidTransformResult { html: result_html, errors }
+    output.push_str(&html[cursor..]);
+    // Preserve the previous reverse replacement order for diagnostics.
+    errors.reverse();
+    MermaidTransformResult { html: output, errors }
 }
 
 struct MermaidBlock {
@@ -163,9 +176,6 @@ fn render_mermaid_with_mmdc(source: &str, mmdc_path: &str) -> std::result::Resul
 
     let _ = std::fs::remove_file(&output_path);
 
-    // Post-process SVG
-    let svg = postprocess_mermaid_svg(&svg, id);
-
     Ok(svg)
 }
 
@@ -180,3 +190,6 @@ fn postprocess_mermaid_svg(svg: &str, id: u64) -> String {
         .replace("background-color:white;", "background-color:transparent;")
         .replace("my-svg", &unique_id)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/ox_content_mermaid/src/tests.rs
+++ b/crates/ox_content_mermaid/src/tests.rs
@@ -1,0 +1,77 @@
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn block(source: &str) -> String {
+    format!(r#"<pre><code class="language-mermaid">{source}</code></pre>"#)
+}
+
+#[test]
+fn repeated_sources_render_once_with_distinct_svg_ids() {
+    let calls = AtomicUsize::new(0);
+    let input = format!("İ前{}後", block("graph TD; A--&gt;B;").repeat(64));
+    let output = transform_with_renderer(input, &|source| {
+        calls.fetch_add(1, Ordering::Relaxed);
+        assert_eq!(source, "graph TD; A-->B;");
+        Ok(r#"<svg id="my-svg"><style>#my-svg{background-color: white;}</style><path marker-end="url(#my-svg-end)"/></svg>"#.to_string())
+    });
+    assert_eq!(calls.load(Ordering::Relaxed), 1);
+    assert!(output.errors.is_empty());
+    assert!(output.html.starts_with("İ前"));
+    assert!(output.html.ends_with('後'));
+    assert_eq!(output.html.matches("<svg").count(), 64);
+    assert!(!output.html.contains("my-svg"));
+    let mut ids = Vec::new();
+    for part in output.html.split("<svg id=\"").skip(1) {
+        let id = part.split('"').next().unwrap_or_default();
+        assert!(part.contains(&format!("#{id}{{background-color: transparent;}}")));
+        assert!(part.contains(&format!("url(#{id}-end)")));
+        ids.push(id);
+    }
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(ids.len(), 64);
+}
+
+#[test]
+fn decoded_equivalent_sources_share_rendering_but_distinct_sources_do_not() {
+    let calls = AtomicUsize::new(0);
+    let output = transform_with_renderer(
+        block("A--&gt;B") + &block("A--&#62;B") + &block("B--&gt;C"),
+        &|_| {
+            calls.fetch_add(1, Ordering::Relaxed);
+            Ok("<svg id=\"my-svg\"></svg>".to_string())
+        },
+    );
+    assert_eq!(calls.load(Ordering::Relaxed), 2);
+    assert_eq!(output.html.matches("<svg").count(), 3);
+}
+
+#[test]
+fn repeated_failures_keep_each_diagnostic_and_authored_block_in_original_error_order() {
+    let calls = AtomicUsize::new(0);
+    let input = block("bad A") + &block("bad A") + &block("bad B");
+    let output = transform_with_renderer(input.clone(), &|source| {
+        calls.fetch_add(1, Ordering::Relaxed);
+        Err(source.to_string())
+    });
+    assert_eq!(calls.load(Ordering::Relaxed), 2);
+    assert_eq!(output.html, input);
+    assert_eq!(output.errors, ["bad B", "bad A", "bad A"]);
+}
+
+#[test]
+fn separate_documents_retry_and_absent_or_unclosed_blocks_never_render() {
+    let calls = AtomicUsize::new(0);
+    let renderer = |_: &str| {
+        calls.fetch_add(1, Ordering::Relaxed);
+        Ok("<svg/>".to_string())
+    };
+    for _ in 0..2 {
+        transform_with_renderer(block("A"), &renderer);
+    }
+    assert_eq!(calls.load(Ordering::Relaxed), 2);
+    for input in ["<p>plain</p>", r#"<pre><code class="language-mermaid">unclosed"#] {
+        assert_eq!(transform_with_renderer(input.to_string(), &renderer).html, input);
+    }
+    assert_eq!(calls.load(Ordering::Relaxed), 2);
+}


### PR DESCRIPTION
Repeated Mermaid sources currently launch a separate mmdc process and browser for every occurrence. Deduplicate decoded sources within one document, render raw SVG once per distinct source, then assign fresh SVG IDs per occurrence. Assemble output in one forward pass and preserve the previous reverse diagnostic order, including one error per failed occurrence. Separate documents still render independently.

Real mmdc 11.16.0 with local Chrome, Apple M5 Pro, release Rust, A/B/B/A order, three samples per workload per run:

| Workload | Base medians ms | Head medians ms |
| --- | --- | --- |
| One diagram | 709.871 / 617.676 | 743.162 / 620.830 |
| Four identical diagrams | 1219.499 / 1229.385 | 623.061 / 697.011 |
| Four distinct diagrams | 1143.736 / 1138.029 | 1164.587 / 1133.941 |

The repeated case is 1.855× faster (46.1% less elapsed time), reducing renderer launches 4→1. Distinct and single controls are approximately +0.7% and +2.7% elapsed time. All 36 successful runs produced SVGs; complete HTML matches after normalizing the intentionally variable `ox-mermaid-N` IDs. These are renderer-stage timings, not whole-build results. First-use browser startup is excluded from these warmed-environment samples.

Four unit regressions verify 64 independent SVG IDs from one render, decoded-equivalent sharing, distinct sources, failure multiplicity/order, untouched malformed input, and document isolation. `cargo test -p ox_content_mermaid`, all-target Clippy, Rustfmt, panic and source-size checks pass. The example `cargo run --release -p ox_content_mermaid --example render -- /path/to/mmdc 4` reproduces the stage; add `distinct` for the control and set `OX_MERMAID_OUTPUT` to retain output. Set `PUPPETEER_EXECUTABLE_PATH` to the same browser at both revisions. Base 3a311bed.

CI infrastructure note: the first VS Code extension job (102497925403, run 34361083059) failed while downloading the test editor: `@vscode/test-electron request timeout out after 15000ms`. It did not report a test assertion failure. The log is retained and that failed job is rerun once at the same head.
