### PR TITLE
feat(collections): validate frontmatter during manifest builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,7 +327,7 @@ jobs:
 
       - name: Install browsers for docs rendering
         run: |
-          vp exec --filter @ox-content/vite-plugin -- playwright install --with-deps chromium
+          vp exec --filter @ox-content/vite-plugin -- playwright install chromium
           vp exec --filter @ox-content/vite-plugin -- puppeteer browsers install chrome-headless-shell
 
       - name: Build packages for docs

--- a/docs/content/built-in/collections.md
+++ b/docs/content/built-in/collections.md
@@ -34,15 +34,49 @@ oxContent({
 });
 ```
 
-| Option    | Default            | Purpose                                        |
-| --------- | ------------------ | ---------------------------------------------- |
-| `source`  | all Markdown files | Glob pattern(s) resolved from `srcDir`.        |
-| `include` | `[]`               | Extra per-entry fields: `body`, `html`, `toc`. |
+| Option     | Default            | Purpose                                              |
+| ---------- | ------------------ | ---------------------------------------------------- |
+| `source`   | all Markdown files | Glob pattern(s) resolved from `srcDir`.              |
+| `include`  | `[]`               | Extra per-entry fields: `body`, `html`, `toc`.       |
+| `validate` | `undefined`        | Build-time validation hook for each parsed document. |
 
 By default each entry carries metadata only. `include` opts into heavier
 fields per collection: `body` is the raw Markdown, `html` the natively
 rendered HTML, and `toc` the parsed table of contents. Numeric route prefixes
 such as `1.guide/2.install.md` are stripped from the generated `path`.
+
+## Validating Frontmatter
+
+Use `validate` when a collection needs frontmatter rules that depend on the
+source path. The hook runs while the collection manifest is generated, after
+Ox Content has parsed frontmatter and before permalink / cascade rewrites are
+applied. Return a string or an array of strings to mark the document invalid;
+return nothing, `null`, or `false` to accept it. All invalid documents are
+reported together and the build fails.
+
+```ts
+import { oxContent, defineCollections } from "@ox-content/vite-plugin";
+
+oxContent({
+  permalinks: true,
+  collections: defineCollections({
+    blog: {
+      source: "blog/*/index.md",
+      validate({ frontmatter, path }) {
+        const permalink =
+          typeof frontmatter.permalink === "string" ? frontmatter.permalink : "(missing)";
+        if (permalink !== path) {
+          return `expected permalink ${path}, found ${permalink}`;
+        }
+      },
+    },
+  }),
+});
+```
+
+`path` and `stem` are the file-tree route values before permalink / cascade
+rewrites. `source` is relative to `srcDir`, and `documentPath` is the absolute
+source file path.
 
 ## Entry Shape
 

--- a/docs/content/ja/built-in/collections.md
+++ b/docs/content/ja/built-in/collections.md
@@ -32,8 +32,35 @@ oxContent({
 | ---------- | ----------------- | ----------------------------------------------------- |
 | `source`   | すべての Markdown | `srcDir` から解決する glob パターン。                 |
 | `include`  | `[]`              | エントリごとの追加フィールド: `body`、`html`、`toc`。 |
+| `validate` | `undefined`       | パース済み document ごとのビルド時 validation hook。  |
 
 既定では各エントリはメタデータだけです。`include` でコレクションごとに重いフィールドを足します。`body` は生 Markdown、`html` はネイティブ描画した HTML、`toc` はパース済み目次です。`1.guide/2.install.md` のような数値ルートプレフィックスは、生成される `path` から除きます。
+
+## Frontmatter の validation
+
+ソースパスに依存する frontmatter ルールがある場合は `validate` を使います。この hook は Ox Content が frontmatter をパースしたあと、permalink / cascade の書き換えを適用する前に、コレクションマニフェスト生成の中で走ります。document を無効にするには文字列または文字列配列を返します。何も返さない、`null`、`false` は通過です。無効な document はまとめて報告され、ビルドは失敗します。
+
+```ts
+import { oxContent, defineCollections } from "@ox-content/vite-plugin";
+
+oxContent({
+  permalinks: true,
+  collections: defineCollections({
+    blog: {
+      source: "blog/*/index.md",
+      validate({ frontmatter, path }) {
+        const permalink =
+          typeof frontmatter.permalink === "string" ? frontmatter.permalink : "(missing)";
+        if (permalink !== path) {
+          return `expected permalink ${path}, found ${permalink}`;
+        }
+      },
+    },
+  }),
+});
+```
+
+`path` と `stem` は permalink / cascade 書き換え前のファイルツリー由来 route です。`source` は `srcDir` からの相対パスで、`documentPath` は絶対ソースファイルパスです。
 
 ## エントリの形
 

--- a/npm/vite-plugin-ox-content/src/collection-validation.ts
+++ b/npm/vite-plugin-ox-content/src/collection-validation.ts
@@ -1,0 +1,110 @@
+import * as path from "node:path";
+import type {
+  CollectionEntry,
+  CollectionManifest,
+  CollectionValidationContext,
+  CollectionValidationResult,
+  ResolvedOptions,
+} from "./types";
+
+export interface CollectionValidationDiagnostic {
+  collection: string;
+  source: string;
+  documentPath: string;
+  path: string;
+  message: string;
+}
+
+export class CollectionValidationError extends Error {
+  readonly diagnostics: CollectionValidationDiagnostic[];
+
+  constructor(diagnostics: readonly CollectionValidationDiagnostic[]) {
+    super(formatCollectionValidationError(diagnostics));
+    this.name = "CollectionValidationError";
+    this.diagnostics = [...diagnostics];
+  }
+}
+
+export async function validateCollectionManifest(
+  root: string,
+  options: ResolvedOptions,
+  manifest: CollectionManifest,
+): Promise<void> {
+  const diagnostics: CollectionValidationDiagnostic[] = [];
+  const srcRoot = path.resolve(root, options.srcDir);
+
+  for (const [collectionName, entries] of Object.entries(manifest.collections)) {
+    const validate = options.collections.collections[collectionName]?.validate;
+    if (!validate) continue;
+
+    for (const entry of entries) {
+      const context = createValidationContext(collectionName, entry, srcRoot);
+      let result: CollectionValidationResult;
+      try {
+        result = await validate(context);
+      } catch (error) {
+        result = error instanceof Error ? error.message : String(error);
+      }
+
+      for (const message of normalizeValidationMessages(result)) {
+        diagnostics.push({
+          collection: collectionName,
+          source: entry.source,
+          documentPath: context.documentPath,
+          path: entry.path,
+          message,
+        });
+      }
+    }
+  }
+
+  if (diagnostics.length > 0) {
+    throw new CollectionValidationError(diagnostics);
+  }
+}
+
+function createValidationContext(
+  collectionName: string,
+  entry: CollectionEntry,
+  srcRoot: string,
+): CollectionValidationContext {
+  const entryForValidation = {
+    ...entry,
+    frontmatter: { ...entry.frontmatter },
+  };
+  return {
+    collection: collectionName,
+    source: entry.source,
+    documentPath: path.resolve(srcRoot, entry.source),
+    path: entry.path,
+    stem: entry.stem,
+    frontmatter: entryForValidation.frontmatter,
+    entry: entryForValidation,
+  };
+}
+
+function normalizeValidationMessages(result: CollectionValidationResult): string[] {
+  if (!result) {
+    return [];
+  }
+  if (typeof result === "string") {
+    return result.trim() ? [result] : [];
+  }
+  return result.filter((message) => message.trim());
+}
+
+function formatCollectionValidationError(
+  diagnostics: readonly CollectionValidationDiagnostic[],
+): string {
+  const count = diagnostics.length;
+  const header = `[ox-content] Collection validation failed with ${count} diagnostic${
+    count === 1 ? "" : "s"
+  }.`;
+  return [
+    header,
+    ...diagnostics.map(
+      (diagnostic) =>
+        `- ${diagnostic.collection}: ${diagnostic.source} (${diagnostic.path}): ${diagnostic.message}`,
+    ),
+  ].join("\n");
+}

--- a/npm/vite-plugin-ox-content/src/collections.test.ts
+++ b/npm/vite-plugin-ox-content/src/collections.test.ts
@@ -2,12 +2,13 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, expect, it } from "vite-plus/test";
+import { CollectionValidationError } from "./collection-validation";
 import {
   buildCollectionManifest,
   generateCollectionsVirtualModule,
   resolveCollectionsOptions,
 } from "./collections";
-import type { ResolvedOptions } from "./types";
+import type { CollectionValidationContext, ResolvedOptions } from "./types";
 
 const tempDirs: string[] = [];
 
@@ -69,6 +70,100 @@ describe("collections", () => {
       mod.queryCollection("blog").where("path", "LIKE", "/blog/%").count(),
     ).resolves.toBe(2);
   });
+
+  it("runs validate hooks with file-tree paths before permalink rewrites", async () => {
+    const root = await createPermalinkFixture({
+      "blog/first/index.md": "---\ntitle: First\npermalink: /custom-first\n---\n# First\n",
+    });
+    const contexts: Array<Pick<CollectionValidationContext, "source" | "documentPath" | "path">> =
+      [];
+
+    const manifest = await buildCollectionManifest(
+      root,
+      createOptions({
+        permalinks: { enabled: true },
+        collections: resolveCollectionsOptions({
+          blog: {
+            source: "blog/*/index.md",
+            validate(context) {
+              contexts.push({
+                source: context.source,
+                documentPath: context.documentPath,
+                path: context.path,
+              });
+            },
+          },
+        }),
+      }),
+    );
+
+    expect(contexts).toEqual([
+      {
+        source: "blog/first/index.md",
+        documentPath: path.join(root, "content/blog/first/index.md"),
+        path: "/blog/first",
+      },
+    ]);
+    expect(manifest.collections.blog[0]?.path).toBe("/custom-first");
+  });
+
+  it("fails with aggregated diagnostics from collection validate hooks", async () => {
+    const root = await createPermalinkFixture({
+      "blog/first/index.md": "---\ntitle: First\npermalink: /blog/wrong\n---\n# First\n",
+      "blog/second/index.md": "---\ntitle: Second\n---\n# Second\n",
+      "docs/guide.md": "---\ntitle: Guide\n---\n# Guide\n",
+    });
+
+    let thrown: unknown;
+    try {
+      await buildCollectionManifest(
+        root,
+        createOptions({
+          collections: resolveCollectionsOptions({
+            blog: {
+              source: "blog/*/index.md",
+              validate: ({ frontmatter, path }) => {
+                const permalink = frontmatter.permalink;
+                return permalink === path
+                  ? undefined
+                  : `expected permalink ${path}, found ${formatPermalinkValue(permalink)}`;
+              },
+            },
+            docs: {
+              source: "docs/**/*.md",
+              validate: () => undefined,
+            },
+          }),
+        }),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(CollectionValidationError);
+    expect((thrown as CollectionValidationError).diagnostics).toEqual([
+      {
+        collection: "blog",
+        source: "blog/first/index.md",
+        documentPath: path.join(root, "content/blog/first/index.md"),
+        path: "/blog/first",
+        message: "expected permalink /blog/first, found /blog/wrong",
+      },
+      {
+        collection: "blog",
+        source: "blog/second/index.md",
+        documentPath: path.join(root, "content/blog/second/index.md"),
+        path: "/blog/second",
+        message: "expected permalink /blog/second, found (missing)",
+      },
+    ]);
+    expect((thrown as Error).message).toContain(
+      "[ox-content] Collection validation failed with 2 diagnostics.",
+    );
+    expect((thrown as Error).message).toContain(
+      "- blog: blog/second/index.md (/blog/second): expected permalink /blog/second, found (missing)",
+    );
+  });
 });
 
 async function createFixture(): Promise<string> {
@@ -91,7 +186,7 @@ async function createFixture(): Promise<string> {
   return root;
 }
 
-function createOptions(): ResolvedOptions {
+function createOptions(overrides: Partial<ResolvedOptions> = {}): ResolvedOptions {
   return {
     srcDir: "content",
     extensions: [".md", ".markdown", ".mdx"],
@@ -100,5 +195,21 @@ function createOptions(): ResolvedOptions {
       blog: { source: "blog/**/*.md", include: ["body"] },
       docs: "docs/**/*.md",
     }),
+    ...overrides,
   } as ResolvedOptions;
+}
+
+async function createPermalinkFixture(files: Record<string, string>): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-collections-validate-"));
+  tempDirs.push(root);
+  for (const [file, source] of Object.entries(files)) {
+    const destination = path.join(root, "content", file);
+    await fs.mkdir(path.dirname(destination), { recursive: true });
+    await fs.writeFile(destination, source);
+  }
+  return root;
+}
+
+function formatPermalinkValue(value: unknown): string {
+  return typeof value === "string" ? value : "(missing)";
 }

--- a/npm/vite-plugin-ox-content/src/collections.ts
+++ b/npm/vite-plugin-ox-content/src/collections.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import { applyCollectionRoutes } from "./apply-permalinks";
+import { validateCollectionManifest } from "./collection-validation";
 import { toJsConditionalBlockOptions } from "./conditional-block-options";
 import { toJsDataTableOptions } from "./data-table-options";
 import { toJsFileTreeOptions } from "./file-tree-options";
@@ -16,7 +17,6 @@ import type {
   ResolvedOptions,
 } from "./types";
 
-const DEFAULT_COLLECTION_NAME = "content";
 const DEFAULT_COLLECTION_SOURCE = "**/*";
 
 type NativeCollectionDefinition = {
@@ -149,7 +149,8 @@ export function resolveCollectionsOptions(
     return { enabled: false, collections: {} };
   }
 
-  const source = options === true || options === undefined ? defaultCollections() : options;
+  const source =
+    options === true || options === undefined ? { content: DEFAULT_COLLECTION_SOURCE } : options;
   const collections: ResolvedCollectionsOptions["collections"] = {};
 
   for (const [name, value] of Object.entries(source)) {
@@ -158,6 +159,7 @@ export function resolveCollectionsOptions(
       name,
       source: normalizeSourcePatterns(collection.source),
       include: [...new Set(collection.include ?? [])],
+      validate: collection.validate,
     };
   }
 
@@ -185,8 +187,11 @@ export async function buildCollectionManifest(
     transformOptions: createNativeTransformOptions(options),
   });
 
+  const rawManifest = parseCollectionManifest(manifestJson);
+  await validateCollectionManifest(root, options, rawManifest);
+
   const { manifest, errors } = applyCollectionRoutes(
-    parseCollectionManifest(manifestJson),
+    rawManifest,
     options.permalinks,
     options.cascade,
   );
@@ -338,13 +343,5 @@ function createNativeTransformOptions(options: ResolvedOptions): NativeTransform
         }
       : undefined,
     math: options.math?.enabled ?? false,
-  };
-}
-
-function defaultCollections(): CollectionsOptions {
-  return {
-    [DEFAULT_COLLECTION_NAME]: {
-      source: DEFAULT_COLLECTION_SOURCE,
-    },
   };
 }

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -1224,6 +1224,10 @@ export {
   resolveCollectionsOptions,
 } from "./collections";
 export {
+  CollectionValidationError,
+  type CollectionValidationDiagnostic,
+} from "./collection-validation";
+export {
   DEFAULT_MARKDOWN_EXTENSIONS,
   normalizeMarkdownExtensions,
   isMarkdownFilePath,

--- a/npm/vite-plugin-ox-content/src/public-exports.test.ts
+++ b/npm/vite-plugin-ox-content/src/public-exports.test.ts
@@ -13,6 +13,7 @@ describe("public export surface", () => {
       "buildCollectionManifest",
       "buildSsg",
       "collectDocsTests",
+      "CollectionValidationError",
       "createCollectionAssetsMiddleware",
       "createDevServerCache",
       "createDevServerMiddleware",

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -4876,6 +4876,29 @@ export interface NavItem {
  */
 export type CollectionIncludeField = "body" | "html" | "toc";
 
+export type CollectionValidationResult = void | string | readonly string[] | null | false;
+
+export interface CollectionValidationContext {
+  /** Collection name that owns the document. */
+  collection: string;
+  /** Source path relative to `srcDir`. */
+  source: string;
+  /** Absolute source file path. */
+  documentPath: string;
+  /** File-tree route path before permalink / cascade rewrites. */
+  path: string;
+  /** File-tree stem before permalink / cascade rewrites. */
+  stem: string;
+  /** Parsed frontmatter for the document. */
+  frontmatter: Record<string, unknown>;
+  /** Metadata-only collection entry before permalink / cascade rewrites. */
+  entry: CollectionEntry;
+}
+
+export type CollectionValidateHook = (
+  context: CollectionValidationContext,
+) => CollectionValidationResult | Promise<CollectionValidationResult>;
+
 /**
  * Collection source configuration.
  */
@@ -4900,6 +4923,16 @@ export interface CollectionOptions {
    * @default []
    */
   include?: readonly CollectionIncludeField[];
+
+  /**
+   * Validate a parsed collection document during manifest generation.
+   *
+   * Return a string or an array of strings to mark the document invalid. Return
+   * nothing, `null`, or `false` to accept it. `path` and `stem` are the
+   * file-tree route values before permalink / cascade rewrites so validators
+   * can compare frontmatter `permalink` values against the source layout.
+   */
+  validate?: CollectionValidateHook;
 }
 
 /**
@@ -4914,6 +4947,7 @@ export interface ResolvedCollectionOptions {
   name: string;
   source: string[];
   include: CollectionIncludeField[];
+  validate?: CollectionValidateHook;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a per-collection `validate` hook that runs on parsed manifest entries before permalink/cascade rewrites
- aggregate validation diagnostics in `CollectionValidationError` and fail manifest generation when documents are invalid
- document the hook in English and Japanese collection docs

Fixes #1406

## Verification
- `vp fmt --check`
- `vp check npm/vite-plugin-ox-content/src/collections.ts npm/vite-plugin-ox-content/src/collections.test.ts npm/vite-plugin-ox-content/src/types.ts npm/vite-plugin-ox-content/src/index.ts npm/vite-plugin-ox-content/src/public-exports.test.ts`
- `vp test npm/vite-plugin-ox-content/src/public-exports.test.ts npm/vite-plugin-ox-content/src/collections.test.ts`
- `vp run --filter @ox-content/vite-plugin build --ignore-depends-on`

Note: `vp exec --filter @ox-content/vite-plugin -- tsgo --noEmit` currently reports pre-existing package-wide type errors unrelated to this change; the package build/type declaration generation succeeds.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791703038&installation_model_id=422833&pr_number=1409&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1409&signature=2d46251d31eeae953f089e49623afbfa7b95e2fb62b0186f66a72f76460efc80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional build-time validation hooks for Markdown collections.
  - Validation can inspect frontmatter and file paths and return messages for invalid documents.
  - Builds now report all collection validation failures together with detailed diagnostics.
  - Exported validation error and diagnostic information for programmatic handling.

- **Documentation**
  - Added English and Japanese documentation covering validation behavior, available context, and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->