### PR TITLE
fix(vite-plugin): dispatch Mermaid fences to the native renderer

### DIFF
--- a/npm/vite-plugin-ox-content/src/plugins/mermaid-dispatch.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/mermaid-dispatch.test.ts
@@ -9,14 +9,41 @@ const { render } = vi.hoisted(() => ({
     errors: [],
   })),
 }));
-vi.mock("../napi", () => ({ importNapiModule: async () => ({ transformMermaid: render }) }));
+vi.mock("../napi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../napi")>();
+  return {
+    ...actual,
+    importNapiModule: async () => ({
+      ...(await actual.importNapiModule()),
+      transformMermaid: render,
+    }),
+  };
+});
 import { transformMermaidStatic } from "./mermaid";
+import { renderMarkdown } from "../render-markdown";
 
 beforeEach(() => {
   render.mockClear();
 });
 
 describe("Mermaid fence dispatch", () => {
+  it("renders ordinary fences when the public mermaid option is enabled", async () => {
+    const source = "```mermaid\ngraph TD; A-->B;\n```";
+    const enabled = await renderMarkdown(source, "/virtual/diagram.md", {
+      mermaid: true,
+      highlight: false,
+      embeds: false,
+    });
+    expect(enabled.html).toContain("<svg>");
+    expect(render).toHaveBeenCalledTimes(1);
+    const disabled = await renderMarkdown(source, "/virtual/diagram.md", {
+      mermaid: false,
+      highlight: false,
+      embeds: false,
+    });
+    expect(disabled.html).toContain('class="language-mermaid"');
+    expect(render).toHaveBeenCalledTimes(1);
+  });
   it("dispatches ordinary Markdown renderer output without a rendered-diagram marker", async () => {
     const html = '<pre><code class="language-mermaid">graph TD; A--&gt;B;</code></pre>\n';
     expect(await transformMermaidStatic(html)).toContain("<svg>");

--- a/npm/vite-plugin-ox-content/src/plugins/mermaid-dispatch.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/mermaid-dispatch.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { render } = vi.hoisted(() => ({
+  render: vi.fn((html: string) => ({
+    html: html.replace(
+      /<pre><code class="language-mermaid">[\s\S]*?<\/code><\/pre>/g,
+      '<div class="ox-mermaid"><svg></svg></div>',
+    ),
+    errors: [],
+  })),
+}));
+vi.mock("../napi", () => ({ importNapiModule: async () => ({ transformMermaid: render }) }));
+import { transformMermaidStatic } from "./mermaid";
+
+beforeEach(() => {
+  render.mockClear();
+});
+
+describe("Mermaid fence dispatch", () => {
+  it("dispatches ordinary Markdown renderer output without a rendered-diagram marker", async () => {
+    const html = '<pre><code class="language-mermaid">graph TD; A--&gt;B;</code></pre>\n';
+    expect(await transformMermaidStatic(html)).toContain("<svg>");
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(render.mock.calls[0]?.[0]).toBe(html);
+  });
+
+  it("leaves already-rendered diagrams and ordinary text on the no-op path", async () => {
+    for (const html of [
+      '<div class="ox-mermaid"><svg></svg></div>',
+      "<p>language-mermaid</p>",
+      '<pre><code class="language-ts">const n = 1;</code></pre>',
+    ]) {
+      expect(await transformMermaidStatic(html)).toBe(html);
+    }
+    expect(render).not.toHaveBeenCalled();
+  });
+});

--- a/npm/vite-plugin-ox-content/src/plugins/mermaid.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/mermaid.ts
@@ -98,7 +98,7 @@ export async function transformMermaidStatic(
   html: string,
   _options?: MermaidOptions,
 ): Promise<string> {
-  if (!html.includes("ox-mermaid")) {
+  if (!html.includes('<pre><code class="language-mermaid">')) {
     return html;
   }
 


### PR DESCRIPTION
The Mermaid fast-path guard checks for `ox-mermaid`, a marker attached only after rendering. Ordinary Markdown produces `<pre><code class="language-mermaid">`, so the public Markdown pipeline currently skips the native renderer entirely. Match the native renderer’s actual input marker, and keep already-rendered diagrams/prose on the no-op path.

The original guard fails the dispatch/no-op regressions; all 13 dispatch/protection tests pass with the fix, including a public renderMarkdown enabled/disabled regression. Changed-file formatting/lint and source-size checks pass. The combined build, including #1396, is also verified through the public `renderMarkdown` API with `{mermaid: true, highlight: false, embeds: false}` using real mmdc/Chrome: four ordinary Mermaid fences produce four SVGs. This fixes dispatch rather than claiming that skipped rendering was a valid fast baseline. Renderer-stage speed measurements are recorded separately in #1396.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791556056&installation_model_id=422833&pr_number=1398&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1398&signature=da63549315ab4a9fcefbfe2ade3e9b9e6e8f1095a5d8c814f1ca839f544312d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->