### PR TITLE
fix(custom-host): resolve dev SSR stylesheet aliases

### DIFF
--- a/npm/vite-plugin-ox-content-svelte/src/custom-host-svelte-stylesheets.fixture.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/custom-host-svelte-stylesheets.fixture.ts
@@ -1,0 +1,275 @@
+import fs from "node:fs/promises";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Page } from "playwright";
+import type { InlineConfig, ViteDevServer } from "vite";
+import { expect } from "vite-plus/test";
+
+const tempDirs: string[] = [];
+const activeServers: ViteDevServer[] = [];
+const activeListeners: http.Server[] = [];
+const PACKAGE_ROOT = path.dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+
+export async function cleanupSvelteStylesheetFixture(): Promise<void> {
+  await Promise.all(activeListeners.splice(0).map((server) => closeServer(server)));
+  await Promise.all(activeServers.splice(0).map((server) => server.close().catch(() => {})));
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+}
+
+export function viteConfig(root: string): InlineConfig {
+  return { root, configFile: path.join(root, "vite.config.mjs") };
+}
+
+export async function createProject(prefix: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(PACKAGE_ROOT, `.tmp-${prefix}`));
+  tempDirs.push(root);
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.mkdir(path.join(root, "src", "components"), { recursive: true });
+  await fs.mkdir(path.join(root, "src", "config"), { recursive: true });
+  await fs.mkdir(path.join(root, "content"), { recursive: true });
+  await writeFile(root, "package.json", '{"type":"module"}\n');
+  await writeFile(
+    root,
+    "tsconfig.json",
+    JSON.stringify({ compilerOptions: { paths: { "@/*": ["./src/*"] } } }, null, 2),
+  );
+  await writeFile(root, "src/main.js", "document.body.dataset.client = 'unused';\n");
+  await writeFile(root, "src/Page.svelte", pageSource());
+  await writeFile(root, "src/components/Child.svelte", childSource("rgb(0,0,255)"));
+  await writeFile(root, "src/SiteLayout.svelte", siteLayoutSource());
+  await writeFile(root, "src/components/SiteHeader.svelte", siteHeaderSource());
+  await writeFile(root, "src/config/site.ts", 'export const siteName = "site";\n');
+  await writeFile(root, "src/config/site-owner.ts", 'export const ownerName = "owner";\n');
+  await writeFile(root, "src/host.ts", hostModuleSource());
+  return root;
+}
+
+export async function writeViteConfig(
+  root: string,
+  sveltePackage: string,
+  dev: { reloadDebounceMs?: number } = {},
+): Promise<void> {
+  const devOptions = { transformHtml: false, ...dev };
+  await writeFile(
+    root,
+    "vite.config.mjs",
+    [
+      'import path from "node:path";',
+      'import { fileURLToPath } from "node:url";',
+      'import { oxContentCustomHost } from "@ox-content/vite-plugin";',
+      `import { svelte } from ${JSON.stringify(sveltePackage)};`,
+      'const root = fileURLToPath(new URL(".", import.meta.url));',
+      "export default {",
+      '  base: "/docs/",',
+      "  appType: 'custom',",
+      "  logLevel: 'silent',",
+      "  resolve: {",
+      '    alias: { "@": path.join(root, "src") },',
+      "    tsconfigPaths: true,",
+      "  },",
+      "  plugins: [",
+      "    noopSsrSvelteStyleImports(),",
+      "    svelte({ configFile: false }),",
+      "    ...oxContentCustomHost({",
+      '      host: "./src/host.ts",',
+      "      oxContent: {",
+      '        base: "/docs/",',
+      '        srcDir: "content",',
+      '        outDir: "dist",',
+      "        resources: false,",
+      "        docs: false,",
+      "        search: false,",
+      "        ogViewer: false,",
+      "        feeds: false,",
+      "        siteMaps: false,",
+      "      },",
+      '      ssrStylesheets: { modules: ["/src/Page.svelte", "/src/SiteLayout.svelte"] },',
+      "      build: { transformHtml: false, runInTest: true },",
+      `      dev: ${JSON.stringify(devOptions)},`,
+      "    }),",
+      "  ],",
+      "  server: { fs: { allow: [root] } },",
+      "  build: {",
+      '    outDir: "dist",',
+      "    emptyOutDir: true,",
+      "    cssMinify: true,",
+      "    cssCodeSplit: true,",
+      "    manifest: true,",
+      '    rollupOptions: { input: path.join(root, "src", "main.js") },',
+      "  },",
+      "};",
+      "function noopSsrSvelteStyleImports() {",
+      "  const prefix = '\\0ox-content-svelte-ssr-style:';",
+      "  const modules = new Map();",
+      "  let command = 'build';",
+      "  return {",
+      "    name: 'ox-content-svelte-test:ssr-style-noop',",
+      "    enforce: 'pre',",
+      "    config(_config, env) {",
+      "      command = env.command;",
+      "    },",
+      "    resolveId(id, importer, options) {",
+      "      const loadingHost = process.env.OX_CONTENT_CUSTOM_HOST_LOAD === '1';",
+      "      const serving = command === 'serve';",
+      "      if ((loadingHost || serving || options?.ssr) && importer?.includes('.svelte') && isSvelteStyleModuleId(id)) {",
+      "        const resolved = `${prefix}${modules.size}`;",
+      "        modules.set(resolved, id);",
+      "        return resolved;",
+      "      }",
+      "      return null;",
+      "    },",
+      "    load(id) {",
+      "      if (modules.has(id)) return \"export default '';\";",
+      "      return null;",
+      "    },",
+      "  };",
+      "}",
+      "function isSvelteStyleModuleId(id) {",
+      "  return id.includes('.svelte') && /[?&]type=style(?:&|$)/u.test(id);",
+      "}",
+      "",
+    ].join("\n"),
+  );
+}
+
+export async function expectRenderedStyles(page: Page, childColor: string): Promise<void> {
+  const state = await page.evaluate(() => {
+    const probe = document.querySelector(".probe");
+    const child = document.querySelector(".child");
+    const header = document.querySelector(".siteHeader");
+    return {
+      client: document.body.dataset.client ?? "",
+      probeColor: probe ? getComputedStyle(probe).color : "",
+      childColor: child ? getComputedStyle(child).color : "",
+      headerColor: header ? getComputedStyle(header).color : "",
+    };
+  });
+  expect(state).toMatchObject({
+    client: "",
+    probeColor: "rgb(255, 0, 0)",
+    childColor,
+    headerColor: "rgb(0, 128, 0)",
+  });
+}
+
+export async function writeFile(root: string, file: string, content: string): Promise<void> {
+  await fs.writeFile(path.join(root, ...file.split("/")), content);
+}
+
+export async function trackServer(serverPromise: Promise<ViteDevServer>): Promise<ViteDevServer> {
+  const server = await serverPromise;
+  activeServers.push(server);
+  return server;
+}
+
+export async function listen(server: ViteDevServer): Promise<{ port: number }> {
+  const listener = http.createServer(server.middlewares);
+  activeListeners.push(listener);
+  await new Promise<void>((resolve) => listener.listen(0, "127.0.0.1", resolve));
+  return { port: (listener.address() as AddressInfo).port };
+}
+
+export async function serveDist(root: string): Promise<{ port: number }> {
+  const dist = path.join(root, "dist");
+  const listener = http.createServer(async (req, res) => {
+    const requestPath = new URL(req.url ?? "/", "http://localhost").pathname;
+    const relative = requestPath.startsWith("/docs/")
+      ? requestPath.slice("/docs/".length)
+      : requestPath.replace(/^\/+/u, "");
+    const decoded = decodeURIComponent(relative || "index.html");
+    const file = path.resolve(dist, decoded);
+    const candidate = requestPath.endsWith("/") ? path.join(file, "index.html") : file;
+    if (!candidate.startsWith(`${dist}${path.sep}`)) {
+      res.statusCode = 403;
+      res.end("Forbidden");
+      return;
+    }
+    try {
+      res.statusCode = 200;
+      res.end(await fs.readFile(candidate));
+    } catch {
+      res.statusCode = 404;
+      res.end("Not found");
+    }
+  });
+  activeListeners.push(listener);
+  await new Promise<void>((resolve) => listener.listen(0, "127.0.0.1", resolve));
+  return { port: (listener.address() as AddressInfo).port };
+}
+
+export async function readLinkedCss(root: string, html: string): Promise<string> {
+  const files = linkedCssPaths(html).map((href) =>
+    path.join(root, "dist", href.replace(/^\/docs\//u, "")),
+  );
+  return (await Promise.all(files.map((file) => fs.readFile(file, "utf8")))).join("\n");
+}
+
+export function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function pageSource(): string {
+  return '<script>\n  import Child from "@/components/Child.svelte";\n  import { siteName } from "@/config/site.ts";\n  import { ownerName } from "@/config/site-owner.ts";\n</script>\n<h1 class="probe">Hello {siteName} {ownerName}</h1>\n<Child />\n<style>.probe{color:rgb(255,0,0)}</style>\n';
+}
+
+function childSource(color: string): string {
+  return `<p class="child">child</p>\n<style>.child{color:${color}}</style>\n`;
+}
+
+function siteLayoutSource(): string {
+  return '<script>\n  import SiteHeader from "@/components/SiteHeader.svelte";\n</script>\n<SiteHeader />\n';
+}
+
+function siteHeaderSource(): string {
+  return '<header class="siteHeader">header</header>\n<style>.siteHeader{color:rgb(0,128,0)}</style>\n';
+}
+
+function hostModuleSource(): string {
+  return `
+let renders = 0;
+
+export default {
+  routes: [
+    {
+      path: "/probe",
+      async render(ctx) {
+        renders += 1;
+        const { default: Page } = await ctx.loadModule("/src/Page.svelte");
+        const { default: SiteLayout } = await ctx.loadModule("/src/SiteLayout.svelte");
+        const { render } = await ctx.loadModule("svelte/server");
+        const rendered = render(Page);
+        const layout = render(SiteLayout);
+        const ssr = ctx.assets.ssrStylesheets({
+          modules: ["/src/Page.svelte", "/src/SiteLayout.svelte"],
+        });
+        const content = await ctx.assets.stylesheetContent({ stylesheets: ssr.stylesheets });
+        const assets = ctx.assets.document({
+          islandStyles: ctx.mode === "build" ? ssr.stylesheets : [],
+          inlineStyles: content.stylesheets.map((stylesheet) => ({
+            key: "critical:" + stylesheet.href,
+            content: stylesheet.content,
+            attrs: { "data-critical": stylesheet.href },
+          })),
+        });
+        return {
+          html: "<!doctype html><html><head>" + assets.headHtml + "</head><body data-render=\\"" + renders + "\\" data-diagnostics=\\"" + ssr.diagnostics.map((diagnostic) => diagnostic.code).join(",") + "\\" data-style-content-diagnostics=\\"" + content.diagnostics.map((diagnostic) => diagnostic.code).join(",") + "\\">" + (layout.html || layout.body || "") + (rendered.html || rendered.body || "") + "</body></html>",
+          dependencies: ssr.dependencies,
+        };
+      },
+    },
+  ],
+};
+`;
+}
+
+function linkedCssPaths(html: string): string[] {
+  return [...html.matchAll(/href="(\/docs\/[^"]+)"/gu)].map((match) =>
+    match[1].replaceAll("&amp;", "&"),
+  );
+}
+
+function closeServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}

--- a/npm/vite-plugin-ox-content-svelte/src/custom-host-svelte-stylesheets.test.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/custom-host-svelte-stylesheets.test.ts
@@ -1,22 +1,23 @@
 import fs from "node:fs/promises";
-import * as http from "node:http";
-import type { AddressInfo } from "node:net";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { chromium, type Browser } from "playwright";
+import { build as viteBuild, createServer } from "vite";
 import { afterEach, describe, expect, it } from "vite-plus/test";
