### PR TITLE
fix(vite-plugin): ignore project config for standalone snippet checks

### DIFF
--- a/npm/vite-plugin-ox-content/src/code-block-typecheck-config.test.ts
+++ b/npm/vite-plugin-ox-content/src/code-block-typecheck-config.test.ts
@@ -1,0 +1,37 @@
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+import { typecheckCodeBlocks } from "./code-blocks";
+
+const require = createRequire(import.meta.url);
+const compilerRequire = createRequire(require.resolve("@typescript/native-preview/package.json"));
+const platformPackage = compilerRequire.resolve(
+  `@typescript/native-preview-${process.platform}-${process.arch}/package.json`,
+);
+const tsgoCommand = join(
+  dirname(platformPackage),
+  "lib",
+  process.platform === "win32" ? "tsgo.exe" : "tsgo",
+);
+
+describe("standalone docs snippet typechecking", () => {
+  it("checks valid snippets even when the consumer has a tsconfig.json", async () => {
+    expect(existsSync("tsconfig.json")).toBe(true);
+    const diagnostics = await typecheckCodeBlocks(
+      "```ts typecheck\nexport const answer: number = 42;\n```",
+      { tsgoCommand },
+    );
+    expect(diagnostics).toEqual([]);
+  });
+
+  it("still reports a real snippet type error instead of TS5112", async () => {
+    const diagnostics = await typecheckCodeBlocks(
+      '```ts typecheck\nexport const answer: number = "wrong";\n```',
+      { tsgoCommand },
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain("TS2322");
+    expect(diagnostics[0]?.message).not.toContain("TS5112");
+  });
+});

--- a/npm/vite-plugin-ox-content/src/code-blocks.ts
+++ b/npm/vite-plugin-ox-content/src/code-blocks.ts
@@ -150,7 +150,7 @@ export async function typecheckCodeBlocks(
     try {
       await execFileAsync(
         options.tsgoCommand ?? "tsgo",
-        ["--noEmit", "--pretty", "false", ...files],
+        ["--ignoreConfig", "--noEmit", "--pretty", "false", ...files],
         {
           cwd: process.cwd(),
           maxBuffer: 1024 * 1024 * 4,


### PR DESCRIPTION
With tsgo 7.0.0-dev.20260707.2 and a tsconfig.json in the consumer working directory, even a valid `ts typecheck` fence fails with TS5112: explicit input files require `--ignoreConfig`. Pass that option when checking the temporary standalone snippet files; this preserves the existing intent to check those explicit files rather than loading a project config.

Found while measuring extension execution. Real compiler regressions verify that a valid `export const answer: number = 42` succeeds in this repository with its tsconfig.json present and an invalid string assignment reports TS2322 rather than TS5112. Both tests fail on the base implementation and pass with the fix. Four focused code-block tests, changed-file formatting/lint and source-size checks pass. Compiler resolution in the tests uses the installed platform-specific native-preview package, including the Windows executable suffix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791554925&installation_model_id=422833&pr_number=1397&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1397&signature=38722ff6ead781d8664453e07865eec5a95e9376d196c02087328ca5a03066b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->