### PR TITLE
feat: export parseFrontmatter and stringifyFrontmatter

### DIFF
--- a/docs/content/built-in/collections.md
+++ b/docs/content/built-in/collections.md
@@ -91,6 +91,28 @@ Use `--config` when the Vite config is not at the project root, and repeat
 vpx oxct validate --config apps/docs/vite.config.ts --collection blog
 ```
 
+## Reading and Writing Frontmatter
+
+`parseFrontmatter` and `stringifyFrontmatter` expose the same frontmatter
+handling the collection pipeline uses, for tools that work on a single document
+outside a build — a scaffolding script, or a loader that reads one file directly.
+
+```ts
+import { parseFrontmatter, stringifyFrontmatter } from "@ox-content/vite-plugin";
+
+const { frontmatter, content } = parseFrontmatter(source);
+
+const document = stringifyFrontmatter(
+  { permalink: "/blog/post", title: "Post", draft: false },
+  "Body\n",
+);
+```
+
+The two round-trip: a document written with `stringifyFrontmatter` parses back to
+the values passed in, so a generated file is read exactly as the build will read
+it. Key order is preserved, and passing no keys returns the body unchanged
+rather than emitting an empty block.
+
 ## Entry Shape
 
 Each entry is a `CollectionEntry`:

--- a/docs/content/ja/built-in/collections.md
+++ b/docs/content/ja/built-in/collections.md
@@ -62,6 +62,27 @@ oxContent({
 
 `path` と `stem` は permalink / cascade 書き換え前のファイルツリー由来 route です。`source` は `srcDir` からの相対パスで、`documentPath` は絶対ソースファイルパスです。
 
+## Frontmatter の読み書き
+
+`parseFrontmatter` と `stringifyFrontmatter` は、コレクションのパイプラインが使う
+frontmatter 処理をそのまま公開します。ビルドの外で単一の document を扱うツール
+（scaffold スクリプトや、ファイルを直読みするローダー）のための API です。
+
+```ts
+import { parseFrontmatter, stringifyFrontmatter } from "@ox-content/vite-plugin";
+
+const { frontmatter, content } = parseFrontmatter(source);
+
+const document = stringifyFrontmatter(
+  { permalink: "/blog/post", title: "Post", draft: false },
+  "Body\n",
+);
+```
+
+両者は round-trip します。`stringifyFrontmatter` で書き出した document は渡した値
+のままパースし直せるので、生成したファイルはビルドが読むのと同じ結果になります。
+キーの順序は保たれ、キーが空の場合は空ブロックを出さずに body をそのまま返します。
+
 ## エントリの形
 
 各エントリは `CollectionEntry` です。

--- a/npm/vite-plugin-ox-content/src/frontmatter.test.ts
+++ b/npm/vite-plugin-ox-content/src/frontmatter.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { parseFrontmatter, stringifyFrontmatter } from "./frontmatter";
+
+describe("parseFrontmatter", () => {
+  it("splits frontmatter from the body", () => {
+    expect(parseFrontmatter("---\ntitle: Post\ndraft: false\n---\nBody\n")).toEqual({
+      frontmatter: { title: "Post", draft: false },
+      content: "Body\n",
+    });
+  });
+
+  it("returns no keys for a source without frontmatter", () => {
+    expect(parseFrontmatter("Body only\n")).toEqual({ frontmatter: {}, content: "Body only\n" });
+  });
+});
+
+describe("stringifyFrontmatter", () => {
+  it("emits a frontmatter block before the body", () => {
+    expect(stringifyFrontmatter({ title: "Post" }, "Body\n")).toBe("---\ntitle: Post\n---\nBody\n");
+  });
+
+  it("keeps a date-like string quoted so it parses back as a string", () => {
+    const source = stringifyFrontmatter({ date: "2026-09-09" });
+    expect(source).toBe("---\ndate: 2026-09-09\n---\n");
+    expect(parseFrontmatter(source).frontmatter.date).toBe("2026-09-09");
+  });
+
+  it("preserves key order", () => {
+    expect(stringifyFrontmatter({ permalink: "/blog/post", title: "Post" })).toBe(
+      "---\npermalink: /blog/post\ntitle: Post\n---\n",
+    );
+  });
+
+  it("omits the block entirely when there are no keys", () => {
+    expect(stringifyFrontmatter({}, "Body\n")).toBe("Body\n");
+  });
+
+  it("round-trips through parseFrontmatter", () => {
+    const frontmatter = { permalink: "/blog/post", title: "Post", draft: false, tags: ["a", "b"] };
+    const parsed = parseFrontmatter(stringifyFrontmatter(frontmatter, "Body\n"));
+    expect(parsed).toEqual({ frontmatter, content: "Body\n" });
+  });
+});

--- a/npm/vite-plugin-ox-content/src/frontmatter.test.ts
+++ b/npm/vite-plugin-ox-content/src/frontmatter.test.ts
@@ -35,6 +35,13 @@ describe("stringifyFrontmatter", () => {
     expect(stringifyFrontmatter({}, "Body\n")).toBe("Body\n");
   });
 
+  it("keeps a body that starts with a blank line", () => {
+    expect(stringifyFrontmatter({}, "\nBody\n")).toBe("\nBody\n");
+    expect(stringifyFrontmatter({ title: "Post" }, "\nBody\n")).toBe(
+      "---\ntitle: Post\n---\n\nBody\n",
+    );
+  });
+
   it("round-trips through parseFrontmatter", () => {
     const frontmatter = { permalink: "/blog/post", title: "Post", draft: false, tags: ["a", "b"] };
     const parsed = parseFrontmatter(stringifyFrontmatter(frontmatter, "Body\n"));

--- a/npm/vite-plugin-ox-content/src/frontmatter.ts
+++ b/npm/vite-plugin-ox-content/src/frontmatter.ts
@@ -29,9 +29,8 @@ export function parseFrontmatter(source: string): ParsedFrontmatter {
  * document without frontmatter should not gain an empty block.
  */
 export function stringifyFrontmatter(frontmatter: Record<string, unknown>, content = ""): string {
-  const body = content.startsWith("\n") ? content.slice(1) : content;
   if (Object.keys(frontmatter).length === 0) {
-    return body;
+    return content;
   }
-  return `---\n${stringifyYaml(frontmatter)}---\n${body}`;
+  return `---\n${stringifyYaml(frontmatter)}---\n${content}`;
 }

--- a/npm/vite-plugin-ox-content/src/frontmatter.ts
+++ b/npm/vite-plugin-ox-content/src/frontmatter.ts
@@ -1,0 +1,37 @@
+import { stringify as stringifyYaml } from "yaml";
+import { importNapiModuleSync } from "./napi";
+
+/** Markdown source split into its frontmatter and the body that follows it. */
+export interface ParsedFrontmatter {
+  /** Parsed frontmatter keys. Empty when the source declares no frontmatter. */
+  frontmatter: Record<string, unknown>;
+  /** Markdown content with the frontmatter block removed. */
+  content: string;
+}
+
+/**
+ * Splits Markdown source into its frontmatter and body.
+ *
+ * This is the same parse the collection pipeline performs, so a document read
+ * this way agrees with how Ox Content will read it during a build.
+ */
+export function parseFrontmatter(source: string): ParsedFrontmatter {
+  const prepared = importNapiModuleSync().prepareSource(source, { frontmatter: true });
+  return { frontmatter: prepared.frontmatter, content: prepared.content };
+}
+
+/**
+ * Serialises frontmatter and body back into Markdown source.
+ *
+ * Round-trips with {@link parseFrontmatter}: the emitted document parses back to
+ * the values passed in. Frontmatter key order is preserved so generated files
+ * stay stable across runs. Passing no keys returns the body unchanged, since a
+ * document without frontmatter should not gain an empty block.
+ */
+export function stringifyFrontmatter(frontmatter: Record<string, unknown>, content = ""): string {
+  const body = content.startsWith("\n") ? content.slice(1) : content;
+  if (Object.keys(frontmatter).length === 0) {
+    return body;
+  }
+  return `---\n${stringifyYaml(frontmatter)}---\n${body}`;
+}

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -1237,6 +1237,7 @@ export {
   CollectionValidationError,
   type CollectionValidationDiagnostic,
 } from "./collection-validation";
+export { parseFrontmatter, stringifyFrontmatter, type ParsedFrontmatter } from "./frontmatter";
 export {
   DEFAULT_MARKDOWN_EXTENSIONS,
   normalizeMarkdownExtensions,

--- a/npm/vite-plugin-ox-content/src/public-exports.test.ts
+++ b/npm/vite-plugin-ox-content/src/public-exports.test.ts
@@ -113,6 +113,8 @@ describe("public export surface", () => {
       "writeSearchIndex",
       "writeSelfHostedAssets",
       "writeSiteMapFiles",
+      "parseFrontmatter",
+      "stringifyFrontmatter",
     ].sort();
 
     const actual = Object.keys(publicApi)


### PR DESCRIPTION
## Summary

- expose `parseFrontmatter` and `stringifyFrontmatter` from `@ox-content/vite-plugin`
- parse reuses the existing napi `prepareSource` call, so it is the same parse the collection pipeline performs
- serialise uses the `yaml` dependency the package already carries — no new dependency
- document the pair in the English and Japanese collection docs

Closes #1416

## Why

Ox Content parses frontmatter for every collection document, but none of that was reachable from outside the plugin. A consumer working on a single document outside a build — a scaffolding script, or a loader that reads one file directly — had to add a second frontmatter library. That parser can disagree with Ox Content on an edge case, and the mismatch only surfaces later as odd build behaviour.

`validate` (#1406) hands parsed frontmatter to a hook, but only inside manifest generation; there was no entry point for a single file.

## API

```ts
import { parseFrontmatter, stringifyFrontmatter } from "@ox-content/vite-plugin";

