### PR TITLE
fix(custom-host): retain Svelte SSR stylesheet roots

### DIFF
--- a/npm/vite-plugin-ox-content-svelte/src/custom-host-svelte-stylesheets.test.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/custom-host-svelte-stylesheets.test.ts
@@ -39,6 +39,7 @@ describe("custom host Svelte SSR stylesheets", () => {
       const css = await readLinkedCss(root, html);
       expect(css).toMatch(/color:(?:red|rgb\(255,0,0\))/u);
       expect(css).toMatch(/color:(?:#00f|blue|rgb\(0,0,255\))/u);
+      expect(css).toMatch(/color:(?:green|rgb\(0,128,0\))/u);
     },
     30_000,
   );
@@ -62,16 +63,19 @@ describe("custom host Svelte SSR stylesheets", () => {
       const state = await page.evaluate(() => {
         const probe = document.querySelector(".probe");
         const child = document.querySelector(".child");
+        const header = document.querySelector(".siteHeader");
         return {
           scripts: document.scripts.length,
           probeColor: probe ? getComputedStyle(probe).color : "",
           childColor: child ? getComputedStyle(child).color : "",
+          headerColor: header ? getComputedStyle(header).color : "",
         };
       });
 
       expect(state.scripts).toBe(0);
       expect(state.probeColor).toBe("rgb(255, 0, 0)");
       expect(state.childColor).toBe("rgb(0, 0, 255)");
+      expect(state.headerColor).toBe("rgb(0, 128, 0)");
     } finally {
       await browser?.close();
     }
@@ -93,9 +97,11 @@ describe("custom host Svelte SSR stylesheets", () => {
       expect(first.text).toContain('data-diagnostics=""');
       expect(first.text).toContain("Page.svelte");
       expect(first.text).toContain("Child.svelte");
+      expect(first.text).toContain("SiteHeader.svelte");
       expect(first.text).toContain("type=style");
 
       expect(first.text).toMatch(/color:\s*rgb\(0,\s*0,\s*255\)/u);
+      expect(first.text).toMatch(/color:\s*rgb\(0,\s*128,\s*0\)/u);
 
       await writeFile(
         root,
@@ -114,10 +120,7 @@ describe("custom host Svelte SSR stylesheets", () => {
 });
 
 function viteConfig(root: string): InlineConfig {
-  return {
-    root,
-    configFile: path.join(root, "vite.config.mjs"),
-  };
+  return { root, configFile: path.join(root, "vite.config.mjs") };
 }
 
 async function createProject(prefix: string): Promise<string> {
@@ -130,19 +133,22 @@ async function createProject(prefix: string): Promise<string> {
   await writeFile(
     root,
     "src/Page.svelte",
-    [
-      "<script>",
-      '  import Child from "./Child.svelte";',
-      "</script>",
-      '<h1 class="probe">Hello</h1>',
-      "<Child />",
-      "<style>.probe{color:rgb(255,0,0)}</style>",
-    ].join("\n"),
+    '<script>\n  import Child from "./Child.svelte";\n</script>\n<h1 class="probe">Hello</h1>\n<Child />\n<style>.probe{color:rgb(255,0,0)}</style>\n',
   );
   await writeFile(
     root,
     "src/Child.svelte",
     '<p class="child">child</p>\n<style>.child{color:rgb(0,0,255)}</style>\n',
+  );
+  await writeFile(
+    root,
+    "src/SiteLayout.svelte",
+    '<script>\n  import SiteHeader from "./SiteHeader.svelte";\n</script>\n<SiteHeader />\n',
+  );
+  await writeFile(
+    root,
+    "src/SiteHeader.svelte",
+    '<header class="siteHeader">header</header>\n<style>.siteHeader{color:rgb(0,128,0)}</style>\n',
   );
   await writeFile(root, "src/host.ts", hostModuleSource());
   return root;
@@ -169,7 +175,7 @@ async function writeViteConfig(
       "  logLevel: 'silent',",
       "  plugins: [",
       "    noopSsrSvelteStyleImports(),",
-      "    svelte(),",
+      "    svelte({ configFile: false }),",
       "    ...oxContentCustomHost({",
       '      host: "./src/host.ts",',
       "      oxContent: {",
@@ -183,7 +189,7 @@ async function writeViteConfig(
       "        feeds: false,",
       "        siteMaps: false,",
       "      },",
-      '      ssrStylesheets: { modules: ["/src/Page.svelte"] },',
+      '      ssrStylesheets: { modules: ["/src/Page.svelte", "/src/SiteLayout.svelte"] },',
       "      build: { transformHtml: false, runInTest: true },",
       `      dev: ${JSON.stringify(devOptions)},`,
       "    }),",
@@ -243,9 +249,13 @@ export default {
       async render(ctx) {
         renders += 1;
         const { default: Page } = await ctx.loadModule("/src/Page.svelte");
+        const { default: SiteLayout } = await ctx.loadModule("/src/SiteLayout.svelte");
         const { render } = await ctx.loadModule("svelte/server");
         const rendered = render(Page);
-        const ssr = ctx.assets.ssrStylesheets({ modules: ["/src/Page.svelte"] });
+        const layout = render(SiteLayout);
+        const ssr = ctx.assets.ssrStylesheets({
+          modules: ["/src/Page.svelte", "/src/SiteLayout.svelte"],
+        });
         const content = await ctx.assets.stylesheetContent({ stylesheets: ssr.stylesheets });
         const assets = ctx.assets.document({
           islandStyles: ssr.stylesheets,
@@ -256,7 +266,7 @@ export default {
           })),
         });
         return {
-          html: "<!doctype html><html><head>" + assets.headHtml + "</head><body data-render=\\"" + renders + "\\" data-diagnostics=\\"" + ssr.diagnostics.map((diagnostic) => diagnostic.code).join(",") + "\\" data-style-content-diagnostics=\\"" + content.diagnostics.map((diagnostic) => diagnostic.code).join(",") + "\\">" + (rendered.html || rendered.body || "") + "</body></html>",
+          html: "<!doctype html><html><head>" + assets.headHtml + "</head><body data-render=\\"" + renders + "\\" data-diagnostics=\\"" + ssr.diagnostics.map((diagnostic) => diagnostic.code).join(",") + "\\" data-style-content-diagnostics=\\"" + content.diagnostics.map((diagnostic) => diagnostic.code).join(",") + "\\">" + (layout.html || layout.body || "") + (rendered.html || rendered.body || "") + "</body></html>",
           dependencies: ssr.dependencies,
         };
       },
@@ -334,7 +344,5 @@ function wait(ms: number): Promise<void> {
 }
 
 function closeServer(server: http.Server): Promise<void> {
-  return new Promise((resolve) => {
-    server.close(() => resolve());
-  });
+  return new Promise((resolve) => server.close(() => resolve()));
 }

--- a/npm/vite-plugin-ox-content/src/custom-host-ssr-build-stylesheets.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-ssr-build-stylesheets.ts
@@ -92,7 +92,9 @@ function stylesheetImport(
     return `import ${binding} from ${moduleId};\nexport const ${binding}ClassNames = Object.values(${binding});`;
   }
   if (isFrameworkStyleRoot(stylesheet.file)) {
-    return `import ${moduleId};`;
+    const binding = `__oxContentSsrStyleRoot${index}`;
+    // Svelte plugins may drop CSS for roots that are imported only for side effects.
+    return `import ${binding} from ${moduleId};\nglobalThis.__oxContentSsrStyleRoot?.(${binding});`;
   }
   return `import ${moduleId};`;
 }

--- a/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.test.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.test.ts
@@ -33,7 +33,14 @@ describe("custom host SSR stylesheets", () => {
         },
         "/repo",
       ),
-    ).toBe(['import "/src/Page.svelte";', 'import "/src/page.css";', ""].join("\n"));
+    ).toBe(
+      [
+        'import __oxContentSsrStyleRoot0 from "/src/Page.svelte";',
+        "globalThis.__oxContentSsrStyleRoot?.(__oxContentSsrStyleRoot0);",
+        'import "/src/page.css";',
+        "",
+      ].join("\n"),
+    );
   });
 
   it("collects imported build chunk CSS before direct root CSS", () => {


### PR DESCRIPTION
## Summary
- keep Svelte SSR stylesheet roots live inside generated stylesheet entries so emitted scoped CSS survives production tree-shaking
- extend rsvelte coverage with configFile false, separate page/layout roots, and transitive scoped Svelte CSS in no-JavaScript output

## Validation
- vp test npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.test.ts npm/vite-plugin-ox-content-svelte/src/custom-host-svelte-stylesheets.test.ts
- vp test --typecheck npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.test.ts npm/vite-plugin-ox-content-svelte/src/custom-host-svelte-stylesheets.test.ts
- node tools/scripts/check-file-lines.ts --base origin/main

Closes #1389

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791627028&installation_model_id=422833&pr_number=1404&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1404&signature=afe8027e9b31f86edaa123598217b43748efdc9b446d9d00707032419f6994db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed server-rendered pages so styles from nested Svelte components and layouts are included correctly.
  - Improved handling of framework-level style roots during server-side rendering.
  - Ensured scoped component styles appear consistently in development, production, browser, and server-rendered builds.

- **Tests**
  - Added coverage verifying that layout and component styles are preserved, rendered correctly, and included in the expected order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->