### PR TITLE
feat(oxct): add collection validation command

### DIFF
--- a/docs/content/built-in/collections.md
+++ b/docs/content/built-in/collections.md
@@ -78,6 +78,19 @@ oxContent({
 rewrites. `source` is relative to `srcDir`, and `documentPath` is the absolute
 source file path.
 
+Run the same hooks in CI without producing the full site:
+
+```bash
+vpx oxct validate
+```
+
+Use `--config` when the Vite config is not at the project root, and repeat
+`--collection` to validate only selected collections:
+
+```bash
+vpx oxct validate --config apps/docs/vite.config.ts --collection blog
+```
+
 ## Entry Shape
 
 Each entry is a `CollectionEntry`:

--- a/npm/vite-plugin-ox-content/bin/oxct-runtime.mjs
+++ b/npm/vite-plugin-ox-content/bin/oxct-runtime.mjs
@@ -6,10 +6,11 @@ import { runLinkCheck, runMdcCheck } from "./oxct-checkers.mjs";
 import { runI18n } from "./oxct-i18n.mjs";
 import { loadNapi } from "./oxct-napi.mjs";
 import { runOgPreview } from "./oxct-og-preview.mjs";
+import { runValidate } from "./oxct-validate.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 
-export function main(args) {
+export async function main(args) {
   if (isHelp(args)) {
     printHelp();
     return;
@@ -18,6 +19,10 @@ export function main(args) {
   const [command, ...rest] = args;
   if (command === "i18n") {
     runI18n(rest);
+    return;
+  }
+  if (command === "validate") {
+    await runValidate(rest);
     return;
   }
   if (command === "link-check") {
@@ -168,6 +173,7 @@ Usage:
 
 Commands:
   i18n <command>           Check dictionaries and validate MessageFormat 2
+  validate                 Run collection validate hooks without a full build
   link-check <files...>    Check Markdown/MDC local links
   migrate vitepress        Generate ox-content config from VitePress config
   mdc-check <files...>     Check MDC component syntax

--- a/npm/vite-plugin-ox-content/bin/oxct-validate.mjs
+++ b/npm/vite-plugin-ox-content/bin/oxct-validate.mjs
@@ -1,0 +1,272 @@
+import { access } from "node:fs/promises";
+import * as path from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const oxContentOptionsMeta = Symbol.for("ox-content:vite-plugin-options");
+
+const defaultConfigFiles = [
+  "vite.config.ts",
+  "vite.config.mts",
+  "vite.config.js",
+  "vite.config.mjs",
+  "vite.config.cts",
+  "vite.config.cjs",
+  "ox-content.config.ts",
+  "ox-content.config.mts",
+  "ox-content.config.js",
+  "ox-content.config.mjs",
+  "ox-content.config.cts",
+  "ox-content.config.cjs",
+];
+
+const directOptionKeys = new Set([
+  "srcDir",
+  "outDir",
+  "collections",
+  "ssg",
+  "permalinks",
+  "cascade",
+  "search",
+  "siteMaps",
+  "feeds",
+  "blog",
+  "gfm",
+  "mdx",
+  "frontmatter",
+]);
+
+export async function runValidate(args) {
+  if (isExplicitHelp(args)) {
+    printValidateHelp();
+    return;
+  }
+
+  const parsed = parseValidateOptions(args);
+  const api = await loadPackageApi();
+  const { root, resolvedOptions } = await loadResolvedOptions(parsed, api);
+  const selectedOptions = selectCollections(resolvedOptions, parsed.collections);
+  const manifest = await api.buildCollectionManifest(root, selectedOptions);
+
+  console.log(formatSuccess(manifest));
+}
+
+function parseValidateOptions(args) {
+  const options = {
+    collections: [],
+    config: undefined,
+    cwd: process.cwd(),
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === "--config" || arg === "-c") {
+      options.config = readValue(args, ++index, arg);
+      continue;
+    }
+
+    if (arg === "--collection") {
+      options.collections.push(readValue(args, ++index, arg));
+      while (args[index + 1] && !args[index + 1].startsWith("-")) {
+        options.collections.push(args[++index]);
+      }
+      continue;
+    }
+
+    if (arg.startsWith("-")) {
+      throw new Error(`Unknown validate option: ${arg}`);
+    }
+
+    throw new Error(`Unexpected validate argument: ${arg}`);
+  }
+
+  return options;
+}
+
+async function loadResolvedOptions(options, api) {
+  const configPath = await resolveConfigPath(options.config, options.cwd);
+  const config = await loadConfig(configPath, options.cwd);
+  const resolvedOptions = findResolvedOptions(config, api);
+  if (!resolvedOptions) {
+    throw new Error(`Could not find an oxContent() plugin or Ox Content options in ${configPath}.`);
+  }
+
+  return {
+    root: resolveConfigRoot(config, options.cwd),
+    resolvedOptions,
+  };
+}
+
+async function loadConfig(configPath, cwd) {
+  const vite = await import("vite");
+  const loaded = await vite.loadConfigFromFile(createConfigEnv(), configPath, cwd, "silent");
+  return normalizeConfig(loaded?.config, configPath);
+}
+
+function findResolvedOptions(config, api) {
+  const pluginOptions = collectPluginOptions(config);
+  if (pluginOptions.length > 1) {
+    throw new Error("Found multiple oxContent() configurations. Keep one plugin or use --config.");
+  }
+  if (pluginOptions.length === 1) {
+    return pluginOptions[0];
+  }
+  if (looksLikeDirectOxContentOptions(config)) {
+    return api.resolveOptions(config);
+  }
+  return undefined;
+}
+
+function collectPluginOptions(value, output = [], seen = new Set()) {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectPluginOptions(item, output, seen);
+    }
+    return output;
+  }
+
+  if (!isRecord(value)) {
+    return output;
+  }
+
+  const metadata = value[oxContentOptionsMeta];
+  if (isRecord(metadata) && isRecord(metadata.resolvedOptions) && !seen.has(metadata)) {
+    seen.add(metadata);
+    output.push(metadata.resolvedOptions);
+  }
+
+  if (Array.isArray(value.plugins)) {
+    collectPluginOptions(value.plugins, output, seen);
+  }
+
+  return output;
+}
+
+function looksLikeDirectOxContentOptions(value) {
+  if (!isRecord(value) || "plugins" in value) {
+    return false;
+  }
+  return Object.keys(value).some((key) => directOptionKeys.has(key));
+}
+
+function selectCollections(options, requestedCollections) {
+  const names = [...new Set(requestedCollections)];
+  if (names.length === 0) {
+    return options;
+  }
+
+  const available = options.collections?.enabled ? options.collections.collections : {};
+  const missing = names.filter((name) => !available[name]);
+  if (missing.length > 0) {
+    const availableNames = Object.keys(available);
+    const suffix =
+      availableNames.length > 0 ? ` Available collections: ${availableNames.join(", ")}.` : "";
+    throw new Error(`Unknown collection: ${missing.join(", ")}.${suffix}`);
+  }
+
+  return {
+    ...options,
+    collections: {
+      enabled: true,
+      collections: Object.fromEntries(names.map((name) => [name, available[name]])),
+    },
+  };
+}
+
+async function loadPackageApi() {
+  const entry = path.resolve(here, "../dist/index.mjs");
+  try {
+    return await import(pathToFileURL(entry).href);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Could not load @ox-content/vite-plugin runtime from ${entry}: ${message}`);
+  }
+}
+
+async function resolveConfigPath(configPath, cwd) {
+  if (configPath) {
+    return resolvePath(cwd, configPath);
+  }
+
+  for (const candidate of defaultConfigFiles) {
+    const resolved = resolvePath(cwd, candidate);
+    if (await fileExists(resolved)) {
+      return resolved;
+    }
+  }
+
+  throw new Error("Could not find a Vite or Ox Content config. Pass --config <path>.");
+}
+
+function normalizeConfig(value, configPath) {
+  if (!value || typeof value !== "object") {
+    throw new Error(`Config did not export an object: ${configPath}`);
+  }
+  return value;
+}
+
+function resolveConfigRoot(config, cwd) {
+  if (isRecord(config) && typeof config.root === "string") {
+    return resolvePath(cwd, config.root);
+  }
+  return cwd;
+}
+
+function formatSuccess(manifest) {
+  const collectionCount = Object.keys(manifest.collections).length;
+  const documentCount = Object.values(manifest.collections).reduce(
+    (count, entries) => count + entries.length,
+    0,
+  );
+  return `[ox-content] Collection validation passed for ${documentCount} document${
+    documentCount === 1 ? "" : "s"
+  } in ${collectionCount} collection${collectionCount === 1 ? "" : "s"}.`;
+}
+
+function createConfigEnv() {
+  return {
+    command: "build",
+    mode: "production",
+    isSsrBuild: false,
+    isPreview: false,
+  };
+}
+
+function resolvePath(cwd, value) {
+  return path.isAbsolute(value) ? path.normalize(value) : path.resolve(cwd, value);
+}
+
+async function fileExists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readValue(args, index, option) {
+  const value = args[index];
+  if (!value || value.startsWith("-")) {
+    throw new Error(`${option} requires a value`);
+  }
+  return value;
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null;
+}
+
+function isExplicitHelp(args) {
+  return args[0] === "--help" || args[0] === "-h";
+}
+
+function printValidateHelp() {
+  console.log(`oxct validate
+
+Usage:
+  oxct validate [--config <path>] [--collection <name>...]
+
+Runs configured collection validate hooks without a full production build.`);
+}

--- a/npm/vite-plugin-ox-content/bin/oxct.mjs
+++ b/npm/vite-plugin-ox-content/bin/oxct.mjs
@@ -3,7 +3,7 @@
 import { main } from "./oxct-runtime.mjs";
 
 try {
-  main(process.argv.slice(2));
+  await main(process.argv.slice(2));
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error));
   process.exitCode = 1;

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -225,6 +225,8 @@ export type {
   MdxImportSpecifierKind,
 } from "./types";
 
+const oxContentOptionsMeta = Symbol.for("ox-content:vite-plugin-options");
+
 /**
  * Creates the Ox Content Vite plugin.
  *
@@ -246,6 +248,7 @@ export type {
  */
 export function oxContent(options: OxContentOptions = {}): Plugin[] {
   const resolvedOptions = resolveOptions(options);
+  const metadata = { options, resolvedOptions };
   let config: ResolvedConfig | undefined;
   const getRoot = () => config?.root || process.cwd();
 
@@ -272,6 +275,13 @@ export function oxContent(options: OxContentOptions = {}): Plugin[] {
 
   if (resolvedOptions.ogViewer) {
     plugins.push(createOgViewerPlugin(resolvedOptions));
+  }
+
+  for (const plugin of plugins) {
+    Object.defineProperty(plugin, oxContentOptionsMeta, {
+      value: metadata,
+      enumerable: false,
+    });
   }
 
   return plugins;

--- a/npm/vite-plugin-ox-content/src/oxct-cli.test.ts
+++ b/npm/vite-plugin-ox-content/src/oxct-cli.test.ts
@@ -1,9 +1,17 @@
 import { spawnSync } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vite-plus/test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vite-plus/test";
 
 const bin = resolve(dirname(fileURLToPath(import.meta.url)), "..", "bin", "oxct.mjs");
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
 
 describe("oxct CLI", () => {
   it("prints the top-level help without loading the native binding", () => {
@@ -12,6 +20,7 @@ describe("oxct CLI", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("oxct <command>");
     expect(result.stdout).toContain("i18n <command>");
+    expect(result.stdout).toContain("validate");
     expect(result.stdout).toContain("link-check");
     expect(result.stdout).toContain("migrate vitepress");
     expect(result.stdout).toContain("mdc-check");
@@ -29,6 +38,7 @@ describe("oxct CLI", () => {
 
   it.each([
     ["link-check", "oxct link-check"],
+    ["validate", "oxct validate"],
     ["mdc-check", "oxct mdc-check"],
     ["lsp", "oxct lsp"],
     ["migrate", "oxct migrate vitepress"],
@@ -47,5 +57,62 @@ describe("oxct CLI", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("oxct migrate vitepress [config]");
+  });
+
+  it("runs collection validation hooks from a Vite config", async () => {
+    const root = await fs.mkdtemp(resolve(os.tmpdir(), "ox-content-validate-cli-"));
+    tempDirs.push(root);
+    await fs.mkdir(resolve(root, "content/blog"), { recursive: true });
+    await fs.mkdir(resolve(root, "content/docs"), { recursive: true });
+    await fs.writeFile(
+      resolve(root, "content/blog/first.md"),
+      "---\ntitle: First\npermalink: /wrong\n---\n# First\n",
+    );
+    await fs.writeFile(resolve(root, "content/docs/guide.md"), "---\ntitle: Guide\n---\n# Guide\n");
+
+    const entryUrl = pathToFileURL(resolve(packageRoot, "dist/index.mjs")).href;
+    await fs.writeFile(
+      resolve(root, "vite.config.mjs"),
+      `import { oxContent, defineCollections } from ${JSON.stringify(entryUrl)};
+
+export default {
+  plugins: [
+    oxContent({
+      srcDir: "content",
+      collections: defineCollections({
+        blog: {
+          source: "blog/*.md",
+          validate({ frontmatter, path }) {
+            return frontmatter.permalink === path
+              ? undefined
+              : \`expected permalink \${path}, found \${frontmatter.permalink ?? "(missing)"}\`;
+          },
+        },
+        docs: "docs/*.md",
+      }),
+    }),
+  ],
+};
+`,
+    );
+
+    const failed = spawnSync(process.execPath, [bin, "validate", "--config", "vite.config.mjs"], {
+      cwd: root,
+      encoding: "utf8",
+    });
+    expect(failed.status).toBe(1);
+    expect(failed.stderr).toContain("[ox-content] Collection validation failed with 1 diagnostic.");
+    expect(failed.stderr).toContain(
+      "- blog: blog/first.md (/blog/first): expected permalink /blog/first, found /wrong",
+    );
+
+    const selected = spawnSync(process.execPath, [bin, "validate", "--collection", "docs"], {
+      cwd: root,
+      encoding: "utf8",
+    });
+    expect(selected.status).toBe(0);
+    expect(selected.stdout).toContain(
+      "[ox-content] Collection validation passed for 1 document in 1 collection.",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add `oxct validate` for running collection `validate` hooks without a full production build
- let the CLI recover resolved Ox Content options from Vite config plugins or direct Ox Content config files
- document the command and cover failing/selected collection validation through the public bin

## Tests
- `vp run build:vite-plugin`
- `vp exec --filter @ox-content/vite-plugin -- vp test src/oxct-cli.test.ts`
- `vp exec --filter @ox-content/vite-plugin -- vp test --typecheck src/oxct-cli.test.ts`
- `node tools/scripts/check-file-lines.ts --base origin/main`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791798126&installation_model_id=422833&pr_number=1415&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1415&signature=faf05409a9e3f63754ef289e8c2a08a963f3353d5198bd24d987808e3184c79d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->