### PR TITLE
fix(custom-host): resolve inherited tsconfig stylesheet imports

### DIFF
--- a/npm/vite-plugin-ox-content-svelte/src/custom-host-svelte-stylesheets.fixture.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/custom-host-svelte-stylesheets.fixture.ts
@@ -28,12 +28,29 @@ export async function createProject(prefix: string): Promise<string> {
   await fs.mkdir(path.join(root, "src"), { recursive: true });
   await fs.mkdir(path.join(root, "src", "components"), { recursive: true });
   await fs.mkdir(path.join(root, "src", "config"), { recursive: true });
+  await fs.mkdir(path.join(root, "config"), { recursive: true });
   await fs.mkdir(path.join(root, "content"), { recursive: true });
   await writeFile(root, "package.json", '{"type":"module"}\n');
   await writeFile(
     root,
     "tsconfig.json",
-    JSON.stringify({ compilerOptions: { paths: { "@/*": ["./src/*"] } } }, null, 2),
+    [
+      "{",
+      '  "extends": "./config/tsconfig.base.json",',
+      '  "compilerOptions": {',
+      '    "allowJs": true,',
+      '    "checkJs": true,',
+      "  },",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  await writeFile(
+    root,
+    "config/tsconfig.base.json",
+    ["{", '  "compilerOptions": {', '    "paths": { "@/*": ["../src/*"] }', "  }", "}", ""].join(
+      "\n",
+    ),
   );
   await writeFile(root, "src/main.js", "document.body.dataset.client = 'unused';\n");
   await writeFile(root, "src/Page.svelte", pageSource());
@@ -66,10 +83,10 @@ export async function writeViteConfig(
       "  appType: 'custom',",
       "  logLevel: 'silent',",
       "  resolve: {",
-      '    alias: { "@": path.join(root, "src") },',
       "    tsconfigPaths: true,",
       "  },",
       "  plugins: [",
+      "    inheritedTsconfigRuntimeResolver(),",
       "    noopSsrSvelteStyleImports(),",
       "    svelte({ configFile: false }),",
       "    ...oxContentCustomHost({",
@@ -100,6 +117,16 @@ export async function writeViteConfig(
       '    rollupOptions: { input: path.join(root, "src", "main.js") },',
       "  },",
       "};",
+      "function inheritedTsconfigRuntimeResolver() {",
+      "  return {",
+      "    name: 'ox-content-svelte-test:inherited-tsconfig-runtime',",
+      "    enforce: 'pre',",
+      "    resolveId(id) {",
+      "      if (!id.startsWith('@/')) return null;",
+      '      return path.join(root, "src", id.slice(2));',
+      "    },",
+      "  };",
+      "}",
       "function noopSsrSvelteStyleImports() {",
       "  const prefix = '\\0ox-content-svelte-ssr-style:';",
       "  const modules = new Map();",

--- a/npm/vite-plugin-ox-content/package.json
+++ b/npm/vite-plugin-ox-content/package.json
@@ -224,6 +224,7 @@
     "@types/react-dom": "catalog:",
     "@typescript/native-preview": "catalog:",
     "budoux": "^0.9.0",
+    "get-tsconfig": "^5.0.0-beta.4",
     "katex": "^0.16.22",
     "vite": "catalog:",
     "vite-plus": "catalog:",

--- a/npm/vite-plugin-ox-content/src/custom-host-dev-resolvers.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-dev-resolvers.ts
@@ -1,5 +1,6 @@
 import * as fsSync from "node:fs";
 import * as path from "node:path";
+import { readTsconfig, resolvePathAlias, type TsconfigResult } from "get-tsconfig";
 import type { Alias, ViteDevServer } from "vite";
 import type { CustomHostDevImportResolver } from "./custom-host-ssr-dev-stylesheets";
 import type { CustomHostDevStylesheetContentResolver } from "./custom-host-stylesheet-content";
@@ -47,15 +48,15 @@ export function createDevImportResolver(
       (typeof alias.find === "string" || alias.find instanceof RegExp) &&
       typeof alias.replacement === "string",
   );
-  const tsconfigPaths = hasTsconfigPathResolver(server)
-    ? readTsconfigPaths(server.config.root)
+  const tsconfigPathResolver = hasTsconfigPathResolver(server)
+    ? createTsconfigPathResolver(server.config.root)
     : undefined;
-  if (aliases.length === 0 && (!tsconfigPaths || tsconfigPaths.paths.length === 0)) {
+  if (aliases.length === 0 && !tsconfigPathResolver) {
     return undefined;
   }
   return (specifier) =>
     resolveAliasImport(specifier, aliases, server.config.root) ??
-    resolveTsconfigPathImport(specifier, tsconfigPaths);
+    resolveTsconfigPathImport(specifier, tsconfigPathResolver);
 }
 
 export function createDevStylesheetContentResolver(
@@ -129,37 +130,17 @@ function replaceStringAlias(
   return undefined;
 }
 
-type TsconfigPaths = {
-  baseUrl: string;
-  paths: { pattern: string; targets: string[] }[];
+type TsconfigPathResolver = {
+  tsconfig: TsconfigResult;
 };
 
-function readTsconfigPaths(root: string): TsconfigPaths | undefined {
+function createTsconfigPathResolver(root: string): TsconfigPathResolver | undefined {
   try {
-    const config = JSON.parse(fsSync.readFileSync(path.join(root, "tsconfig.json"), "utf8")) as {
-      compilerOptions?: {
-        baseUrl?: unknown;
-        paths?: Record<string, unknown>;
-      };
-    };
-    const rawPaths = config.compilerOptions?.paths;
-    if (!rawPaths) {
+    const tsconfig = readTsconfig(path.join(root, "tsconfig.json"));
+    if (!tsconfig.config.compilerOptions?.paths) {
       return undefined;
     }
-    return {
-      baseUrl: path.resolve(
-        root,
-        typeof config.compilerOptions?.baseUrl === "string" ? config.compilerOptions.baseUrl : ".",
-      ),
-      paths: Object.entries(rawPaths)
-        .map(([pattern, targets]) => ({
-          pattern,
-          targets: Array.isArray(targets)
-            ? targets.filter((target): target is string => typeof target === "string")
-            : [],
-        }))
-        .filter((entry) => entry.targets.length > 0),
-    };
+    return { tsconfig };
   } catch {
     return undefined;
   }
@@ -167,32 +148,12 @@ function readTsconfigPaths(root: string): TsconfigPaths | undefined {
 
 function resolveTsconfigPathImport(
   specifier: string,
-  tsconfigPaths: TsconfigPaths | undefined,
+  resolver: TsconfigPathResolver | undefined,
 ): string | undefined {
-  if (!tsconfigPaths) {
+  if (!resolver) {
     return undefined;
   }
-  for (const { pattern, targets } of tsconfigPaths.paths) {
-    const wildcard = tsconfigWildcard(pattern, specifier);
-    if (wildcard == null) {
-      continue;
-    }
-    for (const target of targets) {
-      return path.resolve(tsconfigPaths.baseUrl, target.replace("*", wildcard));
-    }
-  }
-  return undefined;
-}
-
-function tsconfigWildcard(pattern: string, specifier: string): string | undefined {
-  if (!pattern.includes("*")) {
-    return pattern === specifier ? "" : undefined;
-  }
-  const [prefix, suffix = ""] = pattern.split("*", 2);
-  if (!specifier.startsWith(prefix) || !specifier.endsWith(suffix)) {
-    return undefined;
-  }
-  return specifier.slice(prefix.length, specifier.length - suffix.length);
+  return resolvePathAlias(resolver.tsconfig, specifier)[0];
 }
 
 function resolveImportCandidate(specifier: string, root: string): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2131,6 +2131,9 @@ importers:
       budoux:
         specifier: ^0.9.0
         version: 0.9.0(supports-color@10.2.2)
+      get-tsconfig:
+        specifier: ^5.0.0-beta.4
+        version: 5.0.0-beta.4
       katex:
         specifier: ^0.16.22
         version: 0.16.47


### PR DESCRIPTION
## Summary
- replace the dev SSR stylesheet alias parser with get-tsconfig path resolution so extends chains and JSONC configs are handled
- add a Svelte custom-host regression fixture where runtime module loading works outside resolve.alias and static stylesheet discovery must read inherited tsconfig paths

## Verification
- vp run --filter @ox-content/vite-plugin build
- vp test npm/vite-plugin-ox-content-svelte/src/custom-host-svelte-stylesheets.test.ts
- vp test npm/vite-plugin-ox-content-svelte/src/custom-host-svelte-stylesheets.test.ts npm/vite-plugin-ox-content/src/custom-host-ssr-stylesheets.test.ts npm/vite-plugin-ox-content/src/custom-host-stylesheet-content.test.ts npm/vite-plugin-ox-content/src/custom-host-dev-lifecycle.test.ts
- node tools/scripts/check-file-lines.ts
- vp run workspace:fmt:check
- vp run workspace:check
- vp install --frozen-lockfile
- vp run build:npm
- node tools/scripts/package-dry-run.mjs

Fixes #1405

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development-time resolution of TypeScript path aliases, including aliases defined through extended configuration files.
  * Improved runtime handling of `@/` imports in Svelte projects using inherited TypeScript configuration.
  * Reduced configuration-related resolution issues when projects use shared TypeScript settings.

* **Configuration**
  * Generated Svelte project configurations now support JavaScript checking and shared base TypeScript settings while preserving source path aliases.
  * Path aliases continue to work consistently across development and runtime environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->