### PR TITLE
fix(svelte): keep html host runtime package-owned

### DIFF
--- a/docs/content/packages/vite-plugin-ox-content-svelte.md
+++ b/docs/content/packages/vite-plugin-ox-content-svelte.md
@@ -201,10 +201,11 @@ with `data-ox-export` preserving named imports. Use the same module ids in the
 browser loader map so post-local components can share names across documents.
 Pass `diagnostics: "collect"` when a host wants structured diagnostics instead
 of thrown `SvelteHtmlHostRenderError` failures.
-The default server renderer loads `svelte/server` and `svelte` through the same
-`loadModule` callback so Vite development hosts keep the renderer and compiled
-component in one SSR runtime. Hosts that pass `renderComponent` own that runtime
-selection themselves.
+The default server renderer owns its Svelte SSR runtime import so package-level
+`ssr.noExternal` keeps the renderer and compiled component aligned in Vite SSR.
+Hosts that pass `renderComponent` own runtime selection themselves and may load
+`svelte/server` through their host loader when that better matches their module
+graph.
 
 Inside `ctx.markdown.render({ renderHtml })`, `renderHtmlHostMarkdown()` from
 `@ox-content/vite-plugin/html-host` can combine the Svelte island renderer with

--- a/npm/vite-plugin-ox-content-svelte/src/html-host-dev-runtime.test.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/html-host-dev-runtime.test.ts
@@ -37,10 +37,10 @@ describe("Svelte HTML host development runtime", () => {
 
       expect(response.status, response.text).toBe(200);
       expect(response.text).toContain('data-diagnostics=""');
-      expect(response.text).toContain('data-loaded-runtime="true"');
+      expect(response.text).toContain('data-host-runtime-loaded="false"');
       expect(response.text).toContain('data-role="probe"');
       expect(response.text).toContain(">ready</button>");
-      expect(response.text).toContain("svelte/server\nsvelte");
+      expect(response.text).toContain("<pre>/src/Probe.svelte</pre>");
     },
     30_000,
   );
@@ -128,13 +128,13 @@ export default {
           },
         );
         const diagnostics = result.diagnostics.map((diagnostic) => diagnostic.code).join(",");