-import { build as viteBuild, createServer, type InlineConfig, type ViteDevServer } from "vite";
+import {
+  cleanupSvelteStylesheetFixture,
+  createProject,
+  expectRenderedStyles,
+  listen,
+  readLinkedCss,
+  serveDist,
+  trackServer,
+  viteConfig,
+  wait,
+  writeFile,
+  writeViteConfig,
+} from "./custom-host-svelte-stylesheets.fixture";
 
-const tempDirs: string[] = [];
-const activeServers: ViteDevServer[] = [];
-const activeListeners: http.Server[] = [];
-const PACKAGE_ROOT = path.dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
-
-afterEach(async () => {
-  await Promise.all(activeListeners.splice(0).map((server) => closeServer(server)));
-  await Promise.all(activeServers.splice(0).map((server) => server.close().catch(() => {})));
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
-});
+afterEach(cleanupSvelteStylesheetFixture);
 
 describe("custom host Svelte SSR stylesheets", () => {
   it.each([
@@ -60,22 +61,8 @@ describe("custom host Svelte SSR stylesheets", () => {
       const response = await page.goto(`http://127.0.0.1:${staticServer.port}/docs/probe/`);
       expect(response?.status()).toBe(200);
 
-      const state = await page.evaluate(() => {
-        const probe = document.querySelector(".probe");
-        const child = document.querySelector(".child");
-        const header = document.querySelector(".siteHeader");
-        return {
-          scripts: document.scripts.length,
-          probeColor: probe ? getComputedStyle(probe).color : "",
-          childColor: child ? getComputedStyle(child).color : "",
-          headerColor: header ? getComputedStyle(header).color : "",
-        };
-      });
-
-      expect(state.scripts).toBe(0);
-      expect(state.probeColor).toBe("rgb(255, 0, 0)");
-      expect(state.childColor).toBe("rgb(0, 0, 255)");
-      expect(state.headerColor).toBe("rgb(0, 128, 0)");
+      expect(await page.evaluate(() => document.scripts.length)).toBe(0);
+      await expectRenderedStyles(page, "rgb(0, 0, 255)");
     } finally {
       await browser?.close();
     }
@@ -91,258 +78,43 @@ describe("custom host Svelte SSR stylesheets", () => {
       await writeViteConfig(root, plugin, { reloadDebounceMs: 1 });
       const server = await trackServer(createServer(viteConfig(root)));
       const listener = await listen(server);
+      let browser: Browser | undefined;
 
-      const first = await read(listener.port, "/docs/probe");
-      expect(first.status, first.text).toBe(200);
-      expect(first.text).toContain('data-diagnostics=""');
-      expect(first.text).toContain("Page.svelte");
-      expect(first.text).toContain("Child.svelte");
-      expect(first.text).toContain("SiteHeader.svelte");
-      expect(first.text).toContain("type=style");
+      try {
+        browser = await chromium.launch({
+          channel: process.env.CI ? "chrome" : undefined,
+          headless: true,
+        });
+        const page = await browser.newPage();
+        const response = await page.goto(`http://127.0.0.1:${listener.port}/docs/probe`);
+        const firstHtml = await page.content();
+        expect(response?.status(), firstHtml).toBe(200);
+        expect(firstHtml).toContain('data-diagnostics=""');
+        expect(firstHtml).toContain('data-style-content-diagnostics=""');
+        expect(firstHtml).toContain("Page.svelte");
+        expect(firstHtml).toContain("Child.svelte");
+        expect(firstHtml).toContain("SiteHeader.svelte");
+        expect(firstHtml).toContain("type=style");
+        expect(firstHtml).toContain("data-critical");
+        expect(firstHtml).not.toContain('import Child from "@/components/Child.svelte"');
+        expect(firstHtml).not.toContain("<style>.child{color:rgb(0,0,255)}</style>");
+        await expectRenderedStyles(page, "rgb(0, 0, 255)");
 
-      expect(first.text).toMatch(/color:\s*rgb\(0,\s*0,\s*255\)/u);
-      expect(first.text).toMatch(/color:\s*rgb\(0,\s*128,\s*0\)/u);
+        await writeFile(
+          root,
+          "src/components/Child.svelte",
+          '<p class="child">child</p>\n<style>.child{color:rgb(0,128,0)}</style>\n',
+        );
+        server.watcher.emit("change", path.join(root, "src", "components", "Child.svelte"));
+        await wait(50);
 
-      await writeFile(
-        root,
-        "src/Child.svelte",
-        '<p class="child">child</p>\n<style>.child{color:rgb(0,128,0)}</style>\n',
-      );
-      server.watcher.emit("change", path.join(root, "src", "Child.svelte"));
-      await wait(50);
-
-      const updated = await read(listener.port, "/docs/probe");
-      expect(updated.text).toContain('data-render="2"');
-      expect(updated.text).toMatch(/color:\s*rgb\(0,\s*128,\s*0\)/u);
+        await page.reload();
+        expect((await page.locator("body").getAttribute("data-render")) ?? "").toBe("2");
+        await expectRenderedStyles(page, "rgb(0, 128, 0)");
+      } finally {
+        await browser?.close();
+      }
     },
     30_000,
   );
 });
-
-function viteConfig(root: string): InlineConfig {
-  return { root, configFile: path.join(root, "vite.config.mjs") };
-}
-
-async function createProject(prefix: string): Promise<string> {
-  const root = await fs.mkdtemp(path.join(PACKAGE_ROOT, `.tmp-${prefix}`));
-  tempDirs.push(root);
-  await fs.mkdir(path.join(root, "src"), { recursive: true });
-  await fs.mkdir(path.join(root, "content"), { recursive: true });
-  await writeFile(root, "package.json", '{"type":"module"}\n');
-  await writeFile(root, "src/main.js", "document.body.dataset.client = 'unused';\n");
-  await writeFile(
-    root,
-    "src/Page.svelte",
-    '<script>\n  import Child from "./Child.svelte";\n</script>\n<h1 class="probe">Hello</h1>\n<Child />\n<style>.probe{color:rgb(255,0,0)}</style>\n',
-  );
-  await writeFile(
-    root,
-    "src/Child.svelte",
-    '<p class="child">child</p>\n<style>.child{color:rgb(0,0,255)}</style>\n',
-  );
-  await writeFile(
-    root,
-    "src/SiteLayout.svelte",
-    '<script>\n  import SiteHeader from "./SiteHeader.svelte";\n</script>\n<SiteHeader />\n',
-  );
-  await writeFile(
-    root,
-    "src/SiteHeader.svelte",
-    '<header class="siteHeader">header</header>\n<style>.siteHeader{color:rgb(0,128,0)}</style>\n',
-  );
-  await writeFile(root, "src/host.ts", hostModuleSource());
-  return root;
-}
-
-async function writeViteConfig(
-  root: string,
-  sveltePackage: string,
-  dev: { reloadDebounceMs?: number } = {},
-): Promise<void> {
-  const devOptions = { transformHtml: false, ...dev };
-  await writeFile(
-    root,
-    "vite.config.mjs",
-    [
-      'import path from "node:path";',
-      'import { fileURLToPath } from "node:url";',
-      'import { oxContentCustomHost } from "@ox-content/vite-plugin";',
-      `import { svelte } from ${JSON.stringify(sveltePackage)};`,
-      'const root = fileURLToPath(new URL(".", import.meta.url));',
-      "export default {",
-      '  base: "/docs/",',
-      "  appType: 'custom',",
-      "  logLevel: 'silent',",
-      "  plugins: [",
-      "    noopSsrSvelteStyleImports(),",
-      "    svelte({ configFile: false }),",
-      "    ...oxContentCustomHost({",
-      '      host: "./src/host.ts",',
-      "      oxContent: {",
-      '        base: "/docs/",',
-      '        srcDir: "content",',
-      '        outDir: "dist",',
-      "        resources: false,",
-      "        docs: false,",
-      "        search: false,",
-      "        ogViewer: false,",
-      "        feeds: false,",
-      "        siteMaps: false,",
-      "      },",
-      '      ssrStylesheets: { modules: ["/src/Page.svelte", "/src/SiteLayout.svelte"] },',
-      "      build: { transformHtml: false, runInTest: true },",
-      `      dev: ${JSON.stringify(devOptions)},`,
-      "    }),",
-      "  ],",
-      "  server: { fs: { allow: [root] } },",
-      "  build: {",
-      '    outDir: "dist",',
-      "    emptyOutDir: true,",
-      "    cssMinify: true,",
-      "    cssCodeSplit: true,",
-      "    manifest: true,",
-      '    rollupOptions: { input: path.join(root, "src", "main.js") },',
-      "  },",
-      "};",
-      "function noopSsrSvelteStyleImports() {",
-      "  const prefix = '\\0ox-content-svelte-ssr-style:';",
-      "  const modules = new Map();",
-      "  let command = 'build';",
-      "  return {",
-      "    name: 'ox-content-svelte-test:ssr-style-noop',",
-      "    enforce: 'pre',",
-      "    config(_config, env) {",
-      "      command = env.command;",
-      "    },",
-      "    resolveId(id, importer, options) {",
-      "      const loadingHost = process.env.OX_CONTENT_CUSTOM_HOST_LOAD === '1';",
-      "      const serving = command === 'serve';",
-      "      if ((loadingHost || serving || options?.ssr) && importer?.includes('.svelte') && isSvelteStyleModuleId(id)) {",
-      "        const resolved = `${prefix}${modules.size}`;",
-      "        modules.set(resolved, id);",
-      "        return resolved;",
-      "      }",
-      "      return null;",
-      "    },",
-      "    load(id) {",
-      "      if (modules.has(id)) return \"export default '';\";",
-      "      return null;",
-      "    },",
-      "  };",
-      "}",
-      "function isSvelteStyleModuleId(id) {",
-      "  return id.includes('.svelte') && /[?&]type=style(?:&|$)/u.test(id);",
-      "}",
-      "",
-    ].join("\n"),
-  );
-}
-
-function hostModuleSource(): string {
-  return `
-let renders = 0;
-
-export default {
-  routes: [
-    {
-      path: "/probe",
-      async render(ctx) {
-        renders += 1;
-        const { default: Page } = await ctx.loadModule("/src/Page.svelte");
-        const { default: SiteLayout } = await ctx.loadModule("/src/SiteLayout.svelte");
-        const { render } = await ctx.loadModule("svelte/server");
-        const rendered = render(Page);
-        const layout = render(SiteLayout);
-        const ssr = ctx.assets.ssrStylesheets({
-          modules: ["/src/Page.svelte", "/src/SiteLayout.svelte"],
-        });
-        const content = await ctx.assets.stylesheetContent({ stylesheets: ssr.stylesheets });
-        const assets = ctx.assets.document({
-          islandStyles: ssr.stylesheets,
-          inlineStyles: content.stylesheets.map((stylesheet) => ({
-            key: "critical:" + stylesheet.href,
-            content: stylesheet.content,
-            attrs: { "data-critical": stylesheet.href },
-          })),
-        });
-        return {
-          html: "<!doctype html><html><head>" + assets.headHtml + "</head><body data-render=\\"" + renders + "\\" data-diagnostics=\\"" + ssr.diagnostics.map((diagnostic) => diagnostic.code).join(",") + "\\" data-style-content-diagnostics=\\"" + content.diagnostics.map((diagnostic) => diagnostic.code).join(",") + "\\">" + (layout.html || layout.body || "") + (rendered.html || rendered.body || "") + "</body></html>",
-          dependencies: ssr.dependencies,
-        };
-      },
-    },
-  ],
-};
-`;
-}
-
-async function writeFile(root: string, file: string, content: string): Promise<void> {
-  await fs.writeFile(path.join(root, ...file.split("/")), content);
-}
-
-async function trackServer(serverPromise: Promise<ViteDevServer>): Promise<ViteDevServer> {
-  const server = await serverPromise;
-  activeServers.push(server);
-  return server;
-}
-
-async function listen(server: ViteDevServer): Promise<{ port: number }> {
-  const listener = http.createServer(server.middlewares);
-  activeListeners.push(listener);
-  await new Promise<void>((resolve) => listener.listen(0, "127.0.0.1", resolve));
-  return { port: (listener.address() as AddressInfo).port };
-}
-
-async function read(port: number, requestPath: string) {
-  const response = await fetch(`http://127.0.0.1:${port}${requestPath}`);
-  return { status: response.status, headers: response.headers, text: await response.text() };
-}
-
-async function serveDist(root: string): Promise<{ port: number }> {
-  const dist = path.join(root, "dist");
-  const listener = http.createServer(async (req, res) => {
-    const requestPath = new URL(req.url ?? "/", "http://localhost").pathname;
-    const relative = requestPath.startsWith("/docs/")
-      ? requestPath.slice("/docs/".length)
-      : requestPath.replace(/^\/+/u, "");
-    const decoded = decodeURIComponent(relative || "index.html");
-    const file = path.resolve(dist, decoded);
-    const candidate = requestPath.endsWith("/") ? path.join(file, "index.html") : file;
-    if (!candidate.startsWith(`${dist}${path.sep}`)) {
-      res.statusCode = 403;
-      res.end("Forbidden");
-      return;
-    }
-    try {
-      res.statusCode = 200;
-      res.end(await fs.readFile(candidate));
-    } catch {
-      res.statusCode = 404;
-      res.end("Not found");
-    }
-  });
-  activeListeners.push(listener);
-  await new Promise<void>((resolve) => listener.listen(0, "127.0.0.1", resolve));
-  return { port: (listener.address() as AddressInfo).port };
-}
-
-async function readLinkedCss(root: string, html: string): Promise<string> {
-  const files = linkedCssPaths(html).map((href) =>
-    path.join(root, "dist", href.replace(/^\/docs\//u, "")),
-  );
-  return (await Promise.all(files.map((file) => fs.readFile(file, "utf8")))).join("\n");
-}
-
-function linkedCssPaths(html: string): string[] {
-  return [...html.matchAll(/href="(\/docs\/[^"]+)"/gu)].map((match) =>
-    match[1].replaceAll("&amp;", "&"),
-  );
-}
-
-function wait(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function closeServer(server: http.Server): Promise<void> {
-  return new Promise((resolve) => server.close(() => resolve()));
-}

--- a/npm/vite-plugin-ox-content/src/custom-host-assets.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-assets.ts
@@ -4,12 +4,16 @@ import type { Connect } from "vite";
 import { resolveSelfHostedAssetManifest } from "./assets";
 import type { CollectionAssetManifest } from "./collection-assets";
 import { DEFAULT_THEME_TOKEN_HREF } from "./custom-host-constants";
-import { resolveCustomHostStylesheetContent } from "./custom-host-stylesheet-content";
+import {
+  resolveCustomHostStylesheetContent,
+  type CustomHostDevStylesheetContentResolver,
+} from "./custom-host-stylesheet-content";
 import {
   resolveCustomHostStylesheets,
   type CustomHostDevModuleGraph,
 } from "./custom-host-stylesheets";
 import type { CustomHostSsrStylesheetController } from "./custom-host-ssr-stylesheets";
+import type { CustomHostDevImportResolver } from "./custom-host-ssr-dev-stylesheets";
 import type {
   OxContentCustomHostAssetsContext,
   OxContentCustomHostOptions,
@@ -33,6 +37,8 @@ export function createAssetsContext(
   root?: string,
   collectionManifest: () => Promise<CollectionAssetManifest | undefined> = async () => undefined,
   ssrStylesheets?: CustomHostSsrStylesheetController,
+  resolveImport?: CustomHostDevImportResolver,
+  resolveDevContent?: CustomHostDevStylesheetContentResolver,
 ): OxContentCustomHostAssetsContext {
   const selfHosted = resolveSelfHostedAssetManifest(options);
   return {
@@ -57,6 +63,7 @@ export function createAssetsContext(
           manifest: clientManifest,
           moduleGraph,
           root,
+          resolveImport,
         }) ?? {
           stylesheets: [],
           dependencies: [],
@@ -74,6 +81,7 @@ export function createAssetsContext(
         ...input,
         build: !!clientManifest,
         outDir,
+        resolveDevContent,
       });
     },
     document(input: RenderDocumentAssetsInput = {}) {

--- a/npm/vite-plugin-ox-content/src/custom-host-dev-assets.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-dev-assets.ts
@@ -1,0 +1,44 @@
+import type { ViteDevServer } from "vite";
+import type { CollectionAssetManifest } from "./collection-assets";
+import { createAssetsContext } from "./custom-host-assets";
+import {
+  createCombinedDevModuleGraph,
+  createDevImportResolver,
+  createDevStylesheetContentResolver,
+} from "./custom-host-dev-resolvers";
+import type { CustomHostSsrStylesheetController } from "./custom-host-ssr-stylesheets";
+import type { OxContentCustomHostAssetsContext, ResolvedThemeTokens } from "./custom-host-types";
+import type { ResolvedOptions } from "./types";
+
+interface CreateCustomHostDevAssetsContextInput {
+  server: ViteDevServer;
+  options: ResolvedOptions;
+  outDir: string;
+  themeTokens: ResolvedThemeTokens | undefined;
+  root: string;
+  collectionManifest: () => Promise<CollectionAssetManifest | undefined>;
+  ssrStylesheets: CustomHostSsrStylesheetController;
+}
+
+export function createCustomHostDevAssetsContext({
+  server,
+  options,
+  outDir,
+  themeTokens,
+  root,
+  collectionManifest,
+  ssrStylesheets,
+}: CreateCustomHostDevAssetsContextInput): OxContentCustomHostAssetsContext {
+  return createAssetsContext(
+    options,
+    outDir,
+    undefined,
+    themeTokens,
+    createCombinedDevModuleGraph(server),
+    root,
+    collectionManifest,
+    ssrStylesheets,
+    createDevImportResolver(server),
+    createDevStylesheetContentResolver(server, options.base),
+  );
+}

--- a/npm/vite-plugin-ox-content/src/custom-host-dev-resolvers.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-dev-resolvers.ts
@@ -1,0 +1,275 @@
+import * as fsSync from "node:fs";
+import * as path from "node:path";
+import type { Alias, ViteDevServer } from "vite";
+import type { CustomHostDevImportResolver } from "./custom-host-ssr-dev-stylesheets";
+import type { CustomHostDevStylesheetContentResolver } from "./custom-host-stylesheet-content";
+import type { CustomHostDevModuleGraph, CustomHostDevModuleNode } from "./custom-host-stylesheets";
+import { stripBasePathname } from "./custom-host-utils";
+import { viteModuleGraphs } from "./custom-host-vite-invalidation";
+
+export function createCombinedDevModuleGraph(server: ViteDevServer): CustomHostDevModuleGraph {
+  return {
+    get idToModuleMap() {
+      const modules = new Map<string, CustomHostDevModuleNode>();
+      for (const graph of viteModuleGraphs(server)) {
+        for (const [id, node] of graph.idToModuleMap ?? []) {
+          modules.set(id, node as CustomHostDevModuleNode);
+        }
+      }
+      return modules;
+    },
+    getModuleById(id) {
+      for (const graph of viteModuleGraphs(server)) {
+        const node = graph.getModuleById?.(id);
+        if (node) {
+          return node as CustomHostDevModuleNode;
+        }
+      }
+      return undefined;
+    },
+    getModulesByFile(file) {
+      const modules = new Set<CustomHostDevModuleNode>();
+      for (const graph of viteModuleGraphs(server)) {
+        for (const node of graph.getModulesByFile?.(file) ?? []) {
+          modules.add(node as CustomHostDevModuleNode);
+        }
+      }
+      return modules.size > 0 ? modules : undefined;
+    },
+  };
+}
+
+export function createDevImportResolver(
+  server: ViteDevServer,
+): CustomHostDevImportResolver | undefined {
+  const aliases = server.config.resolve.alias.filter(
+    (alias): alias is Alias =>
+      (typeof alias.find === "string" || alias.find instanceof RegExp) &&
+      typeof alias.replacement === "string",
+  );
+  const tsconfigPaths = hasTsconfigPathResolver(server)
+    ? readTsconfigPaths(server.config.root)
+    : undefined;
+  if (aliases.length === 0 && (!tsconfigPaths || tsconfigPaths.paths.length === 0)) {
+    return undefined;
+  }
+  return (specifier) =>
+    resolveAliasImport(specifier, aliases, server.config.root) ??
+    resolveTsconfigPathImport(specifier, tsconfigPaths);
+}
+
+export function createDevStylesheetContentResolver(
+  server: ViteDevServer,
+  base: string,
+): CustomHostDevStylesheetContentResolver {
+  return async (href) => {
+    const url = new URL(href, "http://localhost");
+    const pathname =
+      stripBasePathname(url.pathname, base) ??
+      stripBasePathname(url.pathname, server.config.base) ??
+      url.pathname;
+    const absolutePath = pathname.startsWith("/@fs/")
+      ? pathname.slice("/@fs".length)
+      : path.join(server.config.root, pathname.replace(/^\/+/u, ""));
+    const absoluteId = `${absolutePath}${url.search}`;
+    if (
+      isSvelteStyleRequest(absolutePath, url.searchParams) &&
+      !hasFrameworkStyleBlock(absolutePath)
+    ) {
+      return "";
+    }
+    const loaded = await loadSsrStylesheetContent(server, absoluteId);
+    if (loaded) {
+      return loaded;
+    }
+    try {
+      const result = await server.transformRequest(`${pathname}${url.search}`, { ssr: true });
+      return result?.code ? extractViteCssContent(result.code) : undefined;
+    } catch (error) {
+      return extractViteCssContent(errorPluginCode(error) ?? "");
+    }
+  };
+}
+
+function hasTsconfigPathResolver(server: ViteDevServer): boolean {
+  return (
+    (
+      server.config.resolve as typeof server.config.resolve & {
+        tsconfigPaths?: boolean;
+      }
+    ).tsconfigPaths === true
+  );
+}
+
+function resolveAliasImport(
+  specifier: string,
+  aliases: readonly Alias[],
+  root: string,
+): string | undefined {
+  for (const alias of aliases) {
+    const replaced =
+      typeof alias.find === "string"
+        ? replaceStringAlias(specifier, alias.find, alias.replacement)
+        : specifier.replace(alias.find, alias.replacement);
+    if (replaced && replaced !== specifier) {
+      return resolveImportCandidate(replaced, root);
+    }
+  }
+  return undefined;
+}
+
+function replaceStringAlias(
+  specifier: string,
+  find: string,
+  replacement: string,
+): string | undefined {
+  if (specifier === find || specifier.startsWith(`${find}/`)) {
+    return `${replacement}${specifier.slice(find.length)}`;
+  }
+  return undefined;
+}
+
+type TsconfigPaths = {
+  baseUrl: string;
+  paths: { pattern: string; targets: string[] }[];
+};
+
+function readTsconfigPaths(root: string): TsconfigPaths | undefined {
+  try {
+    const config = JSON.parse(fsSync.readFileSync(path.join(root, "tsconfig.json"), "utf8")) as {
+      compilerOptions?: {
+        baseUrl?: unknown;
+        paths?: Record<string, unknown>;
+      };
+    };
+    const rawPaths = config.compilerOptions?.paths;
+    if (!rawPaths) {
+      return undefined;
+    }
+    return {
+      baseUrl: path.resolve(
+        root,
+        typeof config.compilerOptions?.baseUrl === "string" ? config.compilerOptions.baseUrl : ".",
+      ),
+      paths: Object.entries(rawPaths)
+        .map(([pattern, targets]) => ({
+          pattern,
+          targets: Array.isArray(targets)
+            ? targets.filter((target): target is string => typeof target === "string")
+            : [],
+        }))
+        .filter((entry) => entry.targets.length > 0),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveTsconfigPathImport(
+  specifier: string,
+  tsconfigPaths: TsconfigPaths | undefined,
+): string | undefined {
+  if (!tsconfigPaths) {
+    return undefined;
+  }
+  for (const { pattern, targets } of tsconfigPaths.paths) {
+    const wildcard = tsconfigWildcard(pattern, specifier);
+    if (wildcard == null) {
+      continue;
+    }
+    for (const target of targets) {
+      return path.resolve(tsconfigPaths.baseUrl, target.replace("*", wildcard));
+    }
+  }
+  return undefined;
+}
+
+function tsconfigWildcard(pattern: string, specifier: string): string | undefined {
+  if (!pattern.includes("*")) {
+    return pattern === specifier ? "" : undefined;
+  }
+  const [prefix, suffix = ""] = pattern.split("*", 2);
+  if (!specifier.startsWith(prefix) || !specifier.endsWith(suffix)) {
+    return undefined;
+  }
+  return specifier.slice(prefix.length, specifier.length - suffix.length);
+}
+
+function resolveImportCandidate(specifier: string, root: string): string {
+  if (specifier.startsWith("/@fs/")) {
+    return specifier.slice("/@fs".length);
+  }
+  return path.isAbsolute(specifier) ? specifier : path.resolve(root, specifier);
+}
+
+function isSvelteStyleRequest(file: string, params: URLSearchParams): boolean {
+  return file.endsWith(".svelte") && params.get("type") === "style";
+}
+
+function hasFrameworkStyleBlock(file: string): boolean {
+  try {
+    return /<style(?:\s[^>]*)?>[\s\S]*?<\/style>/iu.test(fsSync.readFileSync(file, "utf8"));
+  } catch {
+    return true;
+  }
+}
+
+async function loadSsrStylesheetContent(
+  server: ViteDevServer,
+  id: string,
+): Promise<string | undefined> {
+  const environment = (
+    server as ViteDevServer & {
+      environments?: Record<string, { pluginContainer?: { load(id: string): Promise<unknown> } }>;
+    }
+  ).environments?.ssr;
+  const loaded = await environment?.pluginContainer?.load(id);
+  return extractViteCssContent(loadResultCode(loaded) ?? "");
+}
+
+function loadResultCode(result: unknown): string | undefined {
+  if (typeof result === "string") {
+    return result;
+  }
+  if (!result || typeof result !== "object") {
+    return undefined;
+  }
+  const code = (result as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function errorPluginCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+  const pluginCode = (error as { pluginCode?: unknown }).pluginCode;
+  return typeof pluginCode === "string" ? pluginCode : undefined;
+}
+
+function extractViteCssContent(code: string): string | undefined {
+  const trimmed = code.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (trimmed.includes("__vite__updateStyle")) {
+    const match = /const\s+__vite__css\s*=\s*("(?:\\.|[^"\\])*")/u.exec(trimmed);
+    if (!match) {
+      return undefined;
+    }
+    try {
+      const css = JSON.parse(match[1]) as unknown;
+      return typeof css === "string" && !isRawSvelteSource(css) ? css : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  return isRawSvelteSource(trimmed) || isLikelyJsModule(trimmed) ? undefined : trimmed;
+}
+
+function isRawSvelteSource(content: string): boolean {
+  return /<\/(?:script|style)>/iu.test(content);
+}
+
+function isLikelyJsModule(content: string): boolean {
+  return /^(?:import|export)\s/mu.test(content);
+}

--- a/npm/vite-plugin-ox-content/src/custom-host-dev-stylesheet-graph.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-dev-stylesheet-graph.ts
@@ -1,0 +1,318 @@
+import * as path from "node:path";
+import {
+  cleanModulePath,
+  isWithinRoot,
+  normalizeFilePath,
+  unique,
+} from "./custom-host-ssr-imports";
+import type {
+  OxContentCustomHostStylesheet,
+  OxContentCustomHostStylesheetDiagnostic,
+  OxContentCustomHostStylesheetsResult,
+} from "./custom-host-types";
+import { withBase } from "./custom-host-utils";
+
+export interface CustomHostDevModuleNode {
+  id?: string | null;
+  url?: string | null;
+  file?: string | null;
+  meta?: Record<string, unknown> | null;
+  transformResult?: { meta?: Record<string, unknown> | null } | null;
+  ssrTransformResult?: { meta?: Record<string, unknown> | null } | null;
+  importedModules?: Iterable<CustomHostDevModuleNode>;
+  ssrImportedModules?: Iterable<CustomHostDevModuleNode>;
+}
+
+export interface CustomHostDevModuleGraph {
+  idToModuleMap?: Map<string, CustomHostDevModuleNode>;
+  getModuleById(id: string): CustomHostDevModuleNode | undefined;
+  getModulesByFile?(file: string): Set<CustomHostDevModuleNode> | undefined;
+}
+
+export function resolveDevStylesheets(
+  moduleIds: readonly string[],
+  moduleGraph: CustomHostDevModuleGraph,
+  base: string | undefined,
+  root: string | undefined,
+): OxContentCustomHostStylesheetsResult {
+  const stylesheets: OxContentCustomHostStylesheet[] = [];
+  const diagnostics: OxContentCustomHostStylesheetDiagnostic[] = [];
+  const seenCss = new Set<string>();
+  const dependencies = new Set<string>();
+
+  for (const moduleId of moduleIds) {
+    const entry = devEntry(moduleGraph, moduleId, root);
+    if (!entry) {
+      diagnostics.push({
+        code: "missing-module",
+        moduleId,
+        message: `Vite module graph entry was not found for custom host module "${moduleId}".`,
+      });
+      continue;
+    }
+    visitDevModule(entry, moduleId, base, root, new Set(), seenCss, stylesheets, dependencies);
+  }
+
+  return { stylesheets, diagnostics, dependencies: [...dependencies] };
+}
+
+function visitDevModule(
+  node: CustomHostDevModuleNode,
+  requestedBy: string,
+  base: string | undefined,
+  root: string | undefined,
+  seenNodes: Set<CustomHostDevModuleNode>,
+  seenCss: Set<string>,
+  stylesheets: OxContentCustomHostStylesheet[],
+  dependencies: Set<string>,
+): void {
+  if (seenNodes.has(node)) {
+    return;
+  }
+  seenNodes.add(node);
+
+  const dependency = devDependency(node, root);
+  if (dependency) {
+    dependencies.add(dependency);
+  }
+  const visitImport = (imported: CustomHostDevModuleNode) =>
+    visitDevModule(
+      imported,
+      requestedBy,
+      base,
+      root,
+      seenNodes,
+      seenCss,
+      stylesheets,
+      dependencies,
+    );
+  for (const imported of node.importedModules ?? []) {
+    visitImport(imported);
+  }
+  for (const imported of node.ssrImportedModules ?? []) {
+    visitImport(imported);
+  }
+
+  const frameworkCss = devFrameworkCssContent(node);
+  if (!frameworkCss && isDevFrameworkStyleModule(node)) {
+    return;
+  }
+  const href = frameworkCss ? devFrameworkCssHref(node, base, root) : devCssHref(node, base, root);
+  if (href) {
+    addDevStylesheet(seenCss, stylesheets, {
+      kind: "style",
+      href,
+      moduleId: requestedBy,
+      content: frameworkCss,
+    });
+  }
+}
+
+function addDevStylesheet(
+  seenCss: Set<string>,
+  stylesheets: OxContentCustomHostStylesheet[],
+  stylesheet: OxContentCustomHostStylesheet,
+): void {
+  if (!seenCss.has(stylesheet.href)) {
+    seenCss.add(stylesheet.href);
+    stylesheets.push(stylesheet);
+    return;
+  }
+  if (stylesheet.content == null) {
+    return;
+  }
+  const index = stylesheets.findIndex((existing) => existing.href === stylesheet.href);
+  if (index >= 0 && stylesheets[index].content == null) {
+    stylesheets[index] = stylesheet;
+  }
+}
+
+function devEntry(
+  moduleGraph: CustomHostDevModuleGraph,
+  moduleId: string,
+  root: string | undefined,
+): CustomHostDevModuleNode | undefined {
+  for (const id of moduleIdCandidates(moduleId, root)) {
+    const direct = moduleGraph.getModuleById(id);
+    if (direct) {
+      return direct;
+    }
+  }
+  for (const file of moduleFileCandidates(moduleId, root)) {
+    const byFile = first(moduleGraph.getModulesByFile?.(file));
+    if (byFile) {
+      return byFile;
+    }
+  }
+
+  const ids = new Set(moduleIdCandidates(moduleId, root).map(cleanModulePath));
+  const files = new Set(moduleFileCandidates(moduleId, root).map(normalizeFilePath));
+  for (const [id, node] of moduleGraph.idToModuleMap ?? []) {
+    const cleanId = cleanModulePath(id);
+    if (ids.has(cleanId) || (node.file && files.has(normalizeFilePath(node.file)))) {
+      return node;
+    }
+  }
+  return undefined;
+}
+
+function moduleIdCandidates(moduleId: string, root: string | undefined): string[] {
+  const clean = cleanModulePath(moduleId).replace(/\\/g, "/");
+  const withoutLeading = clean.replace(/^\/+/, "");
+  const result = [moduleId, clean, withoutLeading];
+  if (root && isWithinRoot(clean, root)) {
+    result.push(path.posix.relative(normalizeFilePath(root), clean));
+  } else if (root && clean.startsWith("/@fs/")) {
+    result.push(path.posix.relative(normalizeFilePath(root), clean.slice("/@fs".length)));
+  } else if (!clean.startsWith("/") && !clean.startsWith(".")) {
+    result.push(`/${clean}`);
+  }
+  return unique(result.filter(Boolean));
+}
+
+function moduleFileCandidates(moduleId: string, root: string | undefined): string[] {
+  const clean = cleanModulePath(moduleId);
+  const result: string[] = [];
+  if (clean.startsWith("/@fs/")) {
+    result.push(clean.slice("/@fs".length));
+  } else if (path.isAbsolute(clean) && !rootRelativeId(clean, root)) {
+    result.push(clean);
+  } else if (root && clean.startsWith("/")) {
+    result.push(path.join(root, clean.slice(1)));
+  } else if (root && clean) {
+    result.push(path.join(root, clean));
+  }
+  return unique(result.map(normalizeFilePath));
+}
+
+function devCssHref(
+  node: CustomHostDevModuleNode,
+  base: string | undefined,
+  root: string | undefined,
+): string | undefined {
+  const raw = node.url ?? node.id ?? node.file;
+  if (!raw) {
+    return undefined;
+  }
+  const [pathname, suffix = ""] = splitModuleSuffix(raw);
+  if (!isDevCssModule(pathname, suffix)) {
+    return undefined;
+  }
+  if (pathname.startsWith("/@fs/")) {
+    return joinBase(base, `${pathname}${suffix}`);
+  }
+  if (root && isWithinRoot(pathname, root)) {
+    const relative = path.posix.relative(normalizeFilePath(root), normalizeFilePath(pathname));
+    return joinBase(base, `/${relative}${suffix}`);
+  }
+  return joinBase(
+    base,
+    pathname.startsWith("/") ? `${pathname}${suffix}` : `/${pathname}${suffix}`,
+  );
+}
+
+function devFrameworkCssHref(
+  node: CustomHostDevModuleNode,
+  base: string | undefined,
+  root: string | undefined,
+): string | undefined {
+  const raw = node.file ?? node.id ?? node.url;
+  if (!raw) {
+    return undefined;
+  }
+  const [pathname] = splitModuleSuffix(raw);
+  if (!pathname.endsWith(".svelte")) {
+    return undefined;
+  }
+  if (pathname.startsWith("/@fs/")) {
+    return joinBase(base, `${pathname}?svelte&type=style&lang.css`);
+  }
+  if (root && isWithinRoot(pathname, root)) {
+    const relative = path.posix.relative(normalizeFilePath(root), normalizeFilePath(pathname));
+    return joinBase(base, `/${relative}?svelte&type=style&lang.css`);
+  }
+  const sourcePath = pathname.startsWith("/") ? pathname : `/${pathname}`;
+  return joinBase(base, `${sourcePath}?svelte&type=style&lang.css`);
+}
+
+function devFrameworkCssContent(node: CustomHostDevModuleNode): string | undefined {
+  for (const meta of [node.meta, node.transformResult?.meta, node.ssrTransformResult?.meta]) {
+    const css = svelteCssCode(meta);
+    if (css?.trim()) {
+      return css;
+    }
+  }
+  return undefined;
+}
+
+function svelteCssCode(meta: Record<string, unknown> | null | undefined): string | undefined {
+  const svelte = meta?.svelte;
+  if (!svelte || typeof svelte !== "object") {
+    return undefined;
+  }
+  const css = (svelte as { css?: { code?: unknown } }).css;
+  return typeof css?.code === "string" ? css.code : undefined;
+}
+
+function isDevFrameworkStyleModule(node: CustomHostDevModuleNode): boolean {
+  const raw = node.url ?? node.id;
+  if (!raw) {
+    return false;
+  }
+  const [pathname, suffix = ""] = splitModuleSuffix(raw);
+  return pathname.endsWith(".svelte") && suffix.includes("type=style");
+}
+
+function isDevCssModule(pathname: string, suffix: string): boolean {
+  if (pathname.endsWith(".css")) {
+    return true;
+  }
+  if (!suffix) {
+    return false;
+  }
+  const params = new URLSearchParams(suffix.slice(1));
+  return (
+    params.get("type") === "style" ||
+    (/(?:[?&])type=style(?:&|$)/u.test(suffix) && /\.css(?:&|$)/u.test(suffix))
+  );
+}
+
+function devDependency(
+  node: CustomHostDevModuleNode,
+  root: string | undefined,
+): string | undefined {
+  const raw = node.file ?? node.id ?? node.url;
+  if (!raw) {
+    return undefined;
+  }
+  const clean = cleanModulePath(raw);
+  if (clean.startsWith("/@fs/")) {
+    return normalizeFilePath(clean.slice("/@fs".length));
+  }
+  if (path.isAbsolute(clean) && !rootRelativeId(clean, root)) {
+    return normalizeFilePath(clean);
+  }
+  if (root && clean.startsWith("/")) {
+    return normalizeFilePath(path.join(root, clean.slice(1)));
+  }
+  return root && clean ? normalizeFilePath(path.join(root, clean)) : undefined;
+}
+
+function rootRelativeId(value: string, root: string | undefined): boolean {
+  return (
+    !!root && value.startsWith("/") && !isWithinRoot(value, root) && !value.startsWith("/@fs/")
+  );
+}
+
+function splitModuleSuffix(moduleId: string): [string, string?] {
+  const match = /[?#]/u.exec(moduleId);
+  return match ? [moduleId.slice(0, match.index), moduleId.slice(match.index)] : [moduleId];
+}
+
+function joinBase(base: string | undefined, href: string): string {
+  return withBase(base ?? "/", href);
+}
+
+function first<T>(set: Set<T> | undefined): T | undefined {
+  return set?.values().next().value;
+}

--- a/npm/vite-plugin-ox-content/src/custom-host-dev.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-dev.ts
@@ -1,9 +1,10 @@
 import type { ViteDevServer } from "vite";
-import { createAssetsContext, themeTokenMiddleware } from "./custom-host-assets";
+import { themeTokenMiddleware } from "./custom-host-assets";
 import {
   createCustomHostCollectionAssetsDevController,
   type CustomHostCollectionAssetsDevController,
 } from "./custom-host-collection-assets";
+import { createCustomHostDevAssetsContext } from "./custom-host-dev-assets";
 import type { DevRoutesState } from "./custom-host-dev-state";
 import { hasRouteHostImportMetaGlob } from "./custom-host-route-glob";
 import type { CustomHostSsrStylesheetController } from "./custom-host-ssr-stylesheets";
@@ -58,16 +59,15 @@ export function configureDevServer(
   const root = server.config.root;
   const outDir = resolveOutDir(server.config, options, root);
   let collectionAssets: CustomHostCollectionAssetsDevController | undefined;
-  const assets = createAssetsContext(
+  const assets = createCustomHostDevAssetsContext({
+    server,
     options,
     outDir,
-    undefined,
     themeTokens,
-    server.moduleGraph,
     root,
-    async () => collectionAssets?.manifest(),
+    collectionManifest: async () => collectionAssets?.manifest(),
     ssrStylesheets,
-  );
+  });
   let ssrVersion = 0;
   const loadModule = (moduleId: string) =>
     server.ssrLoadModule(versionedModuleId(moduleId, ssrVersion));

--- a/npm/vite-plugin-ox-content/src/custom-host-island-stylesheets.test.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-island-stylesheets.test.ts
@@ -1,0 +1,252 @@
+import * as fs from "node:fs/promises";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { build as viteBuild, createServer, type InlineConfig, type ViteDevServer } from "vite";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { oxContentCustomHost } from ".";
+import type { CustomHostDevModuleNode } from "./custom-host-stylesheets";
+
+const tempDirs: string[] = [];
+const activeServers: ViteDevServer[] = [];
+const activeListeners: http.Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(activeListeners.splice(0).map((server) => closeHttpServer(server)));
+  await Promise.all(activeServers.splice(0).map((server) => server.close().catch(() => {})));
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("custom host island stylesheets", () => {
+  it("serves dev island CSS through assets context and invalidates CSS dependencies", async () => {
+    const root = await createProject("ox-custom-host-style-dev-");
+    const server = await trackDevServer(createServer(viteConfig(root, { reloadDebounceMs: 1 })));
+    installFixtureModuleGraph(server, root);
+    const listener = await listen(server);
+
+    const home = await read(listener.port, "/");
+    expect(home.status).toBe(200);
+    expect(home.text).toContain('data-render="1"');
+    expect(home.text).toContain('<link rel="stylesheet" href="/src/islands/prose.css">');
+    expect(home.text).toContain('<link rel="stylesheet" href="/src/islands/child.css">');
+    expect(home.text.match(/href="\/src\/islands\/island\.css"/g)).toHaveLength(1);
+    expect(home.text.indexOf('href="/src/islands/child.css"')).toBeLessThan(
+      home.text.indexOf('src="/src/main.ts"'),
+    );
+    expect(home.text).not.toContain("missing-module");
+
+    const cached = await read(listener.port, "/");
+    expect(cached.text).toContain('data-render="1"');
+
+    const childCss = path.join(root, "src", "islands", "child.css");
+    await fs.writeFile(childCss, ".child{color:navy}\n");
+    server.watcher.emit("change", childCss);
+    await wait(20);
+
+    const updated = await read(listener.port, "/");
+    expect(updated.text).toContain('data-render="2"');
+  });
+
+  it("writes build island CSS from the manifest without exposing moduleGraph", async () => {
+    const root = await createProject("ox-custom-host-style-build-");
+
+    await viteBuild(viteConfig(root));
+
+    const html = await fs.readFile(path.join(root, "dist", "index.html"), "utf8");
+    expect(html).toContain('data-render="1"');
+    expect(html).toContain('href="/assets/');
+    expect(html).toMatch(/href="\/assets\/prose-[^"]+\.css"/u);
+    expect(html).toContain('<script type="module" src="/assets/main-');
+    expect(html.indexOf('href="/assets/')).toBeLessThan(
+      html.indexOf('<script type="module" src="/assets/main-'),
+    );
+    expect(html).not.toContain("missing-module");
+
+    const css = await readDistCss(root);
+    expect(css).toContain(".island");
+    expect(css).toContain(".child");
+    expect(css).toContain(".prose");
+  });
+});
+
+function viteConfig(root: string, dev: { reloadDebounceMs?: number } = {}): InlineConfig {
+  return {
+    root,
+    configFile: false,
+    appType: "custom",
+    logLevel: "silent",
+    plugins: [
+      ...oxContentCustomHost({
+        host: "./src/host.ts",
+        oxContent: {
+          srcDir: "content",
+          outDir: "dist",
+          resources: false,
+          docs: false,
+          search: false,
+          ogViewer: false,
+          feeds: false,
+          siteMaps: false,
+        },
+        dev,
+      }),
+    ],
+    build: {
+      outDir: "dist",
+      emptyOutDir: true,
+      manifest: true,
+      rollupOptions: {
+        input: {
+          main: path.join(root, "src", "main.ts"),
+          prose: path.join(root, "src", "islands", "prose.css"),
+        },
+      },
+    },
+  };
+}
+
+async function createProject(prefix: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(root);
+  await fs.mkdir(path.join(root, "src", "islands"), { recursive: true });
+  await fs.mkdir(path.join(root, "content"), { recursive: true });
+  await fs.writeFile(path.join(root, "package.json"), '{"type":"module"}\n');
+  await fs.writeFile(
+    path.join(root, "src", "main.ts"),
+    'import("./islands/client.ts");\ndocument.documentElement.dataset.client = "ready";\n',
+  );
+  await fs.writeFile(
+    path.join(root, "src", "islands", "Island.ts"),
+    'import { child } from "./Child.ts";\nexport function renderIsland() { return `<section class="island ${child}">Island</section>`; }\n',
+  );
+  await fs.writeFile(
+    path.join(root, "src", "islands", "client.ts"),
+    'import "./island.css";\nimport "./child.css";\nexport const hydrate = true;\n',
+  );
+  await fs.writeFile(
+    path.join(root, "src", "islands", "Child.ts"),
+    'export const child = "child";\n',
+  );
+  await fs.writeFile(path.join(root, "src", "islands", "island.css"), ".island{color:teal}\n");
+  await fs.writeFile(path.join(root, "src", "islands", "child.css"), ".child{color:maroon}\n");
+  await fs.writeFile(path.join(root, "src", "islands", "prose.css"), ".prose{color:olive}\n");
+  await fs.writeFile(path.join(root, "src", "host.ts"), hostModuleSource());
+  return root;
+}
+
+function hostModuleSource(): string {
+  return `
+let renders = 0;
+
+export default {
+  routes: [
+    {
+      path: "/",
+      async render(ctx) {
+        renders += 1;
+        const island = await ctx.loadModule("/src/islands/Island.ts");
+        const styles = ctx.assets.stylesheets({
+          modules: ["/src/islands/prose.css", "/src/islands/client.ts", "/src/islands/client.ts"],
+        });
+        const assets = ctx.assets.document({
+          sharedStyles: ctx.mode === "serve" ? ["/src/islands/island.css"] : [],
+          islandStyles: styles.stylesheets,
+          clientEntries: ["src/main.ts"],
+        });
+        return {
+          html: "<!doctype html><html><head>" + assets.headHtml + "</head><body data-render=\\"" + renders + "\\"><main>" + island.renderIsland() + "</main><p>" + styles.diagnostics.map((diagnostic) => diagnostic.code).join(",") + "</p></body></html>",
+          dependencies: styles.dependencies,
+        };
+      },
+    },
+  ],
+};
+`;
+}
+
+function installFixtureModuleGraph(server: ViteDevServer, root: string): void {
+  const graph = server.moduleGraph as unknown as {
+    getModuleById(id: string): CustomHostDevModuleNode | undefined;
+    getModulesByFile?(file: string): Set<CustomHostDevModuleNode> | undefined;
+  };
+  const childCss = node(
+    "/src/islands/child.css",
+    [],
+    path.join(root, "src", "islands", "child.css"),
+  );
+  const islandCss = node(
+    "/src/islands/island.css",
+    [],
+    path.join(root, "src", "islands", "island.css"),
+  );
+  const proseCss = node(
+    "/src/islands/prose.css",
+    [],
+    path.join(root, "src", "islands", "prose.css"),
+  );
+  const client = node(
+    "/src/islands/client.ts",
+    [childCss, islandCss],
+    path.join(root, "src", "islands", "client.ts"),
+  );
+  const originalGetModuleById = graph.getModuleById.bind(graph);
+  const originalGetModulesByFile = graph.getModulesByFile?.bind(graph);
+
+  graph.getModuleById = (id: string) =>
+    id === "/src/islands/client.ts"
+      ? client
+      : id === "/src/islands/prose.css"
+        ? proseCss
+        : originalGetModuleById(id);
+  graph.getModulesByFile = (file: string) =>
+    file === path.join(root, "src", "islands", "client.ts")
+      ? new Set([client])
+      : file === path.join(root, "src", "islands", "prose.css")
+        ? new Set([proseCss])
+        : originalGetModulesByFile?.(file);
+}
+
+function node(
+  url: string,
+  imports: CustomHostDevModuleNode[] = [],
+  file?: string,
+): CustomHostDevModuleNode {
+  return { id: url, url, file, importedModules: imports };
+}
+
+async function trackDevServer(serverPromise: Promise<ViteDevServer>): Promise<ViteDevServer> {
+  const server = await serverPromise;
+  activeServers.push(server);
+  return server;
+}
+
+async function listen(server: ViteDevServer): Promise<{ port: number }> {
+  const listener = http.createServer(server.middlewares);
+  activeListeners.push(listener);
+  await new Promise<void>((resolve) => listener.listen(0, "127.0.0.1", resolve));
+  return { port: (listener.address() as AddressInfo).port };
+}
+
+async function read(port: number, requestPath: string) {
+  const response = await fetch(`http://127.0.0.1:${port}${requestPath}`);
+  return { status: response.status, headers: response.headers, text: await response.text() };
+}
+
+async function readDistCss(root: string): Promise<string> {
+  const assetDir = path.join(root, "dist", "assets");
+  const files = (await fs.readdir(assetDir)).filter((file) => file.endsWith(".css"));
+  return (
+    await Promise.all(files.map((file) => fs.readFile(path.join(assetDir, file), "utf8")))
+  ).join("\n");
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function closeHttpServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}

--- a/npm/vite-plugin-ox-content/src/custom-host-ssr-dev-stylesheets.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-ssr-dev-stylesheets.ts
@@ -25,10 +25,16 @@ import { withBase } from "./custom-host-utils";
 
 const OUTSIDE_ROOT = Symbol("outside-root");
 
+export type CustomHostDevImportResolver = (
+  specifier: string,
+  importer: string,
+) => string | undefined;
+
 export function resolveStaticDevSsrStylesheets(input: {
   modules: readonly string[];
   base?: string;
   root: string;
+  resolveImport?: CustomHostDevImportResolver;
 }): OxContentCustomHostSsrStylesheetsResult | undefined {
   const stylesheets: OxContentCustomHostStylesheet[] = [];
   const diagnostics: OxContentCustomHostStylesheetDiagnostic[] = [];
@@ -46,7 +52,14 @@ export function resolveStaticDevSsrStylesheets(input: {
       });
       continue;
     }
-    const record = collectRoot(moduleId, rootFile, input.root, input.base, dependencies);
+    const record = collectRoot(
+      moduleId,
+      rootFile,
+      input.root,
+      input.base,
+      dependencies,
+      input.resolveImport,
+    );
     for (const stylesheet of record.stylesheets) {
       if (!seenAggregateCss.has(stylesheet.href)) {
         seenAggregateCss.add(stylesheet.href);
@@ -73,6 +86,7 @@ function collectRoot(
   root: string,
   base: string | undefined,
   dependencies: Set<string>,
+  resolveImport: CustomHostDevImportResolver | undefined,
 ) {
   const stylesheets: OxContentCustomHostStylesheet[] = [];
   const diagnostics: OxContentCustomHostStylesheetDiagnostic[] = [];
@@ -88,12 +102,11 @@ function collectRoot(
     dependencies.add(clean);
     rootDependencies.add(clean);
     const source = fsSync.readFileSync(clean, "utf8");
-    const styleContent = isFrameworkStyleRoot(clean) ? frameworkStyleContent(source) : undefined;
-    if (styleContent) {
+    if (isFrameworkStyleRoot(clean) && hasFrameworkStyleBlock(source)) {
       const href = frameworkStyleHref(clean, root, base);
       if (!seenRootCss.has(href)) {
         seenRootCss.add(href);
-        stylesheets.push({ kind: "style", href, moduleId, content: styleContent });
+        stylesheets.push({ kind: "style", href, moduleId });
       }
     }
     for (const item of parseImports(source)) {
@@ -104,7 +117,7 @@ function collectRoot(
         diagnostics.push(dynamicDiagnostic(moduleId, item.specifier, clean));
         continue;
       }
-      const imported = resolveLocalImport(item.specifier, clean, root);
+      const imported = resolveImportSpecifier(item.specifier, clean, root, resolveImport);
       if (imported === OUTSIDE_ROOT) {
         diagnostics.push(outsideRootDiagnostic(moduleId, item.specifier, clean));
         continue;
@@ -148,6 +161,23 @@ function resolveLocalImport(
   const base = specifier.startsWith(".")
     ? path.resolve(path.dirname(importer), specifier)
     : (fileFromModuleId(specifier, root) ?? path.resolve(root, specifier));
+  return resolveImportFile(base, root);
+}
+
+function resolveImportSpecifier(
+  specifier: string,
+  importer: string,
+  root: string,
+  resolveImport: CustomHostDevImportResolver | undefined,
+): string | typeof OUTSIDE_ROOT | undefined {
+  const resolved = resolveImport?.(specifier, importer);
+  if (resolved) {
+    return resolveImportFile(resolved, root);
+  }
+  return resolveLocalImport(specifier, importer, root);
+}
+
+function resolveImportFile(base: string, root: string): string | typeof OUTSIDE_ROOT | undefined {
   const resolved = firstExisting(candidateFiles(base));
   if (!resolved) {
     return undefined;
@@ -168,11 +198,8 @@ function candidateFiles(file: string): string[] {
   );
 }
 
-function frameworkStyleContent(source: string): string | undefined {
-  const blocks = [...source.matchAll(/<style(?:\s[^>]*)?>([\s\S]*?)<\/style>/giu)]
-    .map((match) => match[1].trim())
-    .filter(Boolean);
-  return blocks.length > 0 ? `${blocks.join("\n")}\n` : undefined;
+function hasFrameworkStyleBlock(source: string): boolean {
+  return /<style(?:\s[^>]*)?>[\s\S]*?<\/style>/iu.test(source);
 }
 
 function frameworkStyleHref(file: string, root: string, base: string | undefined): string {

--- a/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.ts
@@ -13,7 +13,10 @@ import {
   findRecord,
   type RootRecord,
 } from "./custom-host-ssr-discovery";
-import { resolveStaticDevSsrStylesheets } from "./custom-host-ssr-dev-stylesheets";
+import {
+  resolveStaticDevSsrStylesheets,
+  type CustomHostDevImportResolver,
+} from "./custom-host-ssr-dev-stylesheets";
 import { hasGlobSyntax } from "./custom-host-ssr-imports";
 import {
   resolveCustomHostStylesheets,
@@ -57,6 +60,7 @@ export interface ResolveCustomHostSsrStylesheetsInput extends OxContentCustomHos
   root?: string;
   manifest?: DocumentAssetManifest;
   moduleGraph?: CustomHostDevModuleGraph;
+  resolveImport?: CustomHostDevImportResolver;
 }
 
 export function createCustomHostSsrStylesheetController(
@@ -175,16 +179,27 @@ function resolveDev(
   input: ResolveCustomHostSsrStylesheetsInput,
 ): OxContentCustomHostSsrStylesheetsResult {
   const styles = resolveCustomHostStylesheets(input);
+  if (styles.stylesheets.length > 0) {
+    return withDevDescriptors(input, styles);
+  }
   if (input.root) {
     const staticResult = resolveStaticDevSsrStylesheets({
       modules: input.modules,
       base: input.base,
       root: input.root,
+      resolveImport: input.resolveImport,
     });
-    if (staticResult && (styles.stylesheets.length === 0 || hasInlineStyles(staticResult))) {
+    if (staticResult) {
       return staticResult;
     }
   }
+  return withDevDescriptors(input, styles);
+}
+
+function withDevDescriptors(
+  input: ResolveCustomHostSsrStylesheetsInput,
+  styles: OxContentCustomHostStylesheetsResult,
+): OxContentCustomHostSsrStylesheetsResult {
   const descriptors = input.modules.map((moduleId): OxContentCustomHostSsrStylesheetDescriptor => {
     const result = resolveCustomHostStylesheets({ ...input, modules: [moduleId] });
     return {
@@ -194,10 +209,6 @@ function resolveDev(
     };
   });
   return { ...styles, descriptors };
-}
-
-function hasInlineStyles(result: OxContentCustomHostSsrStylesheetsResult): boolean {
-  return result.stylesheets.some((stylesheet) => stylesheet.content != null);
 }
 
 function mergeResult(

--- a/npm/vite-plugin-ox-content/src/custom-host-stylesheet-content.test.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-stylesheet-content.test.ts
@@ -73,6 +73,27 @@ describe("resolveCustomHostStylesheetContent", () => {
       expect.objectContaining({ code: "missing-artifact", href: "/assets/missing.css" }),
     ]);
   });
+
+  it("uses the dev stylesheet content resolver before reporting unavailable CSS", async () => {
+    const outDir = await createTempDir("ox-custom-host-style-content-dev-resolver-");
+    const result = await resolveCustomHostStylesheetContent({
+      build: false,
+      outDir,
+      resolveDevContent: async (href) =>
+        href === "/src/page.css" ? ".page{color:red}\n" : undefined,
+      stylesheets: [{ kind: "style", href: "/src/page.css", moduleId: "/src/page.css" }],
+    });
+
+    expect(result.stylesheets).toEqual([
+      {
+        stylesheet: { kind: "style", href: "/src/page.css", moduleId: "/src/page.css" },
+        href: "/src/page.css",
+        moduleId: "/src/page.css",
+        content: ".page{color:red}\n",
+      },
+    ]);
+    expect(result.diagnostics).toEqual([]);
+  });
 });
 
 describe("custom host stylesheet content", () => {

--- a/npm/vite-plugin-ox-content/src/custom-host-stylesheet-content.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-stylesheet-content.ts
@@ -11,7 +11,10 @@ import { resolveOutputPath } from "./custom-host-utils";
 export interface ResolveCustomHostStylesheetContentInput extends OxContentCustomHostStylesheetContentInput {
   build: boolean;
   outDir: string;
+  resolveDevContent?: CustomHostDevStylesheetContentResolver;
 }
+
+export type CustomHostDevStylesheetContentResolver = (href: string) => Promise<string | undefined>;
 
 export async function resolveCustomHostStylesheetContent(
   input: ResolveCustomHostStylesheetContentInput,
@@ -26,6 +29,11 @@ export async function resolveCustomHostStylesheetContent(
       continue;
     }
     if (!input.build) {
+      const content = await input.resolveDevContent?.(stylesheet.href);
+      if (content != null) {
+        stylesheets.push(stylesheetContent(stylesheet, content));
+        continue;
+      }
       diagnostics.push({
         code: "unavailable",
         href: stylesheet.href,

--- a/npm/vite-plugin-ox-content/src/custom-host-stylesheets.test.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-stylesheets.test.ts
@@ -1,25 +1,8 @@
-import * as fs from "node:fs/promises";
-import * as http from "node:http";
-import type { AddressInfo } from "node:net";
-import * as os from "node:os";
-import * as path from "node:path";
-import { afterEach, describe, expect, it } from "vite-plus/test";
-import { build as viteBuild, createServer, type InlineConfig, type ViteDevServer } from "vite";
-import { oxContentCustomHost } from ".";
+import { describe, expect, it } from "vite-plus/test";
 import {
   resolveCustomHostStylesheets,
   type CustomHostDevModuleNode,
 } from "./custom-host-stylesheets";
-
-const tempDirs: string[] = [];
-const activeServers: ViteDevServer[] = [];
-const activeListeners: http.Server[] = [];
-
-afterEach(async () => {
-  await Promise.all(activeListeners.splice(0).map((server) => closeHttpServer(server)));
-  await Promise.all(activeServers.splice(0).map((server) => server.close().catch(() => {})));
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
-});
 
 describe("resolveCustomHostStylesheets", () => {
   it("collects build CSS in dependency order and dev CSS dependencies", () => {
@@ -100,196 +83,31 @@ describe("resolveCustomHostStylesheets", () => {
       ],
     });
   });
-});
 
-describe("custom host island stylesheets", () => {
-  it("serves dev island CSS through assets context and invalidates CSS dependencies", async () => {
-    const root = await createProject("ox-custom-host-style-dev-");
-    const server = await trackDevServer(createServer(viteConfig(root, { reloadDebounceMs: 1 })));
-    installFixtureModuleGraph(server, root);
-    const listener = await listen(server);
+  it("keeps compiled framework CSS from the dev module graph", () => {
+    const page = node("/src/Page.svelte", [], "/repo/src/Page.svelte");
+    page.meta = { svelte: { css: { code: ".probe.svelte-abc{color:red}\n" } } };
 
-    const home = await read(listener.port, "/");
-    expect(home.status).toBe(200);
-    expect(home.text).toContain('data-render="1"');
-    expect(home.text).toContain('<link rel="stylesheet" href="/src/islands/prose.css">');
-    expect(home.text).toContain('<link rel="stylesheet" href="/src/islands/child.css">');
-    expect(home.text.match(/href="\/src\/islands\/island\.css"/g)).toHaveLength(1);
-    expect(home.text.indexOf('href="/src/islands/child.css"')).toBeLessThan(
-      home.text.indexOf('src="/src/main.ts"'),
-    );
-    expect(home.text).not.toContain("missing-module");
+    const result = resolveCustomHostStylesheets({
+      modules: ["/src/Page.svelte"],
+      moduleGraph: {
+        getModuleById: (id) => (id === "/src/Page.svelte" ? page : undefined),
+      },
+      base: "/docs/",
+      root: "/repo",
+    });
 
-    const cached = await read(listener.port, "/");
-    expect(cached.text).toContain('data-render="1"');
-
-    const childCss = path.join(root, "src", "islands", "child.css");
-    await fs.writeFile(childCss, ".child{color:navy}\n");
-    server.watcher.emit("change", childCss);
-    await wait(20);
-
-    const updated = await read(listener.port, "/");
-    expect(updated.text).toContain('data-render="2"');
-  });
-
-  it("writes build island CSS from the manifest without exposing moduleGraph", async () => {
-    const root = await createProject("ox-custom-host-style-build-");
-
-    await viteBuild(viteConfig(root));
-
-    const html = await fs.readFile(path.join(root, "dist", "index.html"), "utf8");
-    expect(html).toContain('data-render="1"');
-    expect(html).toContain('href="/assets/');
-    expect(html).toMatch(/href="\/assets\/prose-[^"]+\.css"/u);
-    expect(html).toContain('<script type="module" src="/assets/main-');
-    expect(html.indexOf('href="/assets/')).toBeLessThan(
-      html.indexOf('<script type="module" src="/assets/main-'),
-    );
-    expect(html).not.toContain("missing-module");
-
-    const css = await readDistCss(root);
-    expect(css).toContain(".island");
-    expect(css).toContain(".child");
-    expect(css).toContain(".prose");
+    expect(result.stylesheets).toEqual([
+      {
+        kind: "style",
+        href: "/docs/src/Page.svelte?svelte&type=style&lang.css",
+        moduleId: "/src/Page.svelte",
+        content: ".probe.svelte-abc{color:red}\n",
+      },
+    ]);
+    expect(result.diagnostics).toEqual([]);
   });
 });
-
-function viteConfig(root: string, dev: { reloadDebounceMs?: number } = {}): InlineConfig {
-  return {
-    root,
-    configFile: false,
-    appType: "custom",
-    logLevel: "silent",
-    plugins: [
-      ...oxContentCustomHost({
-        host: "./src/host.ts",
-        oxContent: {
-          srcDir: "content",
-          outDir: "dist",
-          resources: false,
-          docs: false,
-          search: false,
-          ogViewer: false,
-          feeds: false,
-          siteMaps: false,
-        },
-        dev,
-      }),
-    ],
-    build: {
-      outDir: "dist",
-      emptyOutDir: true,
-      manifest: true,
-      rollupOptions: {
-        input: {
-          main: path.join(root, "src", "main.ts"),
-          prose: path.join(root, "src", "islands", "prose.css"),
-        },
-      },
-    },
-  };
-}
-
-async function createProject(prefix: string): Promise<string> {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(root);
-  await fs.mkdir(path.join(root, "src", "islands"), { recursive: true });
-  await fs.mkdir(path.join(root, "content"), { recursive: true });
-  await fs.writeFile(path.join(root, "package.json"), '{"type":"module"}\n');
-  await fs.writeFile(
-    path.join(root, "src", "main.ts"),
-    'import("./islands/client.ts");\ndocument.documentElement.dataset.client = "ready";\n',
-  );
-  await fs.writeFile(
-    path.join(root, "src", "islands", "Island.ts"),
-    'import { child } from "./Child.ts";\nexport function renderIsland() { return `<section class="island ${child}">Island</section>`; }\n',
-  );
-  await fs.writeFile(
-    path.join(root, "src", "islands", "client.ts"),
-    'import "./island.css";\nimport "./child.css";\nexport const hydrate = true;\n',
-  );
-  await fs.writeFile(
-    path.join(root, "src", "islands", "Child.ts"),
-    'export const child = "child";\n',
-  );
-  await fs.writeFile(path.join(root, "src", "islands", "island.css"), ".island{color:teal}\n");
-  await fs.writeFile(path.join(root, "src", "islands", "child.css"), ".child{color:maroon}\n");
-  await fs.writeFile(path.join(root, "src", "islands", "prose.css"), ".prose{color:olive}\n");
-  await fs.writeFile(path.join(root, "src", "host.ts"), hostModuleSource());
-  return root;
-}
-
-function hostModuleSource(): string {
-  return `
-let renders = 0;
-
-export default {
-  routes: [
-    {
-      path: "/",
-      async render(ctx) {
-        renders += 1;
-        const island = await ctx.loadModule("/src/islands/Island.ts");
-        const styles = ctx.assets.stylesheets({
-          modules: ["/src/islands/prose.css", "/src/islands/client.ts", "/src/islands/client.ts"],
-        });
-        const assets = ctx.assets.document({
-          sharedStyles: ctx.mode === "serve" ? ["/src/islands/island.css"] : [],
-          islandStyles: styles.stylesheets,
-          clientEntries: ["src/main.ts"],
-        });
-        return {
-          html: "<!doctype html><html><head>" + assets.headHtml + "</head><body data-render=\\"" + renders + "\\"><main>" + island.renderIsland() + "</main><p>" + styles.diagnostics.map((diagnostic) => diagnostic.code).join(",") + "</p></body></html>",
-          dependencies: styles.dependencies,
-        };
-      },
-    },
-  ],
-};
-`;
-}
-
-function installFixtureModuleGraph(server: ViteDevServer, root: string): void {
-  const graph = server.moduleGraph as unknown as {
-    getModuleById(id: string): CustomHostDevModuleNode | undefined;
-    getModulesByFile?(file: string): Set<CustomHostDevModuleNode> | undefined;
-  };
-  const childCss = node(
-    "/src/islands/child.css",
-    [],
-    path.join(root, "src", "islands", "child.css"),
-  );
-  const islandCss = node(
-    "/src/islands/island.css",
-    [],
-    path.join(root, "src", "islands", "island.css"),
-  );
-  const proseCss = node(
-    "/src/islands/prose.css",
-    [],
-    path.join(root, "src", "islands", "prose.css"),
-  );
-  const client = node(
-    "/src/islands/client.ts",
-    [childCss, islandCss],
-    path.join(root, "src", "islands", "client.ts"),
-  );
-  const originalGetModuleById = graph.getModuleById.bind(graph);
-  const originalGetModulesByFile = graph.getModulesByFile?.bind(graph);
-
-  graph.getModuleById = (id: string) =>
-    id === "/src/islands/client.ts"
-      ? client
-      : id === "/src/islands/prose.css"
-        ? proseCss
-        : originalGetModuleById(id);
-  graph.getModulesByFile = (file: string) =>
-    file === path.join(root, "src", "islands", "client.ts")
-      ? new Set([client])
-      : file === path.join(root, "src", "islands", "prose.css")
-        ? new Set([proseCss])
-        : originalGetModulesByFile?.(file);
-}
 
 function node(
   url: string,
@@ -302,40 +120,4 @@ function node(
     file,
     importedModules: imports,
   };
-}
-
-async function trackDevServer(serverPromise: Promise<ViteDevServer>): Promise<ViteDevServer> {
-  const server = await serverPromise;
-  activeServers.push(server);
-  return server;
-}
-
-async function listen(server: ViteDevServer): Promise<{ port: number }> {
-  const listener = http.createServer(server.middlewares);
-  activeListeners.push(listener);
-  await new Promise<void>((resolve) => listener.listen(0, "127.0.0.1", resolve));
-  return { port: (listener.address() as AddressInfo).port };
-}
-
-async function read(port: number, requestPath: string) {
-  const response = await fetch(`http://127.0.0.1:${port}${requestPath}`);
-  return { status: response.status, headers: response.headers, text: await response.text() };
-}
-
-async function readDistCss(root: string): Promise<string> {
-  const assetDir = path.join(root, "dist", "assets");
-  const files = (await fs.readdir(assetDir)).filter((file) => file.endsWith(".css"));
-  return (
-    await Promise.all(files.map((file) => fs.readFile(path.join(assetDir, file), "utf8")))
-  ).join("\n");
-}
-
-function wait(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function closeHttpServer(server: http.Server): Promise<void> {
-  return new Promise((resolve) => {
-    server.close(() => resolve());
-  });
 }

--- a/npm/vite-plugin-ox-content/src/custom-host-stylesheets.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-stylesheets.ts
@@ -12,21 +12,16 @@ import type {
   OxContentCustomHostStylesheetsInput,
   OxContentCustomHostStylesheetsResult,
 } from "./custom-host-types";
+import {
+  resolveDevStylesheets,
+  type CustomHostDevModuleGraph,
+} from "./custom-host-dev-stylesheet-graph";
 import { withBase } from "./custom-host-utils";
 
-export interface CustomHostDevModuleNode {
-  id?: string | null;
-  url?: string | null;
-  file?: string | null;
-  importedModules?: Iterable<CustomHostDevModuleNode>;
-  ssrImportedModules?: Iterable<CustomHostDevModuleNode>;
-}
-
-export interface CustomHostDevModuleGraph {
-  idToModuleMap?: Map<string, CustomHostDevModuleNode>;
-  getModuleById(id: string): CustomHostDevModuleNode | undefined;
-  getModulesByFile?(file: string): Set<CustomHostDevModuleNode> | undefined;
-}
+export type {
+  CustomHostDevModuleGraph,
+  CustomHostDevModuleNode,
+} from "./custom-host-dev-stylesheet-graph";
 
 export interface ResolveCustomHostStylesheetsInput extends OxContentCustomHostStylesheetsInput {
   root?: string;
@@ -117,106 +112,6 @@ function resolveBuildStylesheets(
   return { stylesheets, diagnostics, dependencies: [] };
 }
 
-function resolveDevStylesheets(
-  moduleIds: readonly string[],
-  moduleGraph: CustomHostDevModuleGraph,
-  base: string | undefined,
-  root: string | undefined,
-): OxContentCustomHostStylesheetsResult {
-  const stylesheets: OxContentCustomHostStylesheet[] = [];
-  const diagnostics: OxContentCustomHostStylesheetDiagnostic[] = [];
-  const seenCss = new Set<string>();
-  const dependencies = new Set<string>();
-
-  for (const moduleId of moduleIds) {
-    const entry = devEntry(moduleGraph, moduleId, root);
-    if (!entry) {
-      diagnostics.push({
-        code: "missing-module",
-        moduleId,
-        message: `Vite module graph entry was not found for custom host module "${moduleId}".`,
-      });
-      continue;
-    }
-    visitDevModule(entry, moduleId, base, root, new Set(), seenCss, stylesheets, dependencies);
-  }
-
-  return { stylesheets, diagnostics, dependencies: [...dependencies] };
-}
-
-function visitDevModule(
-  node: CustomHostDevModuleNode,
-  requestedBy: string,
-  base: string | undefined,
-  root: string | undefined,
-  seenNodes: Set<CustomHostDevModuleNode>,
-  seenCss: Set<string>,
-  stylesheets: OxContentCustomHostStylesheet[],
-  dependencies: Set<string>,
-): void {
-  if (seenNodes.has(node)) {
-    return;
-  }
-  seenNodes.add(node);
-
-  const dependency = devDependency(node, root);
-  if (dependency) {
-    dependencies.add(dependency);
-  }
-  const visitImport = (imported: CustomHostDevModuleNode) =>
-    visitDevModule(
-      imported,
-      requestedBy,
-      base,
-      root,
-      seenNodes,
-      seenCss,
-      stylesheets,
-      dependencies,
-    );
-  for (const imported of node.importedModules ?? []) {
-    visitImport(imported);
-  }
-  for (const imported of node.ssrImportedModules ?? []) {
-    visitImport(imported);
-  }
-
-  const href = devCssHref(node, base, root);
-  if (href && !seenCss.has(href)) {
-    seenCss.add(href);
-    stylesheets.push({ kind: "style", href, moduleId: requestedBy });
-  }
-}
-
-function devEntry(
-  moduleGraph: CustomHostDevModuleGraph,
-  moduleId: string,
-  root: string | undefined,
-): CustomHostDevModuleNode | undefined {
-  for (const id of moduleIdCandidates(moduleId, root)) {
-    const direct = moduleGraph.getModuleById(id);
-    if (direct) {
-      return direct;
-    }
-  }
-  for (const file of moduleFileCandidates(moduleId, root)) {
-    const byFile = first(moduleGraph.getModulesByFile?.(file));
-    if (byFile) {
-      return byFile;
-    }
-  }
-
-  const ids = new Set(moduleIdCandidates(moduleId, root).map(cleanModulePath));
-  const files = new Set(moduleFileCandidates(moduleId, root).map(normalizeFilePath));
-  for (const [id, node] of moduleGraph.idToModuleMap ?? []) {
-    const cleanId = cleanModulePath(id);
-    if (ids.has(cleanId) || (node.file && files.has(normalizeFilePath(node.file)))) {
-      return node;
-    }
-  }
-  return undefined;
-}
-
 function manifestKey(
   manifest: DocumentAssetManifest,
   moduleId: string,
@@ -243,98 +138,6 @@ function moduleIdCandidates(moduleId: string, root: string | undefined): string[
   return unique(result.filter(Boolean));
 }
 
-function moduleFileCandidates(moduleId: string, root: string | undefined): string[] {
-  const clean = cleanModulePath(moduleId);
-  const result: string[] = [];
-  if (clean.startsWith("/@fs/")) {
-    result.push(clean.slice("/@fs".length));
-  } else if (path.isAbsolute(clean) && !rootRelativeId(clean, root)) {
-    result.push(clean);
-  } else if (root && clean.startsWith("/")) {
-    result.push(path.join(root, clean.slice(1)));
-  } else if (root && clean) {
-    result.push(path.join(root, clean));
-  }
-  return unique(result.map(normalizeFilePath));
-}
-
-function devCssHref(
-  node: CustomHostDevModuleNode,
-  base: string | undefined,
-  root: string | undefined,
-): string | undefined {
-  const raw = node.url ?? node.id ?? node.file;
-  if (!raw) {
-    return undefined;
-  }
-  const [pathname, suffix = ""] = splitModuleSuffix(raw);
-  if (!isDevCssModule(pathname, suffix)) {
-    return undefined;
-  }
-  if (pathname.startsWith("/@fs/")) {
-    return joinBase(base, `${pathname}${suffix}`);
-  }
-  if (root && isWithinRoot(pathname, root)) {
-    const relative = path.posix.relative(normalizeFilePath(root), normalizeFilePath(pathname));
-    return joinBase(base, `/${relative}${suffix}`);
-  }
-  if (pathname.startsWith("/")) {
-    return joinBase(base, `${pathname}${suffix}`);
-  }
-  return joinBase(base, `/${pathname}${suffix}`);
-}
-
-function isDevCssModule(pathname: string, suffix: string): boolean {
-  if (pathname.endsWith(".css")) {
-    return true;
-  }
-  if (!suffix) {
-    return false;
-  }
-  const params = new URLSearchParams(suffix.slice(1));
-  if (params.get("type") === "style") {
-    return true;
-  }
-  return /(?:[?&])type=style(?:&|$)/u.test(suffix) && /\.css(?:&|$)/u.test(suffix);
-}
-
-function devDependency(
-  node: CustomHostDevModuleNode,
-  root: string | undefined,
-): string | undefined {
-  const raw = node.file ?? node.id ?? node.url;
-  if (!raw) {
-    return undefined;
-  }
-  const clean = cleanModulePath(raw);
-  if (clean.startsWith("/@fs/")) {
-    return normalizeFilePath(clean.slice("/@fs".length));
-  }
-  if (path.isAbsolute(clean) && !rootRelativeId(clean, root)) {
-    return normalizeFilePath(clean);
-  }
-  if (root && clean.startsWith("/")) {
-    return normalizeFilePath(path.join(root, clean.slice(1)));
-  }
-  return root && clean ? normalizeFilePath(path.join(root, clean)) : undefined;
-}
-
-function rootRelativeId(value: string, root: string | undefined): boolean {
-  if (!root || !value.startsWith("/")) {
-    return false;
-  }
-  return !isWithinRoot(value, root) && !value.startsWith("/@fs/");
-}
-
-function splitModuleSuffix(moduleId: string): [string, string?] {
-  const match = /[?#]/u.exec(moduleId);
-  return match ? [moduleId.slice(0, match.index), moduleId.slice(match.index)] : [moduleId];
-}
-
 function joinBase(base: string | undefined, href: string): string {
   return withBase(base ?? "/", href);
-}
-
-function first<T>(set: Set<T> | undefined): T | undefined {
-  return set?.values().next().value;
 }

--- a/npm/vite-plugin-ox-content/src/custom-host-vite-invalidation.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-vite-invalidation.ts
@@ -7,13 +7,13 @@ export function invalidateViteModules(server: ViteDevServer, file: string, all =
         moduleGraph.invalidateAll();
       } else {
         for (const mod of moduleGraph.idToModuleMap?.values() ?? []) {
-          moduleGraph.invalidateModule(mod);
+          moduleGraph.invalidateModule?.(mod);
         }
       }
       continue;
     }
-    for (const mod of moduleGraph.getModulesByFile(file) ?? []) {
-      moduleGraph.invalidateModule(mod);
+    for (const mod of moduleGraph.getModulesByFile?.(file) ?? []) {
+      moduleGraph.invalidateModule?.(mod);
     }
   }
   for (const evaluatedModules of viteEvaluatedModules(server)) {
@@ -27,16 +27,17 @@ export function invalidateViteModules(server: ViteDevServer, file: string, all =
   }
 }
 
-type InvalidatableViteModuleGraph = {
+export type ViteModuleGraphLike = {
   idToModuleMap?: Map<string, unknown>;
-  getModulesByFile(file: string): Set<unknown> | undefined;
+  getModuleById?(id: string): unknown;
+  getModulesByFile?(file: string): Set<unknown> | undefined;
   invalidateAll?: () => void;
-  invalidateModule(mod: unknown): void;
+  invalidateModule?(mod: unknown): void;
 };
 
-function viteModuleGraphs(server: ViteDevServer): InvalidatableViteModuleGraph[] {
-  const graphs = new Set<InvalidatableViteModuleGraph>();
-  graphs.add(server.moduleGraph as unknown as InvalidatableViteModuleGraph);
+export function viteModuleGraphs(server: ViteDevServer): ViteModuleGraphLike[] {
+  const graphs = new Set<ViteModuleGraphLike>();
+  graphs.add(server.moduleGraph as unknown as ViteModuleGraphLike);
   const environments = (
     server as ViteDevServer & {
       environments?: Record<string, ViteEnvironmentWithCaches>;
@@ -51,7 +52,7 @@ function viteModuleGraphs(server: ViteDevServer): InvalidatableViteModuleGraph[]
 }
 
 type ViteEnvironmentWithCaches = {
-  moduleGraph?: InvalidatableViteModuleGraph;
+  moduleGraph?: ViteModuleGraphLike;
   runner?: { evaluatedModules?: InvalidatableEvaluatedModules };
 };
 


### PR DESCRIPTION
## Summary
- resolve development SSR stylesheet imports through Vite aliases and tsconfig path mappings
- collect compiled Svelte CSS from the dev module graph and avoid raw source style extraction
- add browser coverage for aliased nested Svelte imports, critical CSS, and invalidation before client JS

Closes #1405

## Tests
- vp run workspace:fmt:check
- vp run workspace:check
- vp test npm/vite-plugin-ox-content/src/custom-host-stylesheets.test.ts npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.test.ts npm/vite-plugin-ox-content/src/custom-host-stylesheet-content.test.ts npm/vite-plugin-ox-content-svelte/src/custom-host-svelte-stylesheets.test.ts
- vp exec --filter @ox-content/vite-plugin-svelte -- vp test src
- vp exec --filter @ox-content/vite-plugin -- vp test src
- vp exec --filter @ox-content/vite-plugin -- playwright test
- vp run workspace:test (full run hit local resource/flaky reruns; failed jobs above passed individually)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791636794&installation_model_id=422833&pr_number=1407&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1407&signature=81b6817009fa4040552388cc51df1fc63c1382a8c1f3fb917d0b8d09c455b69e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved development-mode stylesheet resolution for custom hosts, including Svelte component styles and CSS dependencies.
  - Added support for resolving stylesheet imports through Vite aliases and TypeScript path mappings.
  - Added island stylesheet handling in development and production builds.
  - Stylesheet content can now be loaded dynamically during development when needed.

- **Bug Fixes**
  - Improved stylesheet invalidation and re-rendering after source changes.
  - Improved SSR stylesheet handling and generated stylesheet links for custom-host pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->