const { frontmatter, content } = parseFrontmatter(source);

const document = stringifyFrontmatter(
  { permalink: "/blog/post", title: "Post", draft: false },
  "Body\n",
);
```

The two round-trip: a document written with `stringifyFrontmatter` parses back to the values passed in. Key order is preserved so generated files stay stable, and passing no keys returns the body unchanged rather than emitting an empty block.

## Verification

- `vp test npm/vite-plugin-ox-content/src/frontmatter.test.ts npm/vite-plugin-ox-content/src/public-exports.test.ts npm/vite-plugin-ox-content/src/markdown-source-frontmatter.test.ts` — 10 passed
- `vp check` on the changed sources — no warnings or lint errors
- `vp fmt --check` on the changed sources and docs — clean

Note: I could not build the napi module locally (`nix develop -c vp run build:napi` fails while building the dev shell — `blacksmith-cli-latest` dependency), so the tests were run against the published `@ox-content/napi@3.2.2` binary placed in `node_modules`. Worth a second look on CI where the module is built from source.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791831960&installation_model_id=422833&pr_number=1417&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1417&signature=1127eb59dd072122eecd0116934e7d9e0d1a9fa842c878b4dd79a3c0d77d1a3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public helpers for parsing and writing Markdown frontmatter.
  * Serialization preserves key order, supports round-tripping, and leaves the body unchanged when no frontmatter keys are provided.

* **Documentation**
  * Added English and Japanese documentation with usage examples and behavior details.

* **Tests**
  * Added coverage for frontmatter serialization, leading newlines, content handling, and public exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->