-        const runtimeLoaded = loaded.includes("svelte/server") && loaded.includes("svelte");
+        const hostRuntimeLoaded = loaded.includes("svelte/server") && loaded.includes("svelte");
         return {
           html:
             '<!doctype html><html><body data-diagnostics="' +
             diagnostics +
-            '" data-loaded-runtime="' +
-            String(runtimeLoaded) +
+            '" data-host-runtime-loaded="' +
+            String(hostRuntimeLoaded) +
             '"><pre>' +
             loaded.slice(-2).join("\\n") +
             "</pre>" +

--- a/npm/vite-plugin-ox-content-svelte/src/html-host-renderer.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/html-host-renderer.ts
@@ -7,7 +7,6 @@ import {
   type SvelteHtmlHostDiagnostic,
   type SvelteServerModuleLoader,
 } from "./html-host";
-import { createSvelteHtmlHostComponentRenderer } from "./html-host-default-renderer";
 import type { MdxImport } from "@ox-content/vite-plugin";
 import type { ComponentsMap } from "./types";
 
@@ -54,7 +53,6 @@ export function createSvelteHtmlHostRenderer(
   input: CreateSvelteHtmlHostRendererInput,
 ): SvelteHtmlHostRenderer {
   const policy = input.diagnostics ?? "throw";
-  const defaultRenderComponent = createSvelteHtmlHostComponentRenderer(input.loadModule);
 
   return async (html, context) => {
     const root = context.root ?? input.root;
@@ -67,7 +65,7 @@ export function createSvelteHtmlHostRenderer(
       imports: context.imports,
       components: context.components ?? input.components,
       loadModule: input.loadModule,
-      renderComponent: context.renderComponent ?? input.renderComponent ?? defaultRenderComponent,
+      renderComponent: context.renderComponent ?? input.renderComponent,
       resolveClientModule:
         context.resolveClientModule ??
         input.resolveClientModule ??

--- a/npm/vite-plugin-ox-content-svelte/src/html-host.test.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/html-host.test.ts
@@ -181,47 +181,39 @@ describe("createSvelteHtmlHostRenderer", () => {
     );
   });
 
-  it("loads the default Svelte SSR runtime through the host module loader", async () => {
-    const loaded: string[] = [];
-    const component = { name: "Echo" };
-    const renderIslands = createSvelteHtmlHostRenderer({
-      root: "/repo",
-      loadModule: async (moduleId) => {
-        loaded.push(moduleId);
-        if (moduleId === "/repo/src/Echo.svelte") {
-          return { default: component };
-        }
-        if (moduleId === "svelte/server") {
-          return {
-            render: (value: unknown, options: { props?: Record<string, unknown> }) => {
-              const children = options.props?.children as { read: () => string } | undefined;
-              return {
-                html: `<section>${String(value === component)}:${children?.read()}</section>`,
-                head: '<meta name="svelte-html-host" content="ready">',
-              };
-            },
-          };
-        }
-        if (moduleId === "svelte") {
-          return {
-            createRawSnippet: (factory: () => { render: () => string }) => ({
-              read: () => factory().render(),
-            }),
-          };
-        }
-        throw new Error(`Unexpected module ${moduleId}`);
+  it("keeps the package default renderer unless a host renderer is provided", async () => {
+    const compiled = compile(
+      "<script>let { children } = $props();</script><section>{@render children?.()}</section>",
+      {
+        filename: "/repo/src/Echo.svelte",
+        generate: "server",
+        runes: true,
       },
-    });
+    );
 
-    const result = await renderIslands('<div data-ox-island="Echo"><em>slot</em></div>', {
-      documentPath: "/repo/docs/report.mdx",
-      components: { Echo: "./src/Echo.svelte" },
-    });
+    await withGeneratedModule(compiled.js.code, async (Echo) => {
+      const loaded: string[] = [];
+      const renderIslands = createSvelteHtmlHostRenderer({
+        root: "/repo",
+        loadModule: async (moduleId) => {
+          loaded.push(moduleId);
+          if (moduleId === "/repo/src/Echo.svelte") {
+            return { default: Echo };
+          }
+          throw new Error(`Unexpected module ${moduleId}`);
+        },
+      });
 
-    expect(loaded).toEqual(["/repo/src/Echo.svelte", "svelte/server", "svelte"]);
-    expect(result.diagnostics).toEqual([]);
-    expect(result.html).toContain("<section>true:<em>slot</em></section>");
-    expect(result.headHtml).toBe('<meta name="svelte-html-host" content="ready">');
+      const result = await renderIslands('<div data-ox-island="Echo"><em>slot</em></div>', {
+        documentPath: "/repo/docs/report.mdx",
+        components: { Echo: "./src/Echo.svelte" },
+      });
+
+      expect(loaded).toEqual(["/repo/src/Echo.svelte"]);
+      expect(result.diagnostics).toEqual([]);
+      expect(result.html).toContain("<section>");
+      expect(result.html).toContain("<em>slot</em>");
+    });
   });
 
   it("throws diagnostics by default and can collect them for custom policies", async () => {

--- a/npm/vite-plugin-ox-content/src/custom-host-collection-assets-context.test.ts
+++ b/npm/vite-plugin-ox-content/src/custom-host-collection-assets-context.test.ts
@@ -109,9 +109,10 @@ describe("custom host collection asset manifest context", () => {
     server.watcher.emit("change", sourcePath);
     await waitFor(() => manifestLoads > loadsBeforeFailedReplan);
 
-    const routeAfterFailedReplan = await text(listener.port, "/");
+    const routeAfterFailedReplan = await waitForResponse(listener.port, "/", (response) =>
+      response.text.includes(secondAsset.contentPath),
+    );
     expect(routeAfterFailedReplan).toMatchObject({ status: 200 });
-    expect(routeAfterFailedReplan.text).toContain(secondAsset.contentPath);
     const failedLoads = manifestLoads;
 
     await fs.writeFile(gatePath, "ok\n");


### PR DESCRIPTION
## Summary
- restore the Svelte HTML host default renderer so it owns its `svelte/server` import instead of resolving runtime modules through the host loader
- keep explicit `renderComponent` as the escape hatch for hosts that need to own Svelte runtime selection
- update regression coverage and docs for the package-level `ssr.noExternal` path

Fixes #1412

## Verification
- `node tools/scripts/check-file-lines.ts --base origin/main`
- `vp fmt --check docs/content/packages/vite-plugin-ox-content-svelte.md npm/vite-plugin-ox-content-svelte/src/html-host-dev-runtime.test.ts npm/vite-plugin-ox-content-svelte/src/html-host-renderer.ts npm/vite-plugin-ox-content-svelte/src/html-host.test.ts`
- `vp check npm/vite-plugin-ox-content-svelte/src/html-host-dev-runtime.test.ts npm/vite-plugin-ox-content-svelte/src/html-host-renderer.ts npm/vite-plugin-ox-content-svelte/src/html-host.test.ts`
- `vp test npm/vite-plugin-ox-content-svelte/src/html-host.test.ts npm/vite-plugin-ox-content-svelte/src/html-host-dev-runtime.test.ts`
- `vp run --filter @ox-content/vite-plugin-svelte build --ignore-depends-on`
- `vp test npm/vite-plugin-ox-content-svelte/src/custom-host-svelte-html-host.test.ts npm/vite-plugin-ox-content-svelte/src/custom-host-svelte-stylesheets.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791768400&installation_model_id=422833&pr_number=1414&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1414&signature=4793d075b2d7bbc6de4bd870f408cf44d4febe3ce459ca55c554322e75193a4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Svelte server-side rendering so the package’s default renderer remains aligned with compiled components.
  - Host-provided rendering callbacks are used only when explicitly configured, preventing unintended host runtime loading.
  - Svelte components and slot content now render correctly with the default setup.
  - Improved development behavior when content assets change during a replan.

- **Documentation**
  - Updated guidance on Svelte SSR runtime handling, including behavior for hosts providing their own component renderer